### PR TITLE
Perfetto plugin - CPU usage % fix and table ordering

### DIFF
--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
@@ -15,7 +15,7 @@ namespace PerfettoCds.Pipeline.Tables
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{db17169e-afe5-41f6-ba24-511af1d869f9}"),
-            "Perfetto CPU Scheduler Events",
+            " Perfetto CPU Scheduler Events", // Space at the start so it shows up alphabetically first in the table list
             "Displays CPU scheduling events for processes and threads",
             "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuSchedEventCookerPath }
@@ -88,12 +88,12 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(EndTimestampColumn, endProjection);
 
             // Create projections that are used for calculating CPU usage%
-            var viewportClippedSwitchOutTimeForNextOnCpuColumn = Projection.ClipTimeToViewport.Create(startProjection);
-            var viewportClippedSwitchOutTimeForPreviousOnCpuColumn = Projection.ClipTimeToViewport.Create(endProjection);
+            var startProjectionClippedToViewport = Projection.ClipTimeToViewport.Create(startProjection);
+            var endProjectionClippedToViewport = Projection.ClipTimeToViewport.Create(endProjection);
 
             IProjection<int, TimestampDelta> cpuUsageInViewportColumn = Projection.Select(
-                    viewportClippedSwitchOutTimeForNextOnCpuColumn,
-                    viewportClippedSwitchOutTimeForPreviousOnCpuColumn,
+                    endProjectionClippedToViewport,
+                    startProjectionClippedToViewport,
                     new ReduceTimeSinceLastDiff());
 
             var percentCpuUsageColumn = Projection.ViewportRelativePercent.Create(cpuUsageInViewportColumn);
@@ -178,7 +178,7 @@ namespace PerfettoCds.Pipeline.Tables
                 .AddTableConfiguration(cpuSchedConfig)
                 .AddTableConfiguration(perCpuUsageConfig)
                 .AddTableConfiguration(perProcessUsageConfig)
-                .SetDefaultTableConfiguration(cpuSchedConfig);
+                .SetDefaultTableConfiguration(perCpuUsageConfig);
         }
 
         struct ReduceTimeSinceLastDiff

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -19,7 +19,7 @@ namespace PerfettoCds.Pipeline.Tables
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{506777b6-f1a3-437a-b976-bc48190450b6}"),
-            "Perfetto Generic Events",
+            " Perfetto Generic Events",  // Space at the start so it shows up alphabetically first in the table list
             "All app/component events in the Perfetto trace",
             "Perfetto - Events",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.GenericEventCookerPath }


### PR DESCRIPTION
- Fixed CPU usage % was not showing up in table. Had projection order backwards. Made this table config first
- You can't set the default table in each table group, it is sorted alphabetically. Putting a space in the name makes it first though. Made a couple of the more interesting tables first 