### PR TITLE
Perfetto plugin - Memory optimizations and table renaming

### DIFF
--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/Cloud-init/Tables/Metadata/FileStatsMetadataTable.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/Cloud-init/Tables/Metadata/FileStatsMetadataTable.cs
@@ -15,7 +15,7 @@ namespace CloudInitMPTAddin.Tables.Metadata
     public sealed class FileStatsMetadataTable
     {
         public static readonly TableDescriptor TableDescriptor = new TableDescriptor(
-            Guid.Parse("{40AF86E5-0DF8-47B1-9A01-1D6C3529B75B}"),
+            Guid.Parse("{806a2599-97a2-4ff7-9ed8-9ac891edeef6}"),
             "File Stats",
             "Statistics for text files",
             isMetadataTable: true,

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/WaLinuxAgent/Tables/Metadata/FileStatsMetadataTable.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/WaLinuxAgent/Tables/Metadata/FileStatsMetadataTable.cs
@@ -31,7 +31,7 @@ namespace WaLinuxAgentMPTAddin.Tables.Metadata
     public static class FileStatsMetadataTable
     {
         public static readonly TableDescriptor TableDescriptor = new TableDescriptor(
-            Guid.Parse("{40AF86E5-0DF8-47B1-9A01-1D6C3529B75B}"),
+            Guid.Parse("{10a8a80a-27a3-42b8-8cde-3a374080e01e}"),
             "File Stats",
             "Statistics for text files",
             isMetadataTable: true,

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
@@ -10,6 +10,7 @@ using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
 using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
@@ -78,23 +79,23 @@ namespace PerfettoCds.Pipeline.CompositeDataCookers
                 // Each event has multiple of these arguments. They get stored in lists
                 foreach (var arg in result.args)
                 {
-                    argKeys.Add(arg.ArgKey);
+                    argKeys.Add(Common.StringIntern(arg.ArgKey));
                     switch (arg.ValueType)
                     {
                         case "json":
                         case "string":
-                            values.Add(arg.StringValue);
+                            values.Add(Common.StringIntern(arg.StringValue));
                             break;
                         case "bool":
                         case "int":
-                            values.Add(arg.IntValue.ToString());
+                            values.Add(Common.StringIntern(arg.IntValue.ToString()));
                             break;
                         case "uint":
                         case "pointer":
-                            values.Add(((uint)arg.IntValue).ToString());
+                            values.Add(Common.StringIntern(((uint)arg.IntValue).ToString()));
                             break;
                         case "real":
-                            values.Add(arg.RealValue.ToString());
+                            values.Add(Common.StringIntern(arg.RealValue.ToString()));
                             break;
                         default:
                             throw new Exception("Unexpected Perfetto value type");

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
@@ -15,6 +15,7 @@ using Microsoft.Performance.SDK.Processing;
 using PerfettoCds.Pipeline.DataOutput;
 using PerfettoCds.Pipeline.SourceDataCookers;
 using PerfettoProcessor;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.CompositeDataCookers
 {
@@ -188,12 +189,12 @@ namespace PerfettoCds.Pipeline.CompositeDataCookers
                 // Each event has multiple of these "debug annotations". They get stored in lists
                 foreach (var arg in result.args)
                 {
-                    argKeys.Add(arg.ArgKey);
+                    argKeys.Add(Common.StringIntern(arg.ArgKey));
                     switch (arg.ValueType)
                     {
                         case "json":
                         case "string":
-                            values.Add(arg.StringValue);
+                            values.Add(Common.StringIntern(arg.StringValue));
 
                             // Check if there are mappings present and if the arg key is the keyword we're looking for
                             if (ProviderGuidMapping.Count > 0 && arg.ArgKey.ToLower().Contains(ProviderDebugAnnotationKey))
@@ -210,14 +211,14 @@ namespace PerfettoCds.Pipeline.CompositeDataCookers
                             break;
                         case "bool":
                         case "int":
-                            values.Add(arg.IntValue.ToString());
+                            values.Add(Common.StringIntern(arg.IntValue.ToString()));
                             break;
                         case "uint":
                         case "pointer":
-                            values.Add(((uint)arg.IntValue).ToString());
+                            values.Add(Common.StringIntern(((uint)arg.IntValue).ToString()));
                             break;
                         case "real":
-                            values.Add(arg.RealValue.ToString());
+                            values.Add(Common.StringIntern(arg.RealValue.ToString()));
                             break;
                         default:
                             throw new Exception("Unexpected Perfetto value type");
@@ -282,7 +283,6 @@ namespace PerfettoCds.Pipeline.CompositeDataCookers
                     new Timestamp(result.slice.RelativeTimestamp + result.slice.Duration) :
                     longestEndTs,
                    result.slice.Category,
-                   result.slice.ArgSetId,
                    values,
                    argKeys,
                    processName,

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoCpuCountersEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoCpuCountersEvent.cs
@@ -8,7 +8,7 @@ namespace PerfettoCds.Pipeline.DataOutput
     public readonly struct PerfettoCpuCountersEvent
     {
         // The specific CPU core
-        public long CpuNum { get; }
+        public int CpuNum { get; }
         public Timestamp StartTimestamp { get; }
         public TimestampDelta Duration { get; }
 
@@ -36,7 +36,7 @@ namespace PerfettoCds.Pipeline.DataOutput
         /// <summary>
         /// For populating the current counter values
         /// </summary>
-        public PerfettoCpuCountersEvent(long cpuNum, Timestamp startTimestamp, TimestampDelta duration,
+        public PerfettoCpuCountersEvent(int cpuNum, Timestamp startTimestamp, TimestampDelta duration,
             double userNs,
             double userNiceNs,
             double systemModeNs,
@@ -70,7 +70,7 @@ namespace PerfettoCds.Pipeline.DataOutput
         /// <summary>
         /// When we have a previous event to compare to, we can calculate the percent change
         /// </summary>
-        public PerfettoCpuCountersEvent(long cpuNum, Timestamp startTimestamp, TimestampDelta duration,
+        public PerfettoCpuCountersEvent(int cpuNum, Timestamp startTimestamp, TimestampDelta duration,
             double userNs,
             double userNiceNs,
             double systemModeNs,

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
@@ -13,14 +13,14 @@ namespace PerfettoCds.Pipeline.DataOutput
         // The current frequency of this CPU
         public double CpuFrequency { get; }
         // The specific CPU core
-        public long CpuNum { get; }
+        public int CpuNum { get; }
         public Timestamp StartTimestamp { get; }
         // Type of CPU frequency event. Whether it's an idle change or frequency change event
         public string Name { get; }
         public TimestampDelta Duration { get; }
         public bool IsIdle { get; }
 
-        public PerfettoCpuFrequencyEvent(double cpuFrequency, long cpuNum, Timestamp startTimestamp, TimestampDelta duration, string name, bool isIdle)
+        public PerfettoCpuFrequencyEvent(double cpuFrequency, int cpuNum, Timestamp startTimestamp, TimestampDelta duration, string name, bool isIdle)
         {
             this.CpuFrequency = cpuFrequency;
             this.CpuNum = cpuNum;

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoCpuSchedEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoCpuSchedEvent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.DataOutput
 {
@@ -14,21 +15,21 @@ namespace PerfettoCds.Pipeline.DataOutput
         public TimestampDelta Duration { get; }
         public Timestamp StartTimestamp { get; }
         public Timestamp EndTimestamp { get; }
-        public long Cpu { get; }
+        public int Cpu { get; }
         public string EndState { get; }
-        public long Priority { get; }
+        public int Priority { get; }
 
         public PerfettoCpuSchedEvent(string processName,
             string threadName,
             TimestampDelta duration,
             Timestamp startTimestamp,
             Timestamp endTimestamp,
-            long cpu,
+            int cpu,
             string endState,
-            long priority)
+            int priority)
         {
-            this.ProcessName = processName;
-            this.ThreadName = threadName;
+            this.ProcessName = Common.StringIntern(processName);
+            this.ThreadName = Common.StringIntern(threadName);
             this.Duration = duration;
             this.StartTimestamp = startTimestamp;
             this.EndTimestamp = endTimestamp;

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK;
 using System.Collections.Generic;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.DataOutput
 {
@@ -13,29 +14,29 @@ namespace PerfettoCds.Pipeline.DataOutput
         public Timestamp StartTimestamp { get; }
         public string ProcessName { get; }
         public string ThreadName { get; }
-        public long Cpu { get; }
+        public int Cpu { get; }
         // Name of the ftrace event
         public string Name { get; }
 
         // From Args table. Variable number per event
-        public List<string> Values { get; }
-        public List<string> ArgKeys { get; }
+        public string[] Values { get; }
+        public string[] ArgKeys { get; }
 
         public PerfettoFtraceEvent(Timestamp startTimestamp,
             string processName,
             string threadName,
-            long cpu,
+            int cpu,
             string name,
             List<string> values,
             List<string> argKeys)
         {
             this.StartTimestamp = startTimestamp;
-            this.ProcessName = processName;
-            this.ThreadName = threadName;
+            this.ProcessName = Common.StringIntern(processName);
+            this.ThreadName = Common.StringIntern(threadName);
             this.Cpu = cpu;
-            this.Name = name;
-            this.Values = values;
-            this.ArgKeys = argKeys;
+            this.Name = Common.StringIntern(name);
+            this.Values = values.ToArray();
+            this.ArgKeys = argKeys.ToArray();
         }
     }
 }

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoGenericEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoGenericEvent.cs
@@ -3,6 +3,7 @@
 using Microsoft.Performance.SDK;
 using PerfettoProcessor;
 using System.Collections.Generic;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.DataOutput
 {
@@ -20,12 +21,9 @@ namespace PerfettoCds.Pipeline.DataOutput
         public Timestamp EndTimestamp { get; }
         public string Category { get; }
 
-        // Key between slice and args table
-        public long ArgSetId { get; }
-
         // From Args table. The debug annotations for an event. Variable number per event
-        public List<string> Values { get; }
-        public List<string> ArgKeys { get; }
+        public string[] Values { get; }
+        public string[] ArgKeys { get; }
 
         // From Process table
         public string Process { get; }
@@ -35,7 +33,7 @@ namespace PerfettoCds.Pipeline.DataOutput
 
         public string Provider { get; }
 
-        public long? ParentId{ get; }
+        public int? ParentId{ get; }
 
         public int ParentTreeDepthLevel { get; }
 
@@ -49,29 +47,27 @@ namespace PerfettoCds.Pipeline.DataOutput
             Timestamp startTimestamp, 
             Timestamp endTimestamp, 
             string category, 
-            long argSetId, 
             List<string> values,
             List<string> argKeys,
             string process,
             string thread,
             string provider,
             PerfettoThreadTrackEvent threadTrack,
-            long? parentId,
+            int? parentId,
             int parentTreeDepthLevel,
             string[] parentEventNameTree)
         {
-            EventName = eventName;
-            Type = type;
+            EventName = Common.StringIntern(eventName);
+            Type = Common.StringIntern(type);
             Duration = duration;
             StartTimestamp = startTimestamp;
             EndTimestamp = endTimestamp;
-            Category = category;
-            ArgSetId = argSetId;
-            Values = values;
-            ArgKeys = argKeys;
-            Process = process;
-            Thread = thread;
-            Provider = provider;
+            Category =  Common.StringIntern(category);
+            Values = values.ToArray();
+            ArgKeys = argKeys.ToArray();
+            Process = Common.StringIntern(process);
+            Thread = Common.StringIntern(thread);
+            Provider = Common.StringIntern(provider);
             ThreadTrack = threadTrack;
             ParentId = parentId;
             ParentTreeDepthLevel = parentTreeDepthLevel;

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoLogcatEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoLogcatEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using Microsoft.Performance.SDK;
 using System.Collections.Generic;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.DataOutput
 {
@@ -25,11 +26,11 @@ namespace PerfettoCds.Pipeline.DataOutput
             string message)
         {
             this.StartTimestamp = startTimestamp;
-            this.ProcessName = processName;
-            this.ThreadName = threadName;
-            this.Priority = priority;
-            this.Tag = tag;
-            this.Message = message;
+            this.ProcessName = Common.StringIntern(processName);
+            this.ThreadName = Common.StringIntern(threadName);
+            this.Priority = Common.StringIntern(priority);
+            this.Tag = Common.StringIntern(tag);
+            this.Message = Common.StringIntern(message);
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuCountersTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuCountersTable.cs
@@ -18,7 +18,7 @@ namespace PerfettoCds.Pipeline.Tables
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{cc2db5d6-5abb-4094-b8c0-475a2f4d9946}"),
-            "Perfetto CPU Counters (coarse)",
+            "CPU Counters (coarse)",
             "Displays coarse CPU usage based on /proc/stat counters",
             "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuCountersEventCookerPath }
@@ -123,7 +123,7 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(CountColumn, Projection.Constant<int>(1));
 
             // Only display the total CPU usage column
-            var cpuUsageConfig = new TableConfiguration("Perfetto CPU Usage")
+            var cpuUsageConfig = new TableConfiguration("CPU Usage %")
             {
                 Columns = new[]
                 {
@@ -150,7 +150,7 @@ namespace PerfettoCds.Pipeline.Tables
             cpuUsageConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
 
             // Display all CPU counter columns
-            var allCountersConfig = new TableConfiguration("Perfetto CPU Counters - All")
+            var allCountersConfig = new TableConfiguration("CPU Counters - All")
             {
                 Columns = new[]
                 {

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
@@ -18,7 +18,7 @@ namespace PerfettoCds.Pipeline.Tables
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{5b9689d4-617c-484c-9b0a-c7242565ec13}"),
-            "Perfetto CPU Frequency Scaling",
+            "CPU Frequency Scaling",
             "Displays CPU frequency scaling events and idle states for CPUs. Idle CPUs show a frequency of 0.",
             "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuFrequencyEventCookerPath }
@@ -82,7 +82,7 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(IsIdleColumn, baseProjection.Compose(x => x.IsIdle));
 
             // We are graphing CPU frequency + duration with MAX accumulation, which gives a steady line graph of the current CPU frequency
-            var tableConfig = new TableConfiguration("Perfetto CPU Frequency")
+            var tableConfig = new TableConfiguration("CPU Frequency")
             {
                 Columns = allColumns,
                 Layout = TableLayoutStyle.GraphAndTable,

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
@@ -15,7 +15,7 @@ namespace PerfettoCds.Pipeline.Tables
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{db17169e-afe5-41f6-ba24-511af1d869f9}"),
-            " Perfetto CPU Scheduler Events", // Space at the start so it shows up alphabetically first in the table list
+            " CPU Scheduler Events", // Space at the start so it shows up alphabetically first in the table list
             "Displays CPU scheduling events for processes and threads",
             "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuSchedEventCookerPath }
@@ -103,7 +103,7 @@ namespace PerfettoCds.Pipeline.Tables
             // the scheduler view
             const string swapperIdleFilter = "[Thread]:=\"swapper\"";
 
-            var cpuSchedConfig = new TableConfiguration("Perfetto CPU Scheduling")
+            var cpuSchedConfig = new TableConfiguration("CPU Scheduling")
             {
                 Columns = new[]
                 {
@@ -126,7 +126,7 @@ namespace PerfettoCds.Pipeline.Tables
             cpuSchedConfig.AddColumnRole(ColumnRole.EndTime, EndTimestampColumn.Metadata.Guid);
             cpuSchedConfig.AddColumnRole(ColumnRole.Duration, DurationColumn.Metadata.Guid);
 
-            var perCpuUsageConfig = new TableConfiguration("Perfetto Utilization by CPU")
+            var perCpuUsageConfig = new TableConfiguration("Utilization by CPU")
             {
                 Columns = new[]
                 {
@@ -150,7 +150,7 @@ namespace PerfettoCds.Pipeline.Tables
             perCpuUsageConfig.AddColumnRole(ColumnRole.EndTime, EndTimestampColumn.Metadata.Guid);
             perCpuUsageConfig.AddColumnRole(ColumnRole.Duration, DurationColumn.Metadata.Guid);
 
-            var perProcessUsageConfig = new TableConfiguration("Perfetto Utilization by Process, Thread")
+            var perProcessUsageConfig = new TableConfiguration("Utilization by Process, Thread")
             {
                 Columns = new[]
                 {

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -19,7 +19,7 @@ namespace PerfettoCds.Pipeline.Tables
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{96beb7a0-5a9e-4713-b1f7-4ee74d27851c}"),
-            "Perfetto Ftrace Events",
+            "Ftrace Events",
             "All Ftrace events in the Perfetto trace",
             "Perfetto - Events",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.FtraceEventCookerPath }
@@ -126,7 +126,7 @@ namespace PerfettoCds.Pipeline.Tables
             cpuColumns.Add(TableConfiguration.GraphColumn); // Columns after this get graphed
             cpuColumns.Add(StartTimestampColumn);
 
-            var cpuConfig = new TableConfiguration("Perfetto Ftrace Events - CPU")
+            var cpuConfig = new TableConfiguration("CPU")
             {
                 Columns = cpuColumns,
                 Layout = TableLayoutStyle.GraphAndTable
@@ -146,7 +146,7 @@ namespace PerfettoCds.Pipeline.Tables
             processThreadColumns.Add(TableConfiguration.GraphColumn); // Columns after this get graphed
             processThreadColumns.Add(StartTimestampColumn);
 
-            var processThreadConfig = new TableConfiguration("Perfetto Ftrace Events - Process-Thread")
+            var processThreadConfig = new TableConfiguration("Process-Thread")
             {
                 Columns = processThreadColumns,
                 Layout = TableLayoutStyle.GraphAndTable

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -193,7 +193,7 @@ namespace PerfettoCds.Pipeline.Tables
                                                                     : String.Empty));
             tableGenerator.AddColumn(trackNameIdColumn);
 
-            var parentIdColumn = new BaseDataColumn<long>(
+            var parentIdColumn = new BaseDataColumn<int>(
                 ParentIdColConfig,
                 genericEventProjection.Compose((genericEvent) => genericEvent.ParentId.HasValue? genericEvent.ParentId.Value : -1));
             tableGenerator.AddColumn(parentIdColumn);
@@ -217,7 +217,7 @@ namespace PerfettoCds.Pipeline.Tables
                 var colIndex = index;  // This seems unncessary but causes odd runtime behavior if not done this way. Compiler is confused perhaps because w/o this func will index=genericEvent.FieldNames.Count every time. index is passed as ref but colIndex as value into func
                 string fieldName = "Field " + (colIndex + 1);
 
-                var genericEventFieldNameProjection = genericEventProjection.Compose((genericEvent) => colIndex < genericEvent.ArgKeys.Count ? genericEvent.ArgKeys[colIndex] : string.Empty);
+                var genericEventFieldNameProjection = genericEventProjection.Compose((genericEvent) => colIndex < genericEvent.ArgKeys.Length ? genericEvent.ArgKeys[colIndex] : string.Empty);
 
                 // generate a column configuration
                 var fieldColumnConfiguration = new ColumnConfiguration(
@@ -235,7 +235,7 @@ namespace PerfettoCds.Pipeline.Tables
                 // Add this column to the column order
                 fieldColumns.Add(fieldColumnConfiguration);
 
-                var genericEventFieldAsStringProjection = genericEventProjection.Compose((genericEvent) => colIndex < genericEvent.Values.Count ? genericEvent.Values[colIndex] : string.Empty);
+                var genericEventFieldAsStringProjection = genericEventProjection.Compose((genericEvent) => colIndex < genericEvent.Values.Length ? genericEvent.Values[colIndex] : string.Empty);
 
                 tableGenerator.AddColumn(fieldColumnConfiguration, genericEventFieldAsStringProjection);
             }

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{506777b6-f1a3-437a-b976-bc48190450b6}"),
-            " Perfetto Generic Events",  // Space at the start so it shows up alphabetically first in the table list
+            " Generic Events",  // Space at the start so it shows up alphabetically first in the table list
             "All app/component events in the Perfetto trace",
             "Perfetto - Events",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.GenericEventCookerPath }
@@ -256,13 +256,27 @@ namespace PerfettoCds.Pipeline.Tables
             defaultColumns.Add(StartTimestampColConfig);
             defaultColumns.Add(EndTimestampColConfig);
 
-            var processThreadConfig = new TableConfiguration("Perfetto Trace Events - Process-Thread")
+            // Proces-Thread config
+            var processThreadConfig = new TableConfiguration("Process-Thread")
             {
                 Columns = defaultColumns,
                 Layout = TableLayoutStyle.GraphAndTable
             };
             SetGraphTableConfig(processThreadConfig);
 
+            // Process-Thread by StartTime config
+            var processThreadByStartTimeColumns = new List<ColumnConfiguration>(defaultColumns);
+            processThreadByStartTimeColumns.Remove(EndTimestampColConfig);
+            processThreadByStartTimeColumns.Insert(processThreadByStartTimeColumns.Count - 3, EndTimestampColConfig);
+
+            var processThreadByStartTimeConfig = new TableConfiguration("Process-Thread by Start Time")
+            {
+                Columns = processThreadByStartTimeColumns,
+                Layout = TableLayoutStyle.GraphAndTable
+            };
+            SetGraphTableConfig(processThreadByStartTimeConfig);
+
+            // Process-Thread Activity config
             var processThreadActivityColumns = new List<ColumnConfiguration>(defaultColumns);
             processThreadActivityColumns.Remove(StartTimestampColConfig);
             processThreadActivityColumns.Insert(8, StartTimestampColConfig);
@@ -276,30 +290,48 @@ namespace PerfettoCds.Pipeline.Tables
             DurationNotSortedColConfig.DisplayHints.SortPriority = 1;
             DurationNotSortedColConfig.DisplayHints.SortOrder = SortOrder.Descending;
 
-            var processThreadActivityConfig = new TableConfiguration("Perfetto Trace Events - Process-Thread Activity")
+            var processThreadActivityConfig = new TableConfiguration("Process-Thread Activity")
             {
                 Columns = processThreadActivityColumns,
                 Layout = TableLayoutStyle.GraphAndTable
             };
             SetGraphTableConfig(processThreadActivityConfig);
 
+            // Process-Thread-Name config
             var processThreadNameColumns = new List<ColumnConfiguration>(defaultColumns);
             processThreadNameColumns.Insert(3, ParentDepthLevelColConfig);
             processThreadNameColumns.Remove(EventNameColConfig);
             processThreadNameColumns.Insert(4, EventNameColConfig);
             processThreadNameColumns.Insert(9, ParentEventNameTreeBranchColConfig);
-            var processThreadNameConfig = new TableConfiguration("Perfetto Trace Events - Process-Thread-Name")
+            var processThreadNameConfig = new TableConfiguration("Process-Thread-Name")
             {
                 Columns = processThreadNameColumns,
                 Layout = TableLayoutStyle.GraphAndTable
             };
             SetGraphTableConfig(processThreadNameConfig);
 
+            // Process-Thread-Name by StartTime config
+            var processThreadNameByStartTimeColumns = new List<ColumnConfiguration>(defaultColumns);
+            processThreadNameByStartTimeColumns.Insert(3, ParentDepthLevelColConfig);
+            processThreadNameByStartTimeColumns.Remove(EventNameColConfig);
+            processThreadNameByStartTimeColumns.Insert(4, EventNameColConfig);
+            processThreadNameByStartTimeColumns.Insert(9, ParentEventNameTreeBranchColConfig);
+            processThreadNameByStartTimeColumns.Remove(EndTimestampColConfig);
+            processThreadNameByStartTimeColumns.Insert(processThreadNameByStartTimeColumns.Count - 3, EndTimestampColConfig);
+
+            var processThreadNameByStartTimeConfig = new TableConfiguration("Process-Thread-Name by Start Time")
+            {
+                Columns = processThreadNameByStartTimeColumns,
+                Layout = TableLayoutStyle.GraphAndTable
+            };
+            SetGraphTableConfig(processThreadNameByStartTimeConfig);
+
+            // Process-Thread-ParentNameTree config
             var processThreadNameTreeColumns = new List<ColumnConfiguration>(defaultColumns);
             processThreadNameTreeColumns.Insert(3, ParentEventNameTreeBranchColConfig);
             processThreadNameTreeColumns.Insert(9, ParentDepthLevelColConfig);
             processThreadNameTreeColumns.Insert(10, ParentEventNameTreeBranchColConfig);
-            var processThreadParentNameTreeConfig = new TableConfiguration("Perfetto Trace Events - Process-Thread-ParentNameTree")
+            var processThreadParentNameTreeConfig = new TableConfiguration("Process-Thread-ParentNameTree")
             {
                 Columns = processThreadNameTreeColumns,
                 Layout = TableLayoutStyle.GraphAndTable
@@ -308,9 +340,11 @@ namespace PerfettoCds.Pipeline.Tables
 
             tableBuilder
                 .AddTableConfiguration(processThreadConfig)
-                .AddTableConfiguration(processThreadActivityConfig)
+                .AddTableConfiguration(processThreadByStartTimeConfig)
                 .AddTableConfiguration(processThreadNameConfig)
+                .AddTableConfiguration(processThreadNameByStartTimeConfig)
                 .AddTableConfiguration(processThreadParentNameTreeConfig)
+                .AddTableConfiguration(processThreadActivityConfig)
                 .SetDefaultTableConfiguration(processThreadNameConfig);
         }
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -267,7 +267,7 @@ namespace PerfettoCds.Pipeline.Tables
             // Process-Thread by StartTime config
             var processThreadByStartTimeColumns = new List<ColumnConfiguration>(defaultColumns);
             processThreadByStartTimeColumns.Remove(EndTimestampColConfig);
-            processThreadByStartTimeColumns.Insert(processThreadByStartTimeColumns.Count - 3, EndTimestampColConfig);
+            processThreadByStartTimeColumns.Insert(processThreadByStartTimeColumns.Count - 2, EndTimestampColConfig);
 
             var processThreadByStartTimeConfig = new TableConfiguration("Process-Thread by Start Time")
             {
@@ -317,7 +317,7 @@ namespace PerfettoCds.Pipeline.Tables
             processThreadNameByStartTimeColumns.Insert(4, EventNameColConfig);
             processThreadNameByStartTimeColumns.Insert(9, ParentEventNameTreeBranchColConfig);
             processThreadNameByStartTimeColumns.Remove(EndTimestampColConfig);
-            processThreadNameByStartTimeColumns.Insert(processThreadNameByStartTimeColumns.Count - 3, EndTimestampColConfig);
+            processThreadNameByStartTimeColumns.Insert(processThreadNameByStartTimeColumns.Count - 2, EndTimestampColConfig);
 
             var processThreadNameByStartTimeConfig = new TableConfiguration("Process-Thread-Name by Start Time")
             {

--- a/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
@@ -20,7 +20,7 @@ namespace PerfettoCds.Pipeline.Tables
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{1b25fe8d-887c-4de9-850f-284eb4c28ad7}"),
-            "Android Logcat Events",
+            "Logcat Events",
             "All logcat events/messages in the Perfetto trace",
             "Perfetto - Android",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.LogcatEventCookerPath }
@@ -79,7 +79,7 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(TagColumn, baseProjection.Compose(x => x.Tag));
             tableGenerator.AddColumn(MessageColumn, baseProjection.Compose(x => x.Message));
 
-            var tableConfig = new TableConfiguration("Perfetto Logcat Events")
+            var tableConfig = new TableConfiguration("Logcat Events")
             {
                 Columns = allColumns,
                 Layout = TableLayoutStyle.GraphAndTable

--- a/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoProcessMemoryTable.cs
@@ -18,7 +18,7 @@ namespace PerfettoCds.Pipeline.Tables
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{80d5ef1d-a24f-472c-83be-707b03239d35}"),
-            "Perfetto Process Memory",
+            "Process Memory",
             "Displays per process memory counts gathered from /proc/<pid>/status",
             "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.ProcessMemoryEventCookerPath }

--- a/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoSystemMemoryTable.cs
@@ -18,7 +18,7 @@ namespace PerfettoCds.Pipeline.Tables
     {
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{edbd3ddd-5610-4929-a85f-f9ca6eceb9b2}"),
-            "Perfetto System Memory",
+            "System Memory",
             "Displays system memory counts gathered from /proc/meminfo",
             "Perfetto - System",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.SystemMemoryEventCookerPath }

--- a/PerfettoProcessor/Events/PerfettoAndroidLogEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoAndroidLogEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using Perfetto.Protos;
+using Utilities;
 
 namespace PerfettoProcessor
 {
@@ -9,14 +10,14 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoAndroidLogEvent";
 
-        public static string SqlQuery = "select ts, prio, tag, msg, utid from android_logs";
+        public const string SqlQuery = "select ts, prio, tag, msg, utid from android_logs";
         public long Timestamp { get; set; }
         public long RelativeTimestamp { get; set; }
-        public long Priority { get; set; }
+        public int Priority { get; set; }
         public string PriorityString { get; set; }
         public string Tag { get; set; }
         public string  Message { get; set; }
-        public long Utid { get; set; }
+        public int Utid { get; set; }
 
         public override string GetSqlQuery()
         {
@@ -48,20 +49,20 @@ namespace PerfettoProcessor
                     switch (col)
                     {
                         case "utid":
-                            Utid = longVal;
+                            Utid = (int)longVal;
                             break;
                         case "ts":
                             Timestamp = longVal;
                             break;
                         case "prio":
-                            Priority = longVal;
+                            Priority = (int)longVal;
                             if (Priority >= 0 && Priority < PriorityToString.Length)
                             {
                                 PriorityString = PriorityToString[longVal];
                             }
                             else
                             {
-                                PriorityString = longVal.ToString();
+                                PriorityString = Common.StringIntern(longVal.ToString());
                             }
                             break;
                     }
@@ -70,7 +71,7 @@ namespace PerfettoProcessor
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
                     break;
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
-                    var strVal = stringCells[counters.StringCounter++];
+                    var strVal = Common.StringIntern(stringCells[counters.StringCounter++]);
                     switch (col)
                     {
                         case "tag":

--- a/PerfettoProcessor/Events/PerfettoArgEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoArgEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using Perfetto.Protos;
+using Utilities;
 
 namespace PerfettoProcessor
 {
@@ -9,8 +10,8 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoArgEvent";
 
-        public static string SqlQuery = "select arg_set_id, flat_key, key, int_value, string_value, real_value, value_type from args order by arg_set_id";
-        public long ArgSetId { get; set; }
+        public const string SqlQuery = "select arg_set_id, flat_key, key, int_value, string_value, real_value, value_type from args order by arg_set_id";
+        public int ArgSetId { get; set; }
         public string Flatkey { get; set; }
         public string ArgKey { get; set; }
         public long? IntValue { get; set; }
@@ -45,7 +46,7 @@ namespace PerfettoProcessor
                     switch (col)
                     {
                         case "arg_set_id":
-                            ArgSetId = longVal;
+                            ArgSetId = (int)longVal;
                             break;
                         case "int_value":
                             IntValue = longVal;
@@ -61,7 +62,7 @@ namespace PerfettoProcessor
                     }
                     break;
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
-                    var strVal = stringCells[counters.StringCounter++];
+                    var strVal = Common.StringIntern(stringCells[counters.StringCounter++]);
                     switch (col)
                     {
                         case "flat_key":

--- a/PerfettoProcessor/Events/PerfettoClockSnapshotEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoClockSnapshotEvent.cs
@@ -20,7 +20,7 @@ namespace PerfettoProcessor
         // Boottime is counting from an arbitrary time in the past (at bootup?). This time aligns with the timestamps that most events return
         public const string BOOTTIME = "BOOTTIME";
 
-        public static string SqlQuery = "select ts, clock_id, clock_name, clock_value, snapshot_id from clock_snapshot order by snapshot_id ASC";
+        public const string SqlQuery = "select ts, clock_id, clock_name, clock_value, snapshot_id from clock_snapshot order by snapshot_id ASC";
         public long Timestamp { get; set; }
         public long ClockId { get; set; }
         public string ClockName { get; set; }

--- a/PerfettoProcessor/Events/PerfettoCounterEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCounterEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoCounterEvent";
 
-        public static string SqlQuery = "select ts, track_id, value from counter";
+        public const string SqlQuery = "select ts, track_id, value from counter";
         public long Timestamp { get; set; }
         public long RelativeTimestamp { get; set; }
         public long TrackId { get; set; }

--- a/PerfettoProcessor/Events/PerfettoCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCounterTrackEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoCounterTrackEvent";
 
-        public static string SqlQuery = "select id, name from counter_track";
+        public const string SqlQuery = "select id, name from counter_track";
         public long Id { get; set; }
         public string Name { get; set; }
 

--- a/PerfettoProcessor/Events/PerfettoCpuCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCpuCounterTrackEvent.cs
@@ -10,9 +10,9 @@ namespace PerfettoProcessor
         public const string Key = "PerfettoCpuCounterTrackEvent";
 
         public static string SqlQuery = "select name, id, cpu from cpu_counter_track";
-        public long Id { get; set; }
+        public int Id { get; set; }
         public string Name { get; set; }
-        public long Cpu { get; set; }
+        public int Cpu { get; set; }
 
         public override string GetSqlQuery()
         {
@@ -41,10 +41,10 @@ namespace PerfettoProcessor
                     switch (col)
                     {
                         case "id":
-                            Id = longVal;
+                            Id = (int)longVal;
                             break;
                         case "cpu":
-                            Cpu = longVal;
+                            Cpu = (int)longVal;
                             break;
                     }
                     break;

--- a/PerfettoProcessor/Events/PerfettoCpuCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCpuCounterTrackEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoCpuCounterTrackEvent";
 
-        public static string SqlQuery = "select name, id, cpu from cpu_counter_track";
+        public const string SqlQuery = "select name, id, cpu from cpu_counter_track";
         public int Id { get; set; }
         public string Name { get; set; }
         public int Cpu { get; set; }

--- a/PerfettoProcessor/Events/PerfettoMetadataEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoMetadataEvent.cs
@@ -13,7 +13,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoMetadataEvent";
 
-        public static string SqlQuery = "select name, key_type, int_value, str_value from metadata";
+        public const string SqlQuery = "select name, key_type, int_value, str_value from metadata";
         public string Name { get; set; }
         public string KeyType { get; set; }
 

--- a/PerfettoProcessor/Events/PerfettoProcessCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoProcessCounterTrackEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoProcessCounterTrackEvent";
 
-        public static string SqlQuery = "select name, id, upid from process_counter_track";
+        public const string SqlQuery = "select name, id, upid from process_counter_track";
         public long Id { get; set; }
         public string Name { get; set; }
         public long Upid { get; set; }

--- a/PerfettoProcessor/Events/PerfettoProcessEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoProcessEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoProcessEvent";
 
-        public static string SqlQuery = "select upid, id, type, pid, name, start_ts, end_ts, parent_upid, uid, android_appid, cmdline, arg_set_id from process";
+        public const string SqlQuery = "select upid, id, type, pid, name, start_ts, end_ts, parent_upid, uid, android_appid, cmdline, arg_set_id from process";
         public long Upid { get; set; }
         public long Id { get; set; }
         public string Type { get; set; }

--- a/PerfettoProcessor/Events/PerfettoProcessTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoProcessTrackEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoProcessTrackEvent";
 
-        public static string SqlQuery = "select id, type, name, source_arg_set_id, upid from process_track";
+        public const string SqlQuery = "select id, type, name, source_arg_set_id, upid from process_track";
         public long ArgSetId { get; set; }
         public long Id { get; set; }
         public string Type { get; set; }

--- a/PerfettoProcessor/Events/PerfettoRawEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoRawEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using Perfetto.Protos;
+using Utilities;
 
 namespace PerfettoProcessor
 {
@@ -9,15 +10,13 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoRawEvent";
 
-        public static string SqlQuery = "select type, ts, name, cpu, utid, arg_set_id from raw";
-        public string Type { get; set; }
+        public const string SqlQuery = "select ts, name, cpu, utid, arg_set_id from raw";
         public long Timestamp { get; set; }
         public long RelativeTimestamp { get; set; }
         public string Name { get; set; }
-        public long Cpu { get; set; }
-        public long Utid { get; set; }
-        public long ArgSetId { get; set; }
-
+        public int Cpu { get; set; }
+        public int Utid { get; set; }
+        public int ArgSetId { get; set; }
 
         public override string GetSqlQuery()
         {
@@ -46,16 +45,16 @@ namespace PerfettoProcessor
                     switch (col)
                     {
                         case "utid":
-                            Utid = longVal;
+                            Utid = (int)longVal;
                             break;
                         case "ts":
                             Timestamp = longVal;
                             break;
                         case "cpu":
-                            Cpu = longVal;
+                            Cpu = (int)longVal;
                             break;
                         case "arg_set_id":
-                            ArgSetId = longVal;
+                            ArgSetId = (int)longVal;
                             break;
                     }
 
@@ -63,12 +62,9 @@ namespace PerfettoProcessor
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
                     break;
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
-                    var strVal = stringCells[counters.StringCounter++];
+                    var strVal = Common.StringIntern(stringCells[counters.StringCounter++]);
                     switch (col)
                     {
-                        case "type":
-                            Type = strVal;
-                            break;
                         case "name":
                             Name = strVal;
                             break;

--- a/PerfettoProcessor/Events/PerfettoSchedSliceEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoSchedSliceEvent.cs
@@ -1,6 +1,7 @@
 ﻿using Perfetto.Protos;
 using System;
 using System.Text;
+using Utilities;
 
 namespace PerfettoProcessor
 {
@@ -8,16 +9,16 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoSchedSliceEvent";
 
-        public static string SqlQuery = "select utid, ts, dur, cpu, end_state, priority from sched_slice";
+        public const string SqlQuery = "select utid, ts, dur, cpu, end_state, priority from sched_slice";
 
-        public long Utid { get; set; }
+        public int Utid { get; set; }
         public long Timestamp { get; set; }
         public long RelativeTimestamp { get; set; }
         public long Duration { get; set; }
-        public long Cpu { get; set; }
+        public int Cpu { get; set; }
         public string EndStateCode { get; set; }
         public string EndStateStr { get; set; }
-        public long Priority { get; set; }
+        public int Priority { get; set; }
 
         public override string GetEventKey()
         {
@@ -94,7 +95,7 @@ namespace PerfettoProcessor
                         break;
                 }
             }
-            EndStateStr = sb.ToString();
+            EndStateStr = Common.StringIntern(sb.ToString());
         }
 
         public override void ProcessCell(string colName, QueryResult.Types.CellsBatch.Types.CellType cellType, QueryResult.Types.CellsBatch batch, string[] stringCells, CellCounters counters)
@@ -110,7 +111,7 @@ namespace PerfettoProcessor
                     switch (col)
                     {
                         case "utid":
-                            Utid = longVal;
+                            Utid = (int)longVal;
                             break;
                         case "ts":
                             Timestamp = longVal;
@@ -119,10 +120,10 @@ namespace PerfettoProcessor
                             Duration = longVal;
                             break;
                         case "cpu":
-                            Cpu = longVal;
+                            Cpu = (int)longVal;
                             break;
                         case "priority":
-                            Priority = longVal;
+                            Priority = (int)longVal;
                             break;
                     }
 

--- a/PerfettoProcessor/Events/PerfettoSliceEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoSliceEvent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using Perfetto.Protos;
+using Utilities;
 
 namespace PerfettoProcessor
 {
@@ -9,17 +10,17 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoSliceEvent";
 
-        public static string SqlQuery = "select id, ts, dur, arg_set_id, track_id, name, type, category, parent_id from slice order by id";
-        public long Id { get; set; }
+        public const string SqlQuery = "select id, ts, dur, arg_set_id, track_id, name, type, category, parent_id from slice order by id";
+        public int Id { get; set; }
         public string Name { get; set; }
         public string Type { get; set; }
         public long Duration { get; set; }
-        public long ArgSetId { get; set; }
+        public int ArgSetId { get; set; }
         public long Timestamp { get; set; }
         public long RelativeTimestamp { get; set; }
         public string Category { get; set; }
-        public long TrackId { get; set; }
-        public long? ParentId { get; set; }
+        public int TrackId { get; set; }
+        public int? ParentId { get; set; }
 
         public override string GetSqlQuery()
         {
@@ -48,7 +49,7 @@ namespace PerfettoProcessor
                     switch (col)
                     {
                         case "id":
-                            Id = longVal;
+                            Id = (int)longVal;
                             break;
                         case "ts":
                             Timestamp = longVal;
@@ -57,13 +58,13 @@ namespace PerfettoProcessor
                             Duration = longVal;
                             break;
                         case "arg_set_id":
-                            ArgSetId = longVal;
+                            ArgSetId = (int)longVal;
                             break;
                         case "track_id":
-                            TrackId = longVal;
+                            TrackId = (int)longVal;
                             break;
                         case "parent_id":
-                            ParentId = longVal;
+                            ParentId = (int)longVal;
                             break;
                     }
 
@@ -71,7 +72,7 @@ namespace PerfettoProcessor
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
                     break;
                 case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
-                    var strVal = stringCells[counters.StringCounter++];
+                    var strVal = Common.StringIntern(stringCells[counters.StringCounter++]);
                     switch (col)
                     {
                         case "name":

--- a/PerfettoProcessor/Events/PerfettoThreadEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoThreadEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoThreadEvent";
 
-        public static string SqlQuery = "select utid, id, type, tid, name, start_ts, end_ts, upid, is_main_thread from thread";
+        public const string SqlQuery = "select utid, id, type, tid, name, start_ts, end_ts, upid, is_main_thread from thread";
         public long Utid { get; set; }
         public long Id { get; set; }
         public string Type { get; set; }

--- a/PerfettoProcessor/Events/PerfettoThreadTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoThreadTrackEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public new const string Key = "PerfettoThreadTrackEvent";
 
-        public new static string SqlQuery = "select id, type, name, source_arg_set_id, utid from thread_track";
+        public new const string SqlQuery = "select id, type, name, source_arg_set_id, utid from thread_track";
 
         public long Utid { get; set; }
 

--- a/PerfettoProcessor/Events/PerfettoTraceBoundsEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoTraceBoundsEvent.cs
@@ -13,7 +13,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoTraceBoundsEvent";
 
-        public static string SqlQuery = "select start_ts, end_ts from trace_bounds";
+        public const string SqlQuery = "select start_ts, end_ts from trace_bounds";
         public long StartTimestamp { get; set; }
         public long RelativeStartTimestamp { get; set; }
 

--- a/PerfettoProcessor/Events/PerfettoTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoTrackEvent.cs
@@ -9,7 +9,7 @@ namespace PerfettoProcessor
     {
         public const string Key = "PerfettoTrackEvent";
 
-        public static string SqlQuery = "select id, type, name, source_arg_set_id from track";
+        public const string SqlQuery = "select id, type, name, source_arg_set_id from track";
         public long Id { get; set; }
         public string Type { get; set; }
         public string Name { get; set; }

--- a/PerfettoProcessor/PerfettoProcessor.csproj
+++ b/PerfettoProcessor/PerfettoProcessor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -8,6 +8,10 @@
     <PackageReference Include="Google.Protobuf" Version="3.17.3">
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/PerfettoUnitTest/PerfettoUnitTest.cs
+++ b/PerfettoUnitTest/PerfettoUnitTest.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PerfettoCds;
 using PerfettoCds.Pipeline.CompositeDataCookers;
 using PerfettoCds.Pipeline.DataOutput;
+using PerfettoProcessor;
 using System.IO;
 using System.Linq;
 

--- a/PerfettoUnitTest/PerfettoUnitTest.cs
+++ b/PerfettoUnitTest/PerfettoUnitTest.cs
@@ -76,7 +76,7 @@ namespace PerfettoUnitTest
             Assert.IsTrue(cpuSchedEventData.Count == 15267);
             Assert.IsTrue(cpuSchedEventData[0].ThreadName == "kworker/u17:9");
             Assert.IsTrue(cpuSchedEventData[1].EndState == "Task Dead");
-            Assert.IsTrue(cpuSchedEventData[0].ProcessName == null);
+            Assert.IsTrue(cpuSchedEventData[0].ProcessName == string.Empty);
 
             Assert.IsTrue(cpuSchedEventData[5801].EndState == "Runnable");
             Assert.IsTrue(cpuSchedEventData[5801].ThreadName == "TraceLogApiTest");

--- a/Utilities/Common.cs
+++ b/Utilities/Common.cs
@@ -51,5 +51,10 @@ namespace Utilities
             Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
             return guid;
         }
+
+        public static string StringIntern(string str)
+        {
+            return str != null ? string.Intern(str) : string.Empty;
+        }
     }
 }


### PR DESCRIPTION
Made some memory optimizations to help improve the sluggishness in WPA when viewing large traces. Memory optimizations reduce memory usage by about 50%. UI is more responsive now. Optimizations include

- Used string interning on the high-count string fields
- Switched the variable length argument fields from List<string> to string[]
- Changed bunch of longs to ints. These are mostly ID fields. Confirmed they are int or smaller within Perfetto

Table renaming

- Removed redundant "Perfetto" from all tables and column config names
- Added column configs that graph by StartTime instead of duration for GenericEvents