### PR TITLE
Perfetto plugin - Added tables for per-process memory and system memory

### DIFF
--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuCountersEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuCountersEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create a CPU counters event.

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuFrequencyEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuFrequencyEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create a a CPU frequency event. CPU frequency events

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuSchedEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuSchedEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create a CPU scheduling event

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create an Ftrace Perfetto event

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
@@ -13,8 +13,9 @@ using PerfettoProcessor;
 using System.Xml;
 using System.Xml.Serialization;
 using System.IO;
+using PerfettoCds.Pipeline.SourceDataCookers;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// XML deserialized EventProvider

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoLogcatEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoLogcatEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create events for logcat output

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoProcessMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoProcessMemoryEventCooker.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Processing;
+using PerfettoCds.Pipeline.DataOutput;
+using PerfettoProcessor;
+
+namespace PerfettoCds.Pipeline.DataCookers
+{
+    /// <summary>
+    /// Pulls data from multiple individual SQL tables and joins them to create a a CPU frequency event. CPU frequency events
+    /// include the current CPU frequency each CPU is running at and whether or not the CPU is idle
+    /// </summary>
+    public sealed class PerfettoProcessMemoryEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
+    {
+        public static readonly DataCookerPath DataCookerPath = PerfettoPluginConstants.ProcessMemoryEventCookerPath;
+
+        public string Description => "CPU Frequency composite cooker";
+
+        public DataCookerPath Path => DataCookerPath;
+
+        // Declare all of the cookers that are used by this CompositeCooker.
+        public IReadOnlyCollection<DataCookerPath> RequiredDataCookers => new[]
+        {
+            PerfettoPluginConstants.CounterCookerPath,
+            PerfettoPluginConstants.ProcessCounterTrackCookerPath,
+            PerfettoPluginConstants.ProcessCookerPath
+        };
+
+        [DataOutput]
+        public ProcessedEventData<PerfettoProcessMemoryEvent> ProcessMemoryEvents { get; }
+
+        public PerfettoProcessMemoryEventCooker() : base(PerfettoPluginConstants.ProcessMemoryEventCookerPath)
+        { 
+            this.ProcessMemoryEvents =
+                new ProcessedEventData<PerfettoProcessMemoryEvent>();
+        }
+
+        public void OnDataAvailable(IDataExtensionRetrieval requiredData)
+        {
+            // Gather the data from all the SQL tables
+            var counterData = requiredData.QueryOutput<ProcessedEventData<PerfettoCounterEvent>>(new DataOutputPath(PerfettoPluginConstants.CounterCookerPath, nameof(PerfettoCounterCooker.CounterEvents)));
+            var processCounterTrackData = requiredData.QueryOutput<ProcessedEventData<PerfettoProcessCounterTrackEvent>>(new DataOutputPath(PerfettoPluginConstants.ProcessCounterTrackCookerPath, nameof(PerfettoProcessCounterTrackCooker.ProcessCounterTrackEvents)));
+            var processData = requiredData.QueryOutput<ProcessedEventData<PerfettoProcessEvent>>(new DataOutputPath(PerfettoPluginConstants.ProcessCookerPath, nameof(PerfettoProcessCooker.ProcessEvents)));
+
+            // Join them all together
+            // Counter table contains the frequency, timestamp
+            // CpuCounterTrack contains the event type and CPU number
+            // Event type is either cpuidle or cpufreq. See below for further explanation
+            var joined = from counter in counterData
+                         join processCounterTrack in processCounterTrackData on counter.TrackId equals processCounterTrack.Id
+                         join process in processData on processCounterTrack.Upid equals process.Upid
+                         where processCounterTrack.Name.StartsWith("mem.")
+                         orderby counter.Timestamp ascending
+                         select new { counter, processCounterTrack, process };
+
+            // TODO explain
+
+            // Create events out of the joined results
+            foreach (var processGroup in joined.GroupBy(x => x.processCounterTrack.Upid))
+            {
+                var timeGroups = processGroup.GroupBy(z => z.counter.RelativeTimestamp);
+
+                for (int i = 0; i < timeGroups.Count(); i++)
+                {
+                    var timeGroup = timeGroups.ElementAt(i);
+
+                    var ts = timeGroup.Key;
+                    var processName = timeGroup.ElementAt(0).process.Name + processGroup.Key;
+                    double virt = 0.0, rss = 0.0, rssAnon = 0.0, rssFile = 0.0, rssShMem = 0.0, rssHwm = 0.0, swap = 0.0, locked = 0.0;
+                    long nextTs = ts;
+                    if (i < timeGroups.Count() - 1)
+                    {
+                        // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration which
+                        // is needed for WPA line graphs
+                        nextTs = timeGroups.ElementAt(i + 1).Key;
+                    }
+
+                    foreach (var thing in timeGroup)
+                    {
+                        switch (thing.processCounterTrack.Name)
+                        {
+                            case "mem.virt":
+                                virt = thing.counter.FloatValue;
+                                break;
+                            case "mem.rss":
+                                rss = thing.counter.FloatValue;
+                                break;
+                            case "mem.rss.anon":
+                                rssAnon = thing.counter.FloatValue;
+                                break;
+                            case "mem.rss.file":
+                                rssFile = thing.counter.FloatValue;
+                                break;
+                            case "mem.rss.shmem":
+                                rssShMem = thing.counter.FloatValue;
+                                break;
+                            case "mem.rss.watermark":
+                                rssHwm = thing.counter.FloatValue;
+                                break;
+                            case "mem.locked":
+                                locked = thing.counter.FloatValue;
+                                break;
+                            case "mem.swap":
+                                swap = thing.counter.FloatValue;
+                                break;
+                        }
+                    }
+                    PerfettoProcessMemoryEvent ev = new PerfettoProcessMemoryEvent
+                    (
+                        0.0,
+                        processName,
+                        new Timestamp(ts),
+                        "",
+                        new TimestampDelta(nextTs - ts),
+                        rssAnon,
+                        locked,
+                        rssShMem,
+                        rssFile,
+                        rssHwm,
+                        rss,
+                        swap,
+                        virt
+                    );
+                    this.ProcessMemoryEvents.AddEvent(ev);
+                }
+
+                //    foreach (var memoryTypeGroup in processGroup.GroupBy(y => y.processCounterTrack.Name))
+                //    {
+                //        for (int i = 0; i < memoryTypeGroup.Count(); i++)
+                //        {
+                //            var result = memoryTypeGroup.ElementAt(i);
+                //            var ts = result.counter.RelativeTimestamp;
+                //            var processName = result.process.Name;
+                //            var memoryTypeName = result.processCounterTrack.Name;
+                //            var value = result.counter.FloatValue;
+
+                //            long nextTs = ts;
+                //            if (i < memoryTypeGroup.Count() - 1)
+                //            {
+                //                // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration which
+                //                // is needed for WPA line graphs
+                //                nextTs = memoryTypeGroup.ElementAt(i + 1).counter.RelativeTimestamp;
+                //            }
+                //            PerfettoProcessMemoryEvent ev = new PerfettoProcessMemoryEvent
+                //            (
+                //                value, 
+                //                processName, 
+                //                new Timestamp(ts),
+                //                memoryTypeName,
+                //                new TimestampDelta(nextTs - ts),
+                //                0,0,0,0,0,0,0,0
+                //            );
+                //            this.ProcessMemoryEvents.AddEvent(ev);
+                //        }
+                //    }
+                //}
+            }
+            this.ProcessMemoryEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoProcessMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoProcessMemoryEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create a process memory event. Process
@@ -69,7 +70,7 @@ namespace PerfettoCds.Pipeline.DataCookers
                     var timeGroup = timeGroups.ElementAt(i);
 
                     var ts = timeGroup.Key;
-                    var processName = timeGroup.ElementAt(0).process.Name + " " + processGroup.Key;
+                    var processName = $"{timeGroup.ElementAt(0).process.Name} {processGroup.Key}";
                     long nextTs = ts;
                     if (i < timeGroups.Count() - 1)
                     {

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoProcessMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoProcessMemoryEventCooker.cs
@@ -73,8 +73,7 @@ namespace PerfettoCds.Pipeline.DataCookers
                     long nextTs = ts;
                     if (i < timeGroups.Count() - 1)
                     {
-                        // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration which
-                        // is needed for WPA line graphs
+                        // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration
                         nextTs = timeGroups.ElementAt(i + 1).Key;
                     }
 

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
@@ -14,7 +14,7 @@ namespace PerfettoCds.Pipeline.DataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create a system memory event. System
-    /// memory events capture period system memory counts
+    /// memory events capture periodic system memory counts
     /// </summary>
     public sealed class PerfettoSystemMemoryEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
     {

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
@@ -110,8 +110,7 @@ namespace PerfettoCds.Pipeline.DataCookers
                     long nextTs = ts;
                     if (i < memoryGroup.Count() - 1)
                     {
-                        // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration which
-                        // is needed for WPA line graphs
+                        // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration
                         nextTs = memoryGroup.ElementAt(i + 1).counter.RelativeTimestamp;
                     }
 

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
@@ -8,9 +8,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Extensibility.DataCooking;
 using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
 
-namespace PerfettoCds.Pipeline.DataCookers
+namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
     /// <summary>
     /// Pulls data from multiple individual SQL tables and joins them to create a system memory event. System
@@ -127,7 +128,5 @@ namespace PerfettoCds.Pipeline.DataCookers
             }
             this.SystemMemoryEvents.FinalizeData();
         }
-
-
     }
 }

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoSystemMemoryEventCooker.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Processing;
+using PerfettoCds.Pipeline.DataOutput;
+using PerfettoProcessor;
+
+namespace PerfettoCds.Pipeline.DataCookers
+{
+    /// <summary>
+    /// Pulls data from multiple individual SQL tables and joins them to create a system memory event. System
+    /// memory events capture period system memory counts
+    /// </summary>
+    public sealed class PerfettoSystemMemoryEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
+    {
+        public static readonly DataCookerPath DataCookerPath = PerfettoPluginConstants.SystemMemoryEventCookerPath;
+
+        public string Description => "System memory composite cooker";
+
+        public DataCookerPath Path => DataCookerPath;
+
+        // Declare all of the cookers that are used by this CompositeCooker.
+        public IReadOnlyCollection<DataCookerPath> RequiredDataCookers => new[]
+        {
+            PerfettoPluginConstants.CounterCookerPath,
+            PerfettoPluginConstants.CounterTrackCookerPath
+        };
+
+        [DataOutput]
+        public ProcessedEventData<PerfettoSystemMemoryEvent> SystemMemoryEvents { get; }
+
+        public PerfettoSystemMemoryEventCooker() : base(PerfettoPluginConstants.SystemMemoryEventCookerPath)
+        { 
+            this.SystemMemoryEvents =
+                new ProcessedEventData<PerfettoSystemMemoryEvent>();
+        }
+
+        public void OnDataAvailable(IDataExtensionRetrieval requiredData)
+        {
+            // Gather the data from all the SQL tables
+            var counterData = requiredData.QueryOutput<ProcessedEventData<PerfettoCounterEvent>>(new DataOutputPath(PerfettoPluginConstants.CounterCookerPath, nameof(PerfettoCounterCooker.CounterEvents)));
+            var counterTrackData = requiredData.QueryOutput<ProcessedEventData<PerfettoCounterTrackEvent>>(new DataOutputPath(PerfettoPluginConstants.CounterTrackCookerPath, nameof(PerfettoCounterTrackCooker.CounterTrackEvents)));
+
+            // Join them all together
+            // Counter table contains the memory count value, timestamp
+            // ProcessCounterTrack contains the UPID and memory type name. All the memory types we care about start with "mem."
+            // Process contains the process name
+            var joined = from counter in counterData
+                         join counterTrack in counterTrackData on counter.TrackId equals counterTrack.Id
+                         where counterTrack.Name.StartsWith("Buffers") || counterTrack.Name.StartsWith("Active")
+                         orderby counter.Timestamp ascending
+                         select new { counter, counterTrack };
+
+            // Create events out of the joined results
+            foreach (var memoryGroup in joined.GroupBy(x => x.counterTrack.Name))
+            {
+                string memoryType = memoryGroup.Key;
+
+                for(int i = 0; i < memoryGroup.Count(); i++)
+                {
+                    var thing = memoryGroup.ElementAt(i);
+                    double val = thing.counter.FloatValue;
+                    var ts = thing.counter.RelativeTimestamp;
+                    long nextTs = ts;
+
+                    if (i < memoryGroup.Count() - 1)
+                    {
+                        // Need to look ahead in the future at the next event to get the timestamp so that we can calculate the duration which
+                        // is needed for WPA line graphs
+                        nextTs = memoryGroup.ElementAt(i + 1).counter.RelativeTimestamp;
+                    }
+                    PerfettoSystemMemoryEvent ev = new PerfettoSystemMemoryEvent
+                    (
+                        val, 
+                        memoryType,
+                        new Timestamp(ts),
+                        new TimestampDelta(nextTs - ts)
+                    );
+                    this.SystemMemoryEvents.AddEvent(ev);
+                }
+
+            }
+            this.SystemMemoryEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
@@ -10,36 +10,40 @@ namespace PerfettoCds.Pipeline.DataOutput
     /// </summary>
     public readonly struct PerfettoProcessMemoryEvent
     {
-        public double Value { get; }
         public string ProcessName { get; }
         public Timestamp StartTimestamp { get; }
-        public string MemoryType { get; }
         public TimestampDelta Duration { get; }
 
+        // Resident set size - anonymous memory
         public double RssAnon { get; }
-        public double Locked { get; }
+        // Resident set size - shared memory
         public double RssShMem { get; }
+        // Resident set size - file mappings
         public double RssFile { get; }
+        // Resident set size - Peak (high water mark)
         public double RssHwm { get; }
+        // Resident set size - Sum of anon, file, ShMem
         public double Rss { get; }
+        // Locked memory size
+        public double Locked { get; }
+        // Swapped out VM size by anonymous private pages
         public double Swap { get; }
+        // Peak virtual memory size
         public double Virt { get; }
 
-        public PerfettoProcessMemoryEvent(double value, string processName, Timestamp startTimestamp, string memoryType, TimestampDelta duration,
+        public PerfettoProcessMemoryEvent(string processName, Timestamp startTimestamp, TimestampDelta duration,
             double rssAnon,
-            double locked,
             double rssShMem,
             double rssFile,
             double rssHwm,
             double rss,
+            double locked,
             double swap,
             double virt)
         {
-            this.Value = value;
             this.ProcessName = processName;
             this.StartTimestamp = startTimestamp;
             this.Duration = duration;
-            this.MemoryType = memoryType;
 
             this.RssAnon = rssAnon;
             this.Locked = locked;

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using System.Collections.Generic;
+
+namespace PerfettoCds.Pipeline.DataOutput
+{
+    /// <summary>
+    /// A event that represents the frequency and state of a CPU at a point in time
+    /// </summary>
+    public readonly struct PerfettoProcessMemoryEvent
+    {
+        public double Value { get; }
+        public string ProcessName { get; }
+        public Timestamp StartTimestamp { get; }
+        public string MemoryType { get; }
+        public TimestampDelta Duration { get; }
+
+        public double RssAnon { get; }
+        public double Locked { get; }
+        public double RssShMem { get; }
+        public double RssFile { get; }
+        public double RssHwm { get; }
+        public double Rss { get; }
+        public double Swap { get; }
+        public double Virt { get; }
+
+        public PerfettoProcessMemoryEvent(double value, string processName, Timestamp startTimestamp, string memoryType, TimestampDelta duration,
+            double rssAnon,
+            double locked,
+            double rssShMem,
+            double rssFile,
+            double rssHwm,
+            double rss,
+            double swap,
+            double virt)
+        {
+            this.Value = value;
+            this.ProcessName = processName;
+            this.StartTimestamp = startTimestamp;
+            this.Duration = duration;
+            this.MemoryType = memoryType;
+
+            this.RssAnon = rssAnon;
+            this.Locked = locked;
+            this.RssShMem = rssShMem;
+            this.RssFile = rssFile;
+            this.RssHwm = rssHwm;
+            this.Rss = rss;
+            this.Swap = swap;
+            this.Virt = virt;
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
@@ -14,21 +14,21 @@ namespace PerfettoCds.Pipeline.DataOutput
         public Timestamp StartTimestamp { get; }
         public TimestampDelta Duration { get; }
 
-        // Resident set size - anonymous memory
+        /// Resident set size - anonymous memory
         public double RssAnon { get; }
-        // Resident set size - shared memory
+        /// Resident set size - shared memory
         public double RssShMem { get; }
-        // Resident set size - file mappings
+        /// Resident set size - file mappings
         public double RssFile { get; }
-        // Resident set size - Peak (high water mark)
+        /// Resident set size - Peak (high water mark)
         public double RssHwm { get; }
-        // Resident set size - Sum of anon, file, ShMem
+        /// Resident set size - Sum of anon, file, ShMem
         public double Rss { get; }
-        // Locked memory size
+        /// Locked memory size
         public double Locked { get; }
-        // Swapped out VM size by anonymous private pages
+        /// Swapped out VM size by anonymous private pages
         public double Swap { get; }
-        // Peak virtual memory size
+        /// Peak virtual memory size
         public double Virt { get; }
 
         public PerfettoProcessMemoryEvent(string processName, Timestamp startTimestamp, TimestampDelta duration,

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoProcessMemoryEvent.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace PerfettoCds.Pipeline.DataOutput
 {
     /// <summary>
-    /// A event that represents the frequency and state of a CPU at a point in time
+    /// A event that represents several memory values for a process at a point in time
     /// </summary>
     public readonly struct PerfettoProcessMemoryEvent
     {

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoSystemMemoryEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoSystemMemoryEvent.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using System.Collections.Generic;
+
+namespace PerfettoCds.Pipeline.DataOutput
+{
+    /// <summary>
+    /// A event that represents a single system memory value at a point in time
+    /// </summary>
+    public readonly struct PerfettoSystemMemoryEvent
+    {
+        public double Value { get; }
+        public string MemoryType { get; }
+        public Timestamp StartTimestamp { get; }
+        public TimestampDelta Duration { get; }
+
+        public PerfettoSystemMemoryEvent(double value, string memoryType, Timestamp startTimestamp, TimestampDelta duration)
+        {
+            this.Value = value;
+            this.MemoryType = memoryType;
+            this.StartTimestamp = startTimestamp;
+            this.Duration = duration;
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK.Extensibility;
+using PerfettoCds.Pipeline.CompositeDataCookers;
+using PerfettoCds.Pipeline.SourceDataCookers;
+using PerfettoCds.Pipeline.DataOutput;
 using PerfettoProcessor;
 
 namespace PerfettoCds
@@ -13,28 +16,28 @@ namespace PerfettoCds
         public const string ParserId = "PerfettoSourceParser";
 
         // ID for source data cookers
-        public const string SliceCookerId = "PerfettoSliceCooker";
-        public const string ArgCookerId = "PerfettoArgCooker";
-        public const string ThreadCookerId = "PerfettoThreadCooker";
-        public const string ThreadTrackCookerId = "PerfettoThreadCookerId";
-        public const string ProcessCookerId = "PerfettoProcessCooker";
-        public const string SchedSliceCookerId = "PerfettoSchedSliceCooker";
-        public const string AndroidLogCookerId = "PerfettoAndroidLogCooker";
-        public const string RawCookerId = "PerfettoRawCooker";
-        public const string CounterCookerId = "PerfettoCounterCooker";
-        public const string CpuCounterTrackCookerId = "PerfettoCpuCounterTrackCooker";
-        public const string ProcessCounterTrackCookerId = "PerfettoProcessCounterTrackCooker";
-        public const string CounterTrackCookerId = "PerfettoCounterTrackCooker";
+        public const string SliceCookerId = nameof(PerfettoSliceCooker);
+        public const string ArgCookerId = nameof(PerfettoArgCooker);
+        public const string ThreadCookerId = nameof(PerfettoThreadCooker);
+        public const string ThreadTrackCookerId = nameof(PerfettoThreadTrackCooker);
+        public const string ProcessCookerId = nameof(PerfettoProcessCooker);
+        public const string SchedSliceCookerId = nameof(PerfettoSchedSliceCooker);
+        public const string AndroidLogCookerId = nameof(PerfettoAndroidLogCooker);
+        public const string RawCookerId = nameof(PerfettoRawCooker);
+        public const string CounterCookerId = nameof(PerfettoCounterCooker);
+        public const string CpuCounterTrackCookerId = nameof(PerfettoCpuCounterTrackCooker);
+        public const string ProcessCounterTrackCookerId = nameof(PerfettoProcessCounterTrackCooker);
+        public const string CounterTrackCookerId = nameof(PerfettoCounterTrackCooker);
 
         // ID for composite data cookers
-        public const string GenericEventCookerId = "PerfettoGenericEventCooker";
-        public const string CpuSchedEventCookerId = "PerfettoCpuSchedEventCooker";
-        public const string LogcatEventCookerId = "PerfettoLogcatEventCooker";
-        public const string FtraceEventCookerId = "PerfettoFtraceEventCooker";
-        public const string CpuFrequencyEventCookerId = "PerfettoCpuFrequencyEventCooker";
-        public const string CpuCountersEventCookerId = "PerfettoCpuCountersEventCooker";
-        public const string ProcessMemoryEventCookerId = "PerfettoProcessMemoryEventCooker";
-        public const string SystemMemoryEventCookerId = "PerfettoSystemMemoryEventCooker";
+        public const string GenericEventCookerId = nameof(PerfettoGenericEventCooker);
+        public const string CpuSchedEventCookerId = nameof(PerfettoCpuSchedEventCooker);
+        public const string LogcatEventCookerId = nameof(PerfettoLogcatEventCooker);
+        public const string FtraceEventCookerId = nameof(PerfettoFtraceEventCooker);
+        public const string CpuFrequencyEventCookerId = nameof(PerfettoCpuFrequencyEventCooker);
+        public const string CpuCountersEventCookerId = nameof(PerfettoCpuCountersEventCooker);
+        public const string ProcessMemoryEventCookerId = nameof(PerfettoProcessMemoryEventCooker);
+        public const string SystemMemoryEventCookerId = nameof(PerfettoSystemMemoryEventCooker);
 
         // Events for source cookers
         public const string SliceEvent = PerfettoSliceEvent.Key;
@@ -51,14 +54,14 @@ namespace PerfettoCds
         public const string CounterTrackEvent = PerfettoCounterTrackEvent.Key;
 
         // Output events for composite cookers
-        public const string GenericEvent = "PerfettoGenericEvent";
-        public const string CpuSchedEvent = "PerfettoCpuSchedEvent";
-        public const string LogcatEvent = "PerfettoLogcatEvent";
-        public const string FtraceEvent = "PerfettoFtraceEvent";
-        public const string CpuFrequencyEvent = "PerfettoCpuFrequencyEvent";
-        public const string CpuCountersEvent = "PerfettoCpuCountersEvent";
-        public const string ProcessMemoryEvent = "PerfettoProcessMemoryEvent";
-        public const string SystemMemoryEvent = "PerfettoSystemMemoryEvent";
+        public const string GenericEvent = nameof(PerfettoGenericEvent);
+        public const string CpuSchedEvent = nameof(PerfettoCpuSchedEvent);
+        public const string LogcatEvent = nameof(PerfettoLogcatEvent);
+        public const string FtraceEvent = nameof(PerfettoFtraceEvent);
+        public const string CpuFrequencyEvent = nameof(PerfettoCpuFrequencyEvent);
+        public const string CpuCountersEvent = nameof(PerfettoCpuCountersEvent);
+        public const string ProcessMemoryEvent = nameof(PerfettoProcessMemoryEvent);
+        public const string SystemMemoryEvent = nameof(PerfettoSystemMemoryEvent);
 
         // Paths for source cookers
         public static readonly DataCookerPath SliceCookerPath =

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -23,6 +23,7 @@ namespace PerfettoCds
         public const string RawCookerId = "PerfettoRawCooker";
         public const string CounterCookerId = "PerfettoCounterCooker";
         public const string CpuCounterTrackCookerId = "PerfettoCpuCounterTrackCooker";
+        public const string ProcessCounterTrackCookerId = "PerfettoProcessCounterTrackCooker";
 
         // ID for composite data cookers
         public const string GenericEventCookerId = "PerfettoGenericEventCooker";
@@ -31,6 +32,7 @@ namespace PerfettoCds
         public const string FtraceEventCookerId = "PerfettoFtraceEventCooker";
         public const string CpuFrequencyEventCookerId = "PerfettoCpuFrequencyEventCooker";
         public const string CpuCountersEventCookerId = "PerfettoCpuCountersEventCooker";
+        public const string ProcessMemoryEventCookerId = "PerfettoProcessMemoryEventCooker";
 
         // Events for source cookers
         public const string SliceEvent = PerfettoSliceEvent.Key;
@@ -43,6 +45,7 @@ namespace PerfettoCds
         public const string RawEvent = PerfettoRawEvent.Key;
         public const string CounterEvent = PerfettoCounterEvent.Key;
         public const string CpuCounterTrackEvent = PerfettoCpuCounterTrackEvent.Key;
+        public const string ProcessCounterTrackEvent = PerfettoProcessCounterTrackEvent.Key;
 
         // Output events for composite cookers
         public const string GenericEvent = "PerfettoGenericEvent";
@@ -51,6 +54,7 @@ namespace PerfettoCds
         public const string FtraceEvent = "PerfettoFtraceEvent";
         public const string CpuFrequencyEvent = "PerfettoCpuFrequencyEvent";
         public const string CpuCountersEvent = "PerfettoCpuCountersEvent";
+        public const string ProcessMemoryEvent = "PerfettoProcessMemoryEvent";
 
         // Paths for source cookers
         public static readonly DataCookerPath SliceCookerPath =
@@ -73,6 +77,8 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CounterCookerId);
         public static readonly DataCookerPath CpuCounterTrackCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CpuCounterTrackCookerId);
+        public static readonly DataCookerPath ProcessCounterTrackCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.ProcessCounterTrackCookerId);
 
         // Paths for composite cookers
         public static readonly DataCookerPath GenericEventCookerPath =
@@ -87,6 +93,8 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.CpuFrequencyEventCookerId);
         public static readonly DataCookerPath CpuCountersEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.CpuCountersEventCookerId);
+        public static readonly DataCookerPath ProcessMemoryEventCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ProcessMemoryEventCookerId);
 
     }
 }

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -24,6 +24,7 @@ namespace PerfettoCds
         public const string CounterCookerId = "PerfettoCounterCooker";
         public const string CpuCounterTrackCookerId = "PerfettoCpuCounterTrackCooker";
         public const string ProcessCounterTrackCookerId = "PerfettoProcessCounterTrackCooker";
+        public const string CounterTrackCookerId = "PerfettoCounterTrackCooker";
 
         // ID for composite data cookers
         public const string GenericEventCookerId = "PerfettoGenericEventCooker";
@@ -33,6 +34,7 @@ namespace PerfettoCds
         public const string CpuFrequencyEventCookerId = "PerfettoCpuFrequencyEventCooker";
         public const string CpuCountersEventCookerId = "PerfettoCpuCountersEventCooker";
         public const string ProcessMemoryEventCookerId = "PerfettoProcessMemoryEventCooker";
+        public const string SystemMemoryEventCookerId = "PerfettoSystemMemoryEventCooker";
 
         // Events for source cookers
         public const string SliceEvent = PerfettoSliceEvent.Key;
@@ -46,6 +48,7 @@ namespace PerfettoCds
         public const string CounterEvent = PerfettoCounterEvent.Key;
         public const string CpuCounterTrackEvent = PerfettoCpuCounterTrackEvent.Key;
         public const string ProcessCounterTrackEvent = PerfettoProcessCounterTrackEvent.Key;
+        public const string CounterTrackEvent = PerfettoCounterTrackEvent.Key;
 
         // Output events for composite cookers
         public const string GenericEvent = "PerfettoGenericEvent";
@@ -55,6 +58,7 @@ namespace PerfettoCds
         public const string CpuFrequencyEvent = "PerfettoCpuFrequencyEvent";
         public const string CpuCountersEvent = "PerfettoCpuCountersEvent";
         public const string ProcessMemoryEvent = "PerfettoProcessMemoryEvent";
+        public const string SystemMemoryEvent = "PerfettoSystemMemoryEvent";
 
         // Paths for source cookers
         public static readonly DataCookerPath SliceCookerPath =
@@ -79,6 +83,8 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CpuCounterTrackCookerId);
         public static readonly DataCookerPath ProcessCounterTrackCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.ProcessCounterTrackCookerId);
+        public static readonly DataCookerPath CounterTrackCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CounterTrackCookerId);
 
         // Paths for composite cookers
         public static readonly DataCookerPath GenericEventCookerPath =
@@ -95,6 +101,8 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.CpuCountersEventCookerId);
         public static readonly DataCookerPath ProcessMemoryEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ProcessMemoryEventCookerId);
+        public static readonly DataCookerPath SystemMemoryEventCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.SystemMemoryEventCookerId);
 
     }
 }

