### PR TITLE
Fix metadata errors when opening LTTng file with multiple traces in it

### DIFF
--- a/CtfPlayback/CtfPlayback.cs
+++ b/CtfPlayback/CtfPlayback.cs
@@ -91,7 +91,8 @@ namespace CtfPlayback
                     streamPlayback.CurrentEvent, 
                     streamPlayback.CurrentPacket, 
                     this.streamToTrace[streamPlayback], 
-                    streamPlayback.EventStream);
+                    streamPlayback.EventStream,
+                    streamPlayback.Metadata);
 
                 this.eventCount++;
 

--- a/CtfPlayback/EventStreams/CtfEvent.cs
+++ b/CtfPlayback/EventStreams/CtfEvent.cs
@@ -14,11 +14,13 @@ namespace CtfPlayback.EventStreams
     {
         private readonly PacketReader packetReader;
         private readonly ICtfPacket owningPacket;
+        private readonly ICtfMetadata metadata;
 
-        public CtfEvent(PacketReader packetReader, ICtfPacket owningPacket)
+        public CtfEvent(PacketReader packetReader, ICtfMetadata metadata, ICtfPacket owningPacket)
         {
             this.packetReader = packetReader;
             this.owningPacket = owningPacket;
+            this.metadata = metadata;
         }
 
         public ulong ByteOffsetWithinPacket { get; private set; }
@@ -49,7 +51,7 @@ namespace CtfPlayback.EventStreams
 
             this.ReadStreamEventContext();
 
-            this.Timestamp = this.packetReader.PlaybackCustomization.GetTimestampFromEventHeader(this, this.owningPacket.CurrentEvent?.Timestamp);
+            this.Timestamp = this.packetReader.PlaybackCustomization.GetTimestampFromEventHeader(this, this.metadata, this.owningPacket.CurrentEvent?.Timestamp);
 
             this.DiscardedEvents = this.owningPacket.StreamPacketContext.ReadFieldAsUInt32("events_discarded");
 
@@ -79,7 +81,7 @@ namespace CtfPlayback.EventStreams
 
         public void Read()
         {
-            this.EventDescriptor = this.packetReader.PlaybackCustomization.GetEventDescriptor(this);
+            this.EventDescriptor = this.packetReader.PlaybackCustomization.GetEventDescriptor(this, this.metadata);
             if (this.EventDescriptor == null)
             {
                 throw new CtfPlaybackException("Missing event descriptor for event.");

--- a/CtfPlayback/EventStreams/CtfPacket.cs
+++ b/CtfPlayback/EventStreams/CtfPacket.cs
@@ -73,7 +73,7 @@ namespace CtfPlayback.EventStreams
             this.PacketTimestampsAreValid = false;
 
             if (this.packetReader.PlaybackCustomization.GetTimestampsFromPacketContext(
-                this, out var startValue, out var endValue))
+                this, this.Metadata, out var startValue, out var endValue))
             {
                 this.Start = startValue;
                 this.End = endValue;
@@ -92,7 +92,7 @@ namespace CtfPlayback.EventStreams
                 return false;
             }
 
-            var nextEvent = new CtfEvent(this.packetReader, this);
+            var nextEvent = new CtfEvent(this.packetReader, this.Metadata, this);
             nextEvent.ReadEventMetadata();
 
             this.CurrentEvent = nextEvent;

--- a/CtfPlayback/FieldValues/CtfTimestamp.cs
+++ b/CtfPlayback/FieldValues/CtfTimestamp.cs
@@ -30,8 +30,9 @@ namespace CtfPlayback.FieldValues
         /// Constructor
         /// </summary>
         /// <param name="metadataCustomization">Extensibility points</param>
+        /// <param name="metadata">The active metadata relevant to this timestamp</param>
         /// <param name="integerValue">integer representation of the timestamp</param>
-        public CtfTimestamp(ICtfMetadataCustomization metadataCustomization, CtfIntegerValue integerValue)
+        public CtfTimestamp(ICtfMetadataCustomization metadataCustomization, ICtfMetadata metadata, CtfIntegerValue integerValue)
         {
             this.BaseIntegerValue = integerValue;
 
@@ -44,9 +45,9 @@ namespace CtfPlayback.FieldValues
                     throw new CtfPlaybackException($"Unable to parse integer map value as a clock: {integerValue.MapValue}");
                 }
 
-                if (metadataCustomization.Metadata.Clocks?.Count == 1)
+                if (metadata.Clocks?.Count == 1)
                 {
-                    clockName = metadataCustomization.Metadata.Clocks[0].Name;
+                    clockName = metadata.Clocks[0].Name;
                 }
                 else
                 {
@@ -55,7 +56,7 @@ namespace CtfPlayback.FieldValues
                 }
             }
 
-            if (!metadataCustomization.Metadata.ClocksByName.TryGetValue(clockName, out var clockDescriptor))
+            if (!metadata.ClocksByName.TryGetValue(clockName, out var clockDescriptor))
             {
                 throw new CtfPlaybackException($"Unable to retrieve clock descriptor for timestamp value: {integerValue.MapValue}");
             }
@@ -77,10 +78,11 @@ namespace CtfPlayback.FieldValues
         /// Constructor
         /// </summary>
         /// <param name="metadataCustomization">Extensibility points</param>
+        /// <param name="metadata">The active metadata relevant to this timestamp</param>
         /// <param name="integerValue">Integer representation of the timestamp</param>
         /// <param name="timestampValue">Timestamp value in units specified by the ClockDescriptor</param>
-        public CtfTimestamp(ICtfMetadataCustomization metadataCustomization, CtfIntegerValue integerValue, long timestampValue)
-            : this(metadataCustomization, integerValue)
+        public CtfTimestamp(ICtfMetadataCustomization metadataCustomization, ICtfMetadata metadata, CtfIntegerValue integerValue, long timestampValue)
+            : this(metadataCustomization, metadata, integerValue)
         {
             if (timestampValue < 0)
             {

--- a/CtfPlayback/ICtfPlaybackCustomization.cs
+++ b/CtfPlayback/ICtfPlaybackCustomization.cs
@@ -30,11 +30,13 @@ namespace CtfPlayback
         /// Allows for customized parsing of a packet to determine its start and end timestamps.
         /// </summary>
         /// <param name="ctfPacket"></param>
+        /// <param name="metadata"></param>
         /// <param name="start"></param>
         /// <param name="end"></param>
         /// <returns></returns>
         bool GetTimestampsFromPacketContext(
             ICtfPacket ctfPacket,
+            ICtfMetadata metadata,
             out CtfTimestamp start,
             out CtfTimestamp end);
 
@@ -42,7 +44,7 @@ namespace CtfPlayback
         /// Allows for customized parsing of an event header data to determine a timestamp
         ///  for the event.
         /// </summary>
-        CtfTimestamp GetTimestampFromEventHeader(ICtfEvent ctfEvent, CtfTimestamp previousTimestamp);
+        CtfTimestamp GetTimestampFromEventHeader(ICtfEvent ctfEvent, ICtfMetadata metadata, CtfTimestamp previousTimestamp);
 
         /// <summary>
         /// Used to retrieve the total number of bits in a packet.
@@ -62,8 +64,9 @@ namespace CtfPlayback
         /// Reads the event at the current location from packetReader 
         /// </summary>
         /// <param name="ctfEvent">Event with its context and header filled in</param>
+        /// <param name="metadata">The metadata for the event</param>
         /// <returns></returns>
-        ICtfEventDescriptor GetEventDescriptor(ICtfEvent ctfEvent);
+        ICtfEventDescriptor GetEventDescriptor(ICtfEvent ctfEvent, ICtfMetadata metadata);
 
         /// <summary>
         /// Called during trace playback for the current event.
@@ -72,6 +75,7 @@ namespace CtfPlayback
         /// <param name="eventPacket">Packet which contains the event</param>
         /// <param name="ctfTraceInput">Trace which contains the event</param>
         /// <param name="ctfEventStream">Stream which contains the event</param>
-        void ProcessEvent(ICtfEvent ctfEvent, ICtfPacket eventPacket, ICtfTraceInput ctfTraceInput, ICtfInputStream ctfEventStream);
+        /// <param name="metadata">The metadata for the event</param>
+        void ProcessEvent(ICtfEvent ctfEvent, ICtfPacket eventPacket, ICtfTraceInput ctfTraceInput, ICtfInputStream ctfEventStream, ICtfMetadata metadata);
     }
 }