--- a/PerfettoCds/Pipeline/PerfettoSourceParser.cs
+++ b/PerfettoCds/Pipeline/PerfettoSourceParser.cs
@@ -164,7 +164,8 @@ namespace PerfettoCds
                     new PerfettoRawEvent(),
                     new PerfettoCpuCounterTrackEvent(),
                     new PerfettoCounterEvent(),
-                    new PerfettoProcessCounterTrackEvent()
+                    new PerfettoProcessCounterTrackEvent(),
+                    new PerfettoCounterTrackEvent()
                 };
 
                 // Increment progress for each table queried.

--- a/PerfettoCds/Pipeline/PerfettoSourceParser.cs
+++ b/PerfettoCds/Pipeline/PerfettoSourceParser.cs
@@ -163,7 +163,8 @@ namespace PerfettoCds
                     new PerfettoAndroidLogEvent(),
                     new PerfettoRawEvent(),
                     new PerfettoCpuCounterTrackEvent(),
-                    new PerfettoCounterEvent()
+                    new PerfettoCounterEvent(),
+                    new PerfettoProcessCounterTrackEvent()
                 };
 
                 // Increment progress for each table queried.

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoAndroidLogCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoAndroidLogCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Android_Logs table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoArgCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoArgCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Args table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+﻿ // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
@@ -1,4 +1,4 @@
-﻿ // Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Counter table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
@@ -13,7 +13,7 @@ using PerfettoProcessor;
 namespace PerfettoCds
 {
     /// <summary>
-    /// Cooks the data from the counter_track table in Perfetto traces
+    /// Cooks the data from the CounterTrack table in Perfetto traces
     /// </summary>
     public sealed class PerfettoCounterTrackCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
     {

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the CounterTrack table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
@@ -1,4 +1,4 @@
-﻿ // Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;
@@ -13,7 +13,7 @@ using PerfettoProcessor;
 namespace PerfettoCds
 {
     /// <summary>
-    /// Cooks the data from the Counter table in Perfetto traces
+    /// Cooks the data from the counter_track table in Perfetto traces
     /// </summary>
     public sealed class PerfettoCounterTrackCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
     {

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterTrackCooker.cs
@@ -1,0 +1,52 @@
+﻿ // Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using Microsoft.Performance.SDK.Processing;
+using System.Collections.Generic;
+using System.Threading;
+using PerfettoCds.Pipeline.Events;
+using PerfettoProcessor;
+
+namespace PerfettoCds
+{
+    /// <summary>
+    /// Cooks the data from the Counter table in Perfetto traces
+    /// </summary>
+    public sealed class PerfettoCounterTrackCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
+    {
+        public override string Description => "Processes events from the counter_track Perfetto SQL table";
+
+        //
+        //  The data this cooker outputs. Tables or other cookers can query for this data
+        //  via the SDK runtime
+        //
+        [DataOutput]
+        public ProcessedEventData<PerfettoCounterTrackEvent> CounterTrackEvents { get; }
+
+        // Instructs runtime to only send events with the given keys this data cooker
+        public override ReadOnlyHashSet<string> DataKeys =>
+            new ReadOnlyHashSet<string>(new HashSet<string> { PerfettoPluginConstants.CounterTrackEvent });
+
+        public PerfettoCounterTrackCooker() : base(PerfettoPluginConstants.CounterTrackCookerPath)
+        {
+            this.CounterTrackEvents = new ProcessedEventData<PerfettoCounterTrackEvent>();
+        }
+
+        public override DataProcessingResult CookDataElement(PerfettoSqlEventKeyed perfettoEvent, PerfettoSourceParser context, CancellationToken cancellationToken)
+        {
+            var newEvent = (PerfettoCounterTrackEvent)perfettoEvent.SqlEvent;
+            this.CounterTrackEvents.AddEvent(newEvent);
+
+            return DataProcessingResult.Processed;
+        }
+
+        public override void EndDataCooking(CancellationToken cancellationToken)
+        {
+            base.EndDataCooking(cancellationToken);
+            this.CounterTrackEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCpuCounterTrack.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCpuCounterTrack.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the CpuCounterTrack table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoProcessCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoProcessCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Process table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoProcessCounterTrackCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoProcessCounterTrackCooker.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using Microsoft.Performance.SDK.Processing;
+using System.Collections.Generic;
+using System.Threading;
+using PerfettoCds.Pipeline.Events;
+using PerfettoProcessor;
+
+namespace PerfettoCds
+{
+    /// <summary>
+    /// Cooks the data from the ProcessCounterTrack table in Perfetto traces
+    /// </summary>
+    public sealed class PerfettoProcessCounterTrackCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
+    {
+        public override string Description => "Processes events from the process_counter_track Perfetto SQL table";
+
+        //
+        //  The data this cooker outputs. Tables or other cookers can query for this data
+        //  via the SDK runtime
+        //
+        [DataOutput]
+        public ProcessedEventData<PerfettoProcessCounterTrackEvent> ProcessCounterTrackEvents { get; }
+
+        // Instructs runtime to only send events with the given keys this data cooker
+        public override ReadOnlyHashSet<string> DataKeys =>
+            new ReadOnlyHashSet<string>(new HashSet<string> { PerfettoPluginConstants.ProcessCounterTrackEvent });
+
+
+        public PerfettoProcessCounterTrackCooker() : base(PerfettoPluginConstants.ProcessCounterTrackCookerPath)
+        {
+            this.ProcessCounterTrackEvents =
+                new ProcessedEventData<PerfettoProcessCounterTrackEvent>();
+        }
+
+        public override DataProcessingResult CookDataElement(PerfettoSqlEventKeyed perfettoEvent, PerfettoSourceParser context, CancellationToken cancellationToken)
+        {
+            this.ProcessCounterTrackEvents.AddEvent((PerfettoProcessCounterTrackEvent)perfettoEvent.SqlEvent);
+
+            return DataProcessingResult.Processed;
+        }
+
+        public override void EndDataCooking(CancellationToken cancellationToken)
+        {
+            base.EndDataCooking(cancellationToken);
+            this.ProcessCounterTrackEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoProcessCounterTrackCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoProcessCounterTrackCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the ProcessCounterTrack table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoRawCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoRawCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Raw table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoSchedSliceCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoSchedSliceCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the SchedSlice table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoSliceCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoSliceCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Slice table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoThreadCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoThreadCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the Thread table in Perfetto traces

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoThreadTrackerCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoThreadTrackerCooker.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using PerfettoCds.Pipeline.Events;
 using PerfettoProcessor;
 
-namespace PerfettoCds
+namespace PerfettoCds.Pipeline.SourceDataCookers
 {
     /// <summary>
     /// Cooks the data from the ThreadTrack table in Perfetto traces

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuCountersTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuCountersTable.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using System.Linq;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuCountersTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuCountersTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{cc2db5d6-5abb-4094-b8c0-475a2f4d9946}"),
             "Perfetto CPU Counters (coarse)",
             "Displays coarse CPU usage based on /proc/stat counters",
-            "Perfetto",
+            "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuCountersEventCookerPath }
         );
 
@@ -123,7 +123,7 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(CountColumn, Projection.Constant<int>(1));
 
             // Only display the total CPU usage column
-            var cpuUsageConfig = new TableConfiguration("Perfetto CPU usage")
+            var cpuUsageConfig = new TableConfiguration("Perfetto CPU Usage")
             {
                 Columns = new[]
                 {

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using System.Linq;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{5b9689d4-617c-484c-9b0a-c7242565ec13}"),
             "Perfetto CPU Frequency Scaling",
             "Displays CPU frequency scaling events and idle states for CPUs. Idle CPUs show a frequency of 0.",
-            "Perfetto",
+            "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuFrequencyEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{db17169e-afe5-41f6-ba24-511af1d869f9}"),
             "Perfetto CPU Scheduler Events",
             "Displays CPU scheduling events for processes and threads",
-            "Perfetto",
+            "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuSchedEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using System.Linq;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using Utilities;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -21,7 +21,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{96beb7a0-5a9e-4713-b1f7-4ee74d27851c}"),
             "Perfetto Ftrace Events",
             "All Ftrace events in the Perfetto trace",
-            "Perfetto",
+            "Perfetto - Events",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.FtraceEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -21,7 +21,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{506777b6-f1a3-437a-b976-bc48190450b6}"),
             "Perfetto Generic Events",
             "All app/component events in the Perfetto trace",
-            "Perfetto",
+            "Perfetto - Events",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.GenericEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using Utilities;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 
 namespace PerfettoCds.Pipeline.Tables
 {

--- a/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
@@ -22,7 +22,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{1b25fe8d-887c-4de9-850f-284eb4c28ad7}"),
             "Android Logcat Events",
             "All logcat events/messages in the Perfetto trace",
-            "Android",
+            "Perfetto - Android",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.LogcatEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{80d5ef1d-a24f-472c-83be-707b03239d35}"),
             "Perfetto Process Memory",
             "Displays per process memory counts gathered from /proc/<pid>/status",
-            "Perfetto",
+            "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.ProcessMemoryEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -25,43 +25,38 @@ namespace PerfettoCds.Pipeline.Tables
         );
 
         private static readonly ColumnConfiguration ProcessNameColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{5f47812f-85ab-42e8-bae3-1e7bf377a689}"), "Process", "Current frequency for this CPU. When idle, displays 0"),
-            new UIHints 
-            { 
-                Width = 210,
-            });
-
+            new ColumnMetadata(new Guid("{5f47812f-85ab-42e8-bae3-1e7bf377a689}"), "Process", "Process name"),
+            new UIHints { Width = 210 });
         private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{4b2c0e42-04ee-4e4f-916f-bf7065f34018}"), "StartTimestamp", "Start timestamp for the frequency event"),
+            new ColumnMetadata(new Guid("{4b2c0e42-04ee-4e4f-916f-bf7065f34018}"), "StartTimestamp", "Start timestamp for the memory event"),
             new UIHints { Width = 120 });
-
         private static readonly ColumnConfiguration DurationColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{1db8a444-3bcc-4787-bc4c-f8ffd25ccf98}"), "Duration", "Start timestamp for the frequency sample"),
+            new ColumnMetadata(new Guid("{1db8a444-3bcc-4787-bc4c-f8ffd25ccf98}"), "Duration", "Start timestamp for the memory sample"),
             new UIHints { Width = 120 });
 
         private static readonly ColumnConfiguration RssAnonColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{59db9b2a-09aa-42c5-9da7-631a507f0dbc}"), "RssAnonymous", "Resident set size - anonymous memory"),
+            new ColumnMetadata(new Guid("{59db9b2a-09aa-42c5-9da7-631a507f0dbc}"), "RssAnonymous(kb)", "Resident set size - anonymous memory"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssShMemColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{2969f7a3-54b3-492c-a393-1bd937389bd2}"), "RssSharedMem", "Resident set size - shared memory"),
+            new ColumnMetadata(new Guid("{2969f7a3-54b3-492c-a393-1bd937389bd2}"), "RssSharedMem(kb)", "Resident set size - shared memory"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssFileColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{96a12428-279e-4ef7-830b-89268c1d90cf}"), "RssFile", "Resident set size - file mappings"),
+            new ColumnMetadata(new Guid("{96a12428-279e-4ef7-830b-89268c1d90cf}"), "RssFile(kb)", "Resident set size - file mappings"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssHwmColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{88f8d32e-c884-4263-9712-44166aee1f95}"), "RssHighWatermark", "Resident set size - peak (high water mark)"),
+            new ColumnMetadata(new Guid("{88f8d32e-c884-4263-9712-44166aee1f95}"), "RssHighWatermark(kb)", "Resident set size - peak (high water mark)"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{1ea71b65-4a32-4fc0-8a87-273073a51aa9}"), "Rss", "Resident set size - sum of anon, file, shared mem"),
+            new ColumnMetadata(new Guid("{1ea71b65-4a32-4fc0-8a87-273073a51aa9}"), "Rss(kb)", "Resident set size - sum of anon, file, shared mem"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration LockedColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{b9a65a94-f421-40cf-840e-74dffb84857f}"), "Locked", "Locked memory size"),
+            new ColumnMetadata(new Guid("{b9a65a94-f421-40cf-840e-74dffb84857f}"), "Locked(kb)", "Locked memory size"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration SwapColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{f0ebf9e8-39a1-44b7-8bf0-5f11ff6a8089}"), "Swap", "Swapped out VM size by anonymous private pages"),
+            new ColumnMetadata(new Guid("{f0ebf9e8-39a1-44b7-8bf0-5f11ff6a8089}"), "Swap(kb)", "Swapped out VM size by anonymous private pages"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration VirtColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{83d575ba-2c24-46f7-901e-57241f72b918}"), "Virtual", "Peak virtual memory size"),
+            new ColumnMetadata(new Guid("{83d575ba-2c24-46f7-901e-57241f72b918}"), "Virtual(kb)", "Peak virtual memory size"),
             new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using System.Linq;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics.CodeAnalysis;
+using PerfettoCds.Pipeline.DataOutput;
+using Microsoft.Performance.SDK;
+using PerfettoCds.Pipeline.DataCookers;
+using System.Linq;
+
+namespace PerfettoCds.Pipeline.Tables
+{
+    [Table]
+    public class PerfettoProcessMemoryTable
+    {
+        public static TableDescriptor TableDescriptor => new TableDescriptor(
+            Guid.Parse("{80d5ef1d-a24f-472c-83be-707b03239d35}"),
+            "Perfetto Process Memory",
+            "Displays CPU frequency scaling events and idle states for CPUs. Idle CPUs show a frequency of 0.",
+            "Perfetto",
+            requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.ProcessMemoryEventCookerPath }
+        );
+
+        private static readonly ColumnConfiguration ValueColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{989b9a02-63ab-4ab4-b466-06671db4c61f}"), "Value", "Specific CPU core"),
+            new UIHints { Width = 210, SortOrder = SortOrder.Ascending });
+
+        private static readonly ColumnConfiguration ProcessNameColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{5f47812f-85ab-42e8-bae3-1e7bf377a689}"), "Process", "Current frequency for this CPU. When idle, displays 0"),
+            new UIHints 
+            { 
+                Width = 210,
+                AggregationMode = AggregationMode.Max,
+            });
+
+        private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{4b2c0e42-04ee-4e4f-916f-bf7065f34018}"), "StartTimestamp", "Start timestamp for the frequency event"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration DurationColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{1db8a444-3bcc-4787-bc4c-f8ffd25ccf98}"), "Duration", "Start timestamp for the frequency sample"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration MemoryTypeColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{e54510cb-b2e7-4f78-be95-e220e59eb3af}"), "MemoryType", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration RssAnonColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{59db9b2a-09aa-42c5-9da7-631a507f0dbc}"), "RssAnon", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration LockedColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{b9a65a94-f421-40cf-840e-74dffb84857f}"), "Locked", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration RssShMemColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{2969f7a3-54b3-492c-a393-1bd937389bd2}"), "RssShMem", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration RssFileColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{96a12428-279e-4ef7-830b-89268c1d90cf}"), "RssFile", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration RssHwmColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{88f8d32e-c884-4263-9712-44166aee1f95}"), "RssHwm", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration RssColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{1ea71b65-4a32-4fc0-8a87-273073a51aa9}"), "Rss", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration SwapColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{f0ebf9e8-39a1-44b7-8bf0-5f11ff6a8089}"), "Swap", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+        private static readonly ColumnConfiguration VirtColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{83d575ba-2c24-46f7-901e-57241f72b918}"), "Virt", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
+            new UIHints { Width = 120 });
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            // Get data from the cooker
+            var events = tableData.QueryOutput<ProcessedEventData<PerfettoProcessMemoryEvent>>(
+                new DataOutputPath(PerfettoPluginConstants.ProcessMemoryEventCookerPath, nameof(PerfettoProcessMemoryEventCooker.ProcessMemoryEvents)));
+
+            // Start construction of the column order. Pivot on process and thread
+
+
+            var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
+            var baseProjection = Projection.Index(events);
+
+            tableGenerator.AddColumn(ValueColumn, baseProjection.Compose(x => x.Value));
+            tableGenerator.AddColumn(MemoryTypeColumn, baseProjection.Compose(x => x.MemoryType));
+            tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
+            tableGenerator.AddColumn(ProcessNameColumn, baseProjection.Compose(x => x.ProcessName));
+            tableGenerator.AddColumn(DurationColumn, baseProjection.Compose(x => x.Duration));
+
+            tableGenerator.AddColumn(RssAnonColumn, baseProjection.Compose(x => x.RssAnon));
+            tableGenerator.AddColumn(LockedColumn, baseProjection.Compose(x => x.Locked));
+            tableGenerator.AddColumn(RssShMemColumn, baseProjection.Compose(x => x.RssShMem));
+            tableGenerator.AddColumn(RssFileColumn, baseProjection.Compose(x => x.RssFile));
+            tableGenerator.AddColumn(RssHwmColumn, baseProjection.Compose(x => x.RssHwm));
+            tableGenerator.AddColumn(RssColumn, baseProjection.Compose(x => x.Rss));
+            tableGenerator.AddColumn(SwapColumn, baseProjection.Compose(x => x.Swap));
+            tableGenerator.AddColumn(VirtColumn, baseProjection.Compose(x => x.Virt));
+
+            // We are graphing CPU frequency + duration with MAX accumulation, which gives a steady line graph of the current CPU frequency
+            var tableConfig = new TableConfiguration("Table 1")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    MemoryTypeColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    ValueColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            tableConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn); // TODO need this?
+            tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            var tableConfig2 = new TableConfiguration("Table 2")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
+                    LockedColumn,
+                    RssShMemColumn,
+                    RssFileColumn,
+                    RssHwmColumn,
+                    RssColumn,
+                    SwapColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    RssAnonColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            tableConfig2.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            tableConfig2.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn); // TODO need this?
+            tableConfig2.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            tableBuilder.AddTableConfiguration(tableConfig).AddTableConfiguration(tableConfig2).SetDefaultTableConfiguration(tableConfig);
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -29,7 +29,6 @@ namespace PerfettoCds.Pipeline.Tables
             new UIHints 
             { 
                 Width = 210,
-                AggregationMode = AggregationMode.Max,
             });
 
         private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -19,14 +19,10 @@ namespace PerfettoCds.Pipeline.Tables
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{80d5ef1d-a24f-472c-83be-707b03239d35}"),
             "Perfetto Process Memory",
-            "Displays CPU frequency scaling events and idle states for CPUs. Idle CPUs show a frequency of 0.",
+            "Displays per process memory counts gathered from /proc/<pid>/status",
             "Perfetto",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.ProcessMemoryEventCookerPath }
         );
-
-        private static readonly ColumnConfiguration ValueColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{989b9a02-63ab-4ab4-b466-06671db4c61f}"), "Value", "Specific CPU core"),
-            new UIHints { Width = 210, SortOrder = SortOrder.Ascending });
 
         private static readonly ColumnConfiguration ProcessNameColumn = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{5f47812f-85ab-42e8-bae3-1e7bf377a689}"), "Process", "Current frequency for this CPU. When idle, displays 0"),
@@ -44,34 +40,30 @@ namespace PerfettoCds.Pipeline.Tables
             new ColumnMetadata(new Guid("{1db8a444-3bcc-4787-bc4c-f8ffd25ccf98}"), "Duration", "Start timestamp for the frequency sample"),
             new UIHints { Width = 120 });
 
-        private static readonly ColumnConfiguration MemoryTypeColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{e54510cb-b2e7-4f78-be95-e220e59eb3af}"), "MemoryType", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
-
         private static readonly ColumnConfiguration RssAnonColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{59db9b2a-09aa-42c5-9da7-631a507f0dbc}"), "RssAnon", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
-        private static readonly ColumnConfiguration LockedColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{b9a65a94-f421-40cf-840e-74dffb84857f}"), "Locked", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{59db9b2a-09aa-42c5-9da7-631a507f0dbc}"), "RssAnonymous", "Resident set size - anonymous memory"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssShMemColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{2969f7a3-54b3-492c-a393-1bd937389bd2}"), "RssShMem", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{2969f7a3-54b3-492c-a393-1bd937389bd2}"), "RssSharedMem", "Resident set size - shared memory"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssFileColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{96a12428-279e-4ef7-830b-89268c1d90cf}"), "RssFile", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{96a12428-279e-4ef7-830b-89268c1d90cf}"), "RssFile", "Resident set size - file mappings"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssHwmColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{88f8d32e-c884-4263-9712-44166aee1f95}"), "RssHwm", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{88f8d32e-c884-4263-9712-44166aee1f95}"), "RssHighWatermark", "Resident set size - peak (high water mark)"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration RssColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{1ea71b65-4a32-4fc0-8a87-273073a51aa9}"), "Rss", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{1ea71b65-4a32-4fc0-8a87-273073a51aa9}"), "Rss", "Resident set size - sum of anon, file, shared mem"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
+        private static readonly ColumnConfiguration LockedColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{b9a65a94-f421-40cf-840e-74dffb84857f}"), "Locked", "Locked memory size"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration SwapColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{f0ebf9e8-39a1-44b7-8bf0-5f11ff6a8089}"), "Swap", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{f0ebf9e8-39a1-44b7-8bf0-5f11ff6a8089}"), "Swap", "Swapped out VM size by anonymous private pages"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
         private static readonly ColumnConfiguration VirtColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{83d575ba-2c24-46f7-901e-57241f72b918}"), "Virt", "Indicates CPU change events. 'cpuidle' indicates a change in idle state. 'cpufreq' indicates a change of frequency"),
-            new UIHints { Width = 120 });
+            new ColumnMetadata(new Guid("{83d575ba-2c24-46f7-901e-57241f72b918}"), "Virtual", "Peak virtual memory size"),
+            new UIHints { Width = 120, AggregationMode = AggregationMode.Max });
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
         {
@@ -79,14 +71,9 @@ namespace PerfettoCds.Pipeline.Tables
             var events = tableData.QueryOutput<ProcessedEventData<PerfettoProcessMemoryEvent>>(
                 new DataOutputPath(PerfettoPluginConstants.ProcessMemoryEventCookerPath, nameof(PerfettoProcessMemoryEventCooker.ProcessMemoryEvents)));
 
-            // Start construction of the column order. Pivot on process and thread
-
-
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
             var baseProjection = Projection.Index(events);
 
-            tableGenerator.AddColumn(ValueColumn, baseProjection.Compose(x => x.Value));
-            tableGenerator.AddColumn(MemoryTypeColumn, baseProjection.Compose(x => x.MemoryType));
             tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
             tableGenerator.AddColumn(ProcessNameColumn, baseProjection.Compose(x => x.ProcessName));
             tableGenerator.AddColumn(DurationColumn, baseProjection.Compose(x => x.Duration));
@@ -100,27 +87,8 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(SwapColumn, baseProjection.Compose(x => x.Swap));
             tableGenerator.AddColumn(VirtColumn, baseProjection.Compose(x => x.Virt));
 
-            // We are graphing CPU frequency + duration with MAX accumulation, which gives a steady line graph of the current CPU frequency
-            var tableConfig = new TableConfiguration("Table 1")
-            {
-                Columns = new[]
-                {
-                    ProcessNameColumn,
-                    MemoryTypeColumn,
-                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
-                    StartTimestampColumn,
-                    DurationColumn,
-                    TableConfiguration.GraphColumn, // Columns after this get graphed
-                    ValueColumn
-                },
-                Layout = TableLayoutStyle.GraphAndTable,
-                ChartType = ChartType.Line
-            };
-            tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
-            tableConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn); // TODO need this?
-            tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
-
-            var tableConfig2 = new TableConfiguration("Table 2")
+            // Virtual
+            var virtConfig = new TableConfiguration("Virtual")
             {
                 Columns = new[]
                 {
@@ -129,23 +97,214 @@ namespace PerfettoCds.Pipeline.Tables
                     StartTimestampColumn,
                     DurationColumn,
                     RssAnonColumn,
+                    RssShMemColumn,
+                    RssFileColumn,
+                    RssHwmColumn,
+                    RssColumn,
                     LockedColumn,
+                    SwapColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    VirtColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            virtConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            virtConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            virtConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // Swap
+            var swapConfig = new TableConfiguration("Swap")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
+                    RssShMemColumn,
+                    RssFileColumn,
+                    RssHwmColumn,
+                    RssColumn,
+                    LockedColumn,
+                    VirtColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    SwapColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            swapConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            swapConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            swapConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // Locked
+            var lockedConfig = new TableConfiguration("Locked")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
                     RssShMemColumn,
                     RssFileColumn,
                     RssHwmColumn,
                     RssColumn,
                     SwapColumn,
+                    VirtColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    LockedColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            lockedConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            lockedConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            lockedConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // Rss
+            var rssConfig = new TableConfiguration("RSS (sum of anon, file, shared mem)")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
+                    RssShMemColumn,
+                    RssFileColumn,
+                    RssHwmColumn,
+                    LockedColumn,
+                    SwapColumn,
+                    VirtColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    RssColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            rssConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            rssConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            rssConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // rssHwm
+            var rssHwmConfig = new TableConfiguration("RSS Peak (high water mark)")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
+                    RssShMemColumn,
+                    RssFileColumn,
+                    RssColumn,
+                    LockedColumn,
+                    SwapColumn,
+                    VirtColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    RssHwmColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            rssHwmConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            rssHwmConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            rssHwmConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // rssFile
+            var rssFileConfig = new TableConfiguration("RSS File")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
+                    RssShMemColumn,
+                    RssHwmColumn,
+                    RssColumn,
+                    LockedColumn,
+                    SwapColumn,
+                    VirtColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    RssFileColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            rssFileConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            rssFileConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            rssFileConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // rssShMem
+            var rssShMemConfig = new TableConfiguration("RSS Shared Memory")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssAnonColumn,
+                    RssFileColumn,
+                    RssHwmColumn,
+                    RssColumn,
+                    LockedColumn,
+                    SwapColumn,
+                    VirtColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    RssShMemColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            rssShMemConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            rssShMemConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            rssShMemConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            // rssAnon
+            var rssAnonConfig = new TableConfiguration("RSS Anonymous")
+            {
+                Columns = new[]
+                {
+                    ProcessNameColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    RssShMemColumn,
+                    RssFileColumn,
+                    RssHwmColumn,
+                    RssColumn,
+                    LockedColumn,
+                    SwapColumn,
+                    VirtColumn,
                     TableConfiguration.GraphColumn, // Columns after this get graphed
                     RssAnonColumn
                 },
                 Layout = TableLayoutStyle.GraphAndTable,
                 ChartType = ChartType.Line
             };
-            tableConfig2.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
-            tableConfig2.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn); // TODO need this?
-            tableConfig2.AddColumnRole(ColumnRole.Duration, DurationColumn);
+            rssAnonConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            rssAnonConfig.AddColumnRole(ColumnRole.ResourceId, ProcessNameColumn);
+            rssAnonConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
 
-            tableBuilder.AddTableConfiguration(tableConfig).AddTableConfiguration(tableConfig2).SetDefaultTableConfiguration(tableConfig);
+            tableBuilder.AddTableConfiguration(virtConfig)
+                .AddTableConfiguration(virtConfig)
+                .AddTableConfiguration(swapConfig)
+                .AddTableConfiguration(lockedConfig)
+                .AddTableConfiguration(rssConfig)
+                .AddTableConfiguration(rssHwmConfig)
+                .AddTableConfiguration(rssFileConfig)
+                .AddTableConfiguration(rssShMemConfig)
+                .AddTableConfiguration(rssAnonConfig)
+                .SetDefaultTableConfiguration(virtConfig);
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics.CodeAnalysis;
+using PerfettoCds.Pipeline.DataOutput;
+using Microsoft.Performance.SDK;
+using PerfettoCds.Pipeline.DataCookers;
+using System.Linq;
+
+namespace PerfettoCds.Pipeline.Tables
+{
+    [Table]
+    public class PerfettoSystemMemoryTable
+    {
+        public static TableDescriptor TableDescriptor => new TableDescriptor(
+            Guid.Parse("{edbd3ddd-5610-4929-a85f-f9ca6eceb9b2}"),
+            "Perfetto System Memory",
+            "Displays system memory counts gathered from /proc/meminfo",
+            "Perfetto",
+            requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.SystemMemoryEventCookerPath }
+        );
+
+        private static readonly ColumnConfiguration MemoryTypeColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{ac84aa1d-ea66-46d2-8fc3-8ead853f81b4}"), "MemoryType", "Current frequency for this CPU. When idle, displays 0"),
+            new UIHints { Width = 210, });
+        private static readonly ColumnConfiguration MemoryValueColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{3ada3dda-2893-4366-b1a7-a5fe8344e17b}"), "MemoryValue", "Current frequency for this CPU. When idle, displays 0"),
+            new UIHints { Width = 210,  AggregationMode = AggregationMode.Max});
+
+
+        private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{6a9f870f-103c-461c-b909-9b098fe3695f}"), "StartTimestamp", "Start timestamp for the frequency event"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration DurationColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{bade2ff2-0a7c-4358-a736-058163739ae4}"), "Duration", "Start timestamp for the frequency sample"),
+            new UIHints { Width = 120 });
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            // Get data from the cooker
+            var events = tableData.QueryOutput<ProcessedEventData<PerfettoSystemMemoryEvent>>(
+                new DataOutputPath(PerfettoPluginConstants.SystemMemoryEventCookerPath, nameof(PerfettoSystemMemoryEventCooker.SystemMemoryEvents)));
+
+            var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
+            var baseProjection = Projection.Index(events);
+
+            tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
+            tableGenerator.AddColumn(MemoryTypeColumn, baseProjection.Compose(x => x.MemoryType));
+            tableGenerator.AddColumn(MemoryValueColumn, baseProjection.Compose(x => x.Value));
+            tableGenerator.AddColumn(DurationColumn, baseProjection.Compose(x => x.Duration));
+
+            // Virtual
+            var tableConfig = new TableConfiguration("Virtual")
+            {
+                Columns = new[]
+                {
+                    MemoryTypeColumn,
+                    TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                    StartTimestampColumn,
+                    DurationColumn,
+                    TableConfiguration.GraphColumn, // Columns after this get graphed
+                    MemoryValueColumn
+                },
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.Line
+            };
+            tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            //tableConfig.AddColumnRole(ColumnRole.ResourceId, MemoryTypeColumn);
+            tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            tableBuilder.AddTableConfiguration(tableConfig)
+                .SetDefaultTableConfiguration(tableConfig);
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
             Guid.Parse("{edbd3ddd-5610-4929-a85f-f9ca6eceb9b2}"),
             "Perfetto System Memory",
             "Displays system memory counts gathered from /proc/meminfo",
-            "Perfetto",
+            "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.SystemMemoryEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
@@ -25,19 +25,18 @@ namespace PerfettoCds.Pipeline.Tables
         );
 
         private static readonly ColumnConfiguration MemoryTypeColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{ac84aa1d-ea66-46d2-8fc3-8ead853f81b4}"), "MemoryType", "Current frequency for this CPU. When idle, displays 0"),
+            new ColumnMetadata(new Guid("{ac84aa1d-ea66-46d2-8fc3-8ead853f81b4}"), "MemoryType", "Type of memory"),
             new UIHints { Width = 210, });
         private static readonly ColumnConfiguration MemoryValueColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{3ada3dda-2893-4366-b1a7-a5fe8344e17b}"), "MemoryValue", "Current frequency for this CPU. When idle, displays 0"),
+            new ColumnMetadata(new Guid("{3ada3dda-2893-4366-b1a7-a5fe8344e17b}"), "MemoryValue(kb)", "Memory value"),
             new UIHints { Width = 210,  AggregationMode = AggregationMode.Max});
 
-
         private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{6a9f870f-103c-461c-b909-9b098fe3695f}"), "StartTimestamp", "Start timestamp for the frequency event"),
+            new ColumnMetadata(new Guid("{6a9f870f-103c-461c-b909-9b098fe3695f}"), "StartTimestamp", "Start timestamp for the memory event"),
             new UIHints { Width = 120 });
 
         private static readonly ColumnConfiguration DurationColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{bade2ff2-0a7c-4358-a736-058163739ae4}"), "Duration", "Start timestamp for the frequency sample"),
+            new ColumnMetadata(new Guid("{bade2ff2-0a7c-4358-a736-058163739ae4}"), "Duration", "Start timestamp for the memory sample"),
             new UIHints { Width = 120 });
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
@@ -55,7 +54,7 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(DurationColumn, baseProjection.Compose(x => x.Duration));
 
             // Virtual
-            var tableConfig = new TableConfiguration("Virtual")
+            var tableConfig = new TableConfiguration("System Memory")
             {
                 Columns = new[]
                 {
@@ -70,7 +69,6 @@ namespace PerfettoCds.Pipeline.Tables
                 ChartType = ChartType.Line
             };
             tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
-            //tableConfig.AddColumnRole(ColumnRole.ResourceId, MemoryTypeColumn);
             tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
 
             tableBuilder.AddTableConfiguration(tableConfig)

--- a/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using System.Linq;
 
 namespace PerfettoCds.Pipeline.Tables

--- a/PerfettoProcessor/Events/PerfettoCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCounterTrackEvent.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Perfetto.Protos;
+
+namespace PerfettoProcessor
+{
+    public class PerfettoCounterTrackEvent : PerfettoSqlEvent
+    {
+        public const string Key = "PerfettoCounterTrackEvent";
+
+        public static string SqlQuery = "select id, name from counter_track";
+        public long Id { get; set; }
+        public string Name { get; set; }
+
+        public override string GetSqlQuery()
+        {
+            return SqlQuery;
+        }
+
+        public override string GetEventKey()
+        {
+            return Key;
+        }
+
+        public override void ProcessCell(string colName,
+            QueryResult.Types.CellsBatch.Types.CellType cellType,
+            QueryResult.Types.CellsBatch batch,
+            string[] stringCells,
+            CellCounters counters)
+        {
+            var col = colName.ToLower();
+            switch (cellType)
+            {
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellInvalid:
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellNull:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellVarint:
+                    var longVal = batch.VarintCells[counters.IntCounter++];
+                    switch (col)
+                    {
+                        case "id":
+                            Id = longVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
+                    var strVal = stringCells[counters.StringCounter++];
+                    switch (col)
+                    {
+                        case "name":
+                            Name = strVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellBlob:
+                    break;
+                default:
+                    throw new Exception("Unexpected CellType");
+            }
+        }
+    }
+}

--- a/PerfettoProcessor/Events/PerfettoProcessCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoProcessCounterTrackEvent.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Perfetto.Protos;
+
+namespace PerfettoProcessor
+{
+    public class PerfettoProcessCounterTrackEvent : PerfettoSqlEvent
+    {
+        public const string Key = "PerfettoProcessCounterTrackEvent";
+
+        public static string SqlQuery = "select name, id, upid from process_counter_track";
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public long Upid { get; set; }
+
+        public override string GetSqlQuery()
+        {
+            return SqlQuery;
+        }
+
+        public override string GetEventKey()
+        {
+            return Key;
+        }
+
+        public override void ProcessCell(string colName,
+            QueryResult.Types.CellsBatch.Types.CellType cellType,
+            QueryResult.Types.CellsBatch batch,
+            string[] stringCells,
+            CellCounters counters)
+        {
+            var col = colName.ToLower();
+            switch (cellType)
+            {
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellInvalid:
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellNull:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellVarint:
+                    var longVal = batch.VarintCells[counters.IntCounter++];
+                    switch (col)
+                    {
+                        case "id":
+                            Id = longVal;
+                            break;
+                        case "upid":
+                            Upid = longVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
+                    var strVal = stringCells[counters.StringCounter++];
+                    switch (col)
+                    {
+                        case "name":
+                            Name = strVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellBlob:
+                    break;
+                default:
+                    throw new Exception("Unexpected CellType");
+            }
+        }
+    }
+}

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -282,6 +282,9 @@ namespace PerfettoProcessor
                                 case PerfettoMetadataEvent.Key:
                                     ev = new PerfettoMetadataEvent();
                                     break;
+                                case PerfettoProcessCounterTrackEvent.Key:
+                                    ev = new PerfettoProcessCounterTrackEvent();
+                                    break;
                                 default:
                                     throw new Exception("Invalid event type");
                             }

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -285,6 +285,9 @@ namespace PerfettoProcessor
                                 case PerfettoProcessCounterTrackEvent.Key:
                                     ev = new PerfettoProcessCounterTrackEvent();
                                     break;
+                                case PerfettoCounterTrackEvent.Key:
+                                    ev = new PerfettoCounterTrackEvent();
+                                    break;
                                 default:
                                     throw new Exception("Invalid event type");
                             }

--- a/PerfettoUnitTest/PerfettoUnitTest.cs
+++ b/PerfettoUnitTest/PerfettoUnitTest.cs
@@ -3,7 +3,7 @@ using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.Toolkit.Engine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PerfettoCds;
-using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Pipeline.CompositeDataCookers;
 using PerfettoCds.Pipeline.DataOutput;
 using System.IO;
 


### PR DESCRIPTION
- Added table that displays memory for each process based on /proc/<pid>/status
- Added table that displays overall system memory based on /proc/meminfo
- Reorganized table groups into "Perfetto - Android", "Perfetto  - Events", and "Perfetto - System"

![image](https://user-images.githubusercontent.com/1233941/131754004-8da032be-677b-44c7-8b84-0b70b11b6108.png)