--- a/CtfPlayback/Metadata/Interfaces/ICtfEventDescriptor.cs
+++ b/CtfPlayback/Metadata/Interfaces/ICtfEventDescriptor.cs
@@ -11,6 +11,11 @@ namespace CtfPlayback.Metadata.Interfaces
     public interface ICtfEventDescriptor
     {
         /// <summary>
+        /// The id of the event
+        /// </summary>
+        public uint Id { get; }
+
+        /// <summary>
         /// Event context type
         /// </summary>
         ICtfTypeDescriptor Context { get; }

--- a/CtfPlayback/PacketReader.cs
+++ b/CtfPlayback/PacketReader.cs
@@ -323,7 +323,7 @@ namespace CtfPlayback
 
             // progress by entire bytes, we should be byte aligned at this point
             Debug.Assert(this.bitsConsumedInCurrentByte == 0);
-            while (bitsToProgress > 8)
+            while (bitsToProgress >= 8)
             {
                 if (this.bufferByteIndex + 1 >= this.bufferByteCount)
                 {

--- a/LTTngCds/CtfExtensions/TraceContext.cs
+++ b/LTTngCds/CtfExtensions/TraceContext.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using CtfPlayback.Metadata.Interfaces;
+
 namespace LTTngCds.CtfExtensions
 {
     internal class TraceContext
     {
-        internal TraceContext(LTTngMetadata metadata)
+        internal TraceContext(ICtfMetadata metadata)
         {
             if (metadata.EnvironmentDescriptor.Properties.TryGetValue("hostname", out string hostName))
             {

--- a/PerfCds/CtfExtensions/TraceContext.cs
+++ b/PerfCds/CtfExtensions/TraceContext.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using CtfPlayback.Metadata.Interfaces;
+
 namespace PerfCds.CtfExtensions
 {
     internal class TraceContext
     {
-        internal TraceContext(PerfMetadata metadata)
+        internal TraceContext(ICtfMetadata metadata)
         {
             if (metadata.EnvironmentDescriptor.Properties.TryGetValue("hostname", out string hostName))
             {


### PR DESCRIPTION
When a file is opened that has multiple traces inside, there is a race condition with how the metadata is maintained with the PlaybackMetadataCustomization and how it is reused.
This change avoids that problem by instead making sure that the objects have a copy of their metadata directly on their thread so they do not need to reference the current in the PlaybackMetadata. More full explanation below.

As part of a more robust fix, this also moves further from explicitly typed/casting of explicit types and instead uses the interfaces extensively (leaving explicit types when it provides a notable perf optimization with a fallback to the interface).

This additionally fixes a math error if the trace is a multiple of 8 bytes

Race condition:
When we open a file, we start in CtfPlayback.GeneratePlaybackStreams which creates the MetadataParser itself for the stream. As part of this, we may start a CtfStreamReadAhead which will try to parse the file on a worker thread. After reading enough packets from the current stream, we will move onto the next stream and do the same.
Since these streams exist within the same playback, we will share the PlaybackCustomization and it will make a new MetadataParser. This means that PlaybackCustomization.Metadata will change at that point (while the background threads can still be running). This means that at that point, any of the worker threads may not be able to find metadata like clocks or event ids because they are looking at a different and possibly empty metadata.