### PR TITLE
Add support for Android Logcat txt based parsing. 

### DIFF
--- a/LinuxLogParsers/LinuxLogParser/AndroidLogcat/AndroidLogcatLogParsedEntry.cs
+++ b/LinuxLogParsers/LinuxLogParser/AndroidLogcat/AndroidLogcatLogParsedEntry.cs
@@ -51,4 +51,38 @@ namespace LinuxLogParser.AndroidLogcat
         {
         }
     }
+
+    public class DurationLogEntry : AndroidLogcatLogParsedEntry
+    {
+        public Timestamp StartTimestamp;
+        public Timestamp EndTimestamp;
+        public TimestampDelta Duration;
+        public string FilePath;
+        public ulong LineNumber;
+        public uint PID;
+        public uint TID;
+        public string Priority;
+        public string Tag;
+        public string Message;
+        public string Name;
+
+        public DurationLogEntry() : base(LogParsedDataKey.GeneralLog)
+        {
+        }
+
+        public DurationLogEntry(LogEntry logEntry, Timestamp startTimestamp, TimestampDelta duration, string name) : base(LogParsedDataKey.GeneralLog)
+        {
+            StartTimestamp = startTimestamp;
+            EndTimestamp = logEntry.Timestamp;
+            Duration = duration;
+            FilePath = logEntry.FilePath;
+            LineNumber = logEntry.LineNumber;
+            PID = logEntry.PID;
+            TID = logEntry.TID;
+            Priority = logEntry.Priority;
+            Tag = logEntry.Tag;
+            Message = logEntry.Message;
+            Name = name;
+        }
+    }
 }

--- a/LinuxLogParsers/LinuxLogParser/AndroidLogcat/AndroidLogcatLogParsedEntry.cs
+++ b/LinuxLogParsers/LinuxLogParser/AndroidLogcat/AndroidLogcatLogParsedEntry.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+
+namespace LinuxLogParser.AndroidLogcat
+{
+    public enum LogParsedDataKey
+    {
+        GeneralLog
+    }
+
+    public class AndroidLogcatLogParsedEntry : IKeyedDataType<LogParsedDataKey>
+    {
+        private readonly LogParsedDataKey key;
+
+        public AndroidLogcatLogParsedEntry(LogParsedDataKey key)
+        {
+            this.key = key;
+        }
+
+        public int CompareTo(LogParsedDataKey other)
+        {
+            return key.CompareTo(other);
+        }
+
+        public LogParsedDataKey GetKey()
+        {
+            return key;
+        }
+    }
+
+    /// <summary>
+    ///  Per https://developer.android.com/studio/debug/am-logcat
+    ///  date time PID    TID    priority tag: message
+    ///  Example: "12-13 10:32:24.869    26    26 I Checkpoint: cp_prepareCheckpoint called"
+    /// </summary>
+    public class LogEntry: AndroidLogcatLogParsedEntry
+    {
+        public Timestamp Timestamp;
+        public string FilePath;
+        public ulong LineNumber;
+        public uint PID;
+        public uint TID;
+        public string Priority;
+        public string Tag;
+        public string Message;
+
+        public LogEntry(): base(LogParsedDataKey.GeneralLog)
+        {
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxLogParser/AndroidLogcat/AndroidLogcatLogParser.cs
+++ b/LinuxLogParsers/LinuxLogParser/AndroidLogcat/AndroidLogcatLogParser.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using LinuxLogParserCore;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility.SourceParsing;
+using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace LinuxLogParser.AndroidLogcat
+{
+    public class AndroidLogcatLogParser : LogParserBase<AndroidLogcatLogParsedEntry, LogParsedDataKey>
+    {
+        public override string Id => SourceParserIds.AndroidLogcatLog;
+        public override DataSourceInfo DataSourceInfo => dataSourceInfo;
+
+        private DataSourceInfo dataSourceInfo;
+
+        ///  Per https://developer.android.com/studio/debug/am-logcat
+        ///  date time PID    TID    priority tag: message
+        ///  Example: "12-13 10:32:24.869    26    26 I Checkpoint: cp_prepareCheckpoint called"
+        public static Regex AndroidLogCatRegex = new Regex(@"^(.{18})\s+(\d+)\s+(\d+)\s+(\S) (.+?)\s?: (.*)$");
+
+        public AndroidLogcatLogParser(string[] filePaths) : base(filePaths)
+        {
+        }
+
+        public override void ProcessSource(
+           ISourceDataProcessor<AndroidLogcatLogParsedEntry, LogContext, LogParsedDataKey> dataProcessor,
+           ILogger logger, IProgress<int> progress, CancellationToken cancellationToken)
+        {
+            var contentDictionary = new Dictionary<string, IReadOnlyList<LogEntry>>();
+            Timestamp oldestTimestamp = new Timestamp(long.MaxValue);
+            Timestamp newestTImestamp = new Timestamp(long.MinValue);
+            long startNanoSeconds = 0;
+            DateTime fileStartTime = default;
+            var dateTimeCultureInfo = new CultureInfo("en-US");
+
+            foreach (var path in FilePaths)
+            {
+                ulong currentLineNumber = 1;
+                var file = new System.IO.StreamReader(path);
+                string line = string.Empty;
+                var entriesList = new List<LogEntry>();
+                LogEntry lastEntry = null;
+
+                while ((line = file.ReadLine()) != null)
+                {
+                    // Optimization - don't save blank lines
+                    if (line == String.Empty)
+                    {
+                        currentLineNumber++;
+                        continue;
+                    }
+
+                    var androidLogCatMatch = AndroidLogCatRegex.Match(line);
+
+                    // First, we check if the line is a new log entry if it matched Regex and by trying to parse its timestamp
+                    if (androidLogCatMatch.Success &&
+                        androidLogCatMatch.Groups.Count >= 7 &&
+                        DateTime.TryParseExact(androidLogCatMatch.Groups[1].Value, "MM-dd HH:mm:ss.fff", dateTimeCultureInfo, DateTimeStyles.None, out DateTime parsedTime))
+                    {
+                        var timeStamp = Timestamp.FromNanoseconds(parsedTime.Ticks * 100);
+
+                        if (timeStamp < oldestTimestamp)
+                        {
+                            oldestTimestamp = timeStamp;
+                            fileStartTime = parsedTime;
+                            startNanoSeconds = oldestTimestamp.ToNanoseconds;
+                        }
+                        if (timeStamp > newestTImestamp)
+                        {
+                            newestTImestamp = timeStamp;
+                        }
+
+                        lastEntry = new LogEntry
+                        {
+                            Timestamp = new Timestamp(timeStamp.ToNanoseconds - startNanoSeconds),
+                            FilePath = path,
+                            LineNumber = currentLineNumber,
+                            PID = uint.Parse(androidLogCatMatch.Groups[2].Value),
+                            TID = uint.Parse(androidLogCatMatch.Groups[3].Value),
+                            Priority = androidLogCatMatch.Groups[4].Value,
+                            Tag = androidLogCatMatch.Groups[5].Value.Trim(),
+                            Message = androidLogCatMatch.Groups[6].Value,
+                        };
+
+                        entriesList.Add(lastEntry);
+                    }
+                    else
+                    {
+                        lastEntry = new LogEntry
+                        {
+                            Timestamp = Timestamp.MinValue,
+                            FilePath = path,
+                            LineNumber = currentLineNumber,
+                            Message = line,
+                        };
+
+                        entriesList.Add(lastEntry);
+                    }
+
+                    if (lastEntry != null)
+                    {
+                        dataProcessor.ProcessDataElement(lastEntry, Context, cancellationToken);
+                    }
+
+                    currentLineNumber++;
+                }
+
+                contentDictionary[path] = entriesList.AsReadOnly();
+
+                file.Close();
+
+                --currentLineNumber;
+                Context.UpdateFileMetadata(path, new FileMetadata(currentLineNumber));
+            }
+
+            var offsetEndTimestamp = new Timestamp(newestTImestamp.ToNanoseconds - startNanoSeconds);
+            dataSourceInfo = new DataSourceInfo(0, offsetEndTimestamp.ToNanoseconds, DateTime.FromFileTimeUtc(fileStartTime.ToFileTime()));
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxLogParser/LinuxLogParser.csproj
+++ b/LinuxLogParsers/LinuxLogParser/LinuxLogParser.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Utilities\Utilities.csproj" />
     <ProjectReference Include="..\LinuxLogParserCore\LinuxLogParserCore.csproj" />
   </ItemGroup>
 

--- a/LinuxLogParsers/LinuxLogParser/SourceParserIds.cs
+++ b/LinuxLogParsers/LinuxLogParser/SourceParserIds.cs
@@ -8,5 +8,6 @@ namespace LinuxLogParser
         public const string CloudInitLog = "CloudInitLog";
         public const string WaLinuxAgentLog = "WaLinuxAgentLog";
         public const string DmesgIsoLog = "DmesgIsoLog";
+        public const string AndroidLogcatLog = "AndroidLogcatLog";
     }
 }

--- a/LinuxLogParsers/LinuxLogParsersUnitTest/LinuxLogParsersUnitTest.cs
+++ b/LinuxLogParsers/LinuxLogParsersUnitTest/LinuxLogParsersUnitTest.cs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
+using System.Linq;
+using AndroidLogcatMPTAddin;
 using CloudInitMPTAddin;
 using DmesgIsoMPTAddin;
+using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using Microsoft.Performance.Toolkit.Engine;
@@ -23,20 +27,84 @@ namespace LinuxLogParsersUnitTest
             var dmesgDataPath = new FileInfo(dmesgData[0]);
             Assert.IsTrue(dmesgDataPath.Exists);
 
-            using (var runtime = Engine.Create(new FileDataSource(dmesgDataPath.FullName)))
+            using var runtime = Engine.Create(new FileDataSource(dmesgDataPath.FullName));
+            var cooker = new DmesgIsoDataCooker().Path;
+            runtime.EnableCooker(cooker);
+
+            var runtimeExecutionResults = runtime.Process();
+
+            var eventData = runtimeExecutionResults.QueryOutput<DmesgIsoLogParsedResult>(
+                new DataOutputPath(
+                    cooker,
+                    nameof(DmesgIsoDataCooker.ParsedResult)));
+
+            Assert.IsTrue(eventData.LogEntries.Count >= 0);
+        }
+
+        [TestMethod]
+        public void AndroidLogcat()
+        {
+            // Some other examples focusing on RegEx
+            var trickySamples = new string[] 
             {
-                var cooker = new DmesgIsoDataCooker().Path;
-                runtime.EnableCooker(cooker);
+                "12-13 10:32:21.278     0     0 I         : Linux version 5.10.43-2-windows-subsystem-for-android (oe-user@oe-host) (clang version 10.0.1 (https://github.com/llvm/llvm-project ef32c611aa214dea855364efd7ba451ec5ec3f74), GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP PREEMPT Tue Sep 14 09:09:25 UTC 2021",
+               @"12-13 10:32:21.278     0     0 I Command line: initrd=\initrd.img panic=-1 nr_cpus=8 earlycon=uart8250,io,0x3f8,115200 console=hvc0 debug pty.legacy_count=0 androidboot.hardware=windows_x86_64 panic=-1 pty.legacy_count=0 androidboot.veritymode=enforcing androidboot.verifiedbootstate=green loglevel=6 transparent_hugepage=never swiotlb=noforce  androidboot.hardware.egl=emulation androidboot.hardware.gralloc=emulation",
+                "12-13 10:32:21.278     0     0 I x86/fpu : Supporting XSAVE feature 0x001: 'x87 floating point registers'",
+                "12-13 10:32:25.709    86    86 E APM::AudioPolicyEngine/Config: parseLegacyVolumeFile: Could not parse document /odm/etc/audio_policy_configuration.xml",
+                "12-13 10:32:21.278     0     0 I BIOS-e820: [mem 0x0000000000000000-0x000000000009ffff] usable",
+                "12-13 10:32:21.317     0     0 I IOAPIC[0]: apic_id 8, version 17, address 0xfec00000, GSI 0-23",
+                "12-13 10:32:21.328     0     0 I         : Built 1 zonelists, mobility grouping on.  Total pages: 1547406"
+            };
 
-                var runtimeExecutionResults = runtime.Process();
+            foreach (var s in trickySamples)
+            {
+                var m = LinuxLogParser.AndroidLogcat.AndroidLogcatLogParser.AndroidLogCatRegex.Match(s);
+                if (!m.Success)
+                {
+                    Console.WriteLine(s);
+                }
 
-                var eventData = runtimeExecutionResults.QueryOutput<DmesgIsoLogParsedResult>(
-                    new DataOutputPath(
-                        cooker,
-                        nameof(DmesgIsoDataCooker.ParsedResult)));
-
-                Assert.IsTrue(eventData.LogEntries.Count >= 0);
+                Assert.IsTrue(m.Success);
             }
+
+            // Input data from log
+            string[] androidlogcatData = { @"..\..\..\..\..\TestData\AndroidLogs\Logcat\AndroidLogcatWSA.log" };
+            var androidlogcatDataPath = new FileInfo(androidlogcatData[0]);
+            Assert.IsTrue(androidlogcatDataPath.Exists);
+
+            using var runtime = Engine.Create(new FileDataSource(androidlogcatDataPath.FullName));
+            var cooker = new AndroidLogcatDataCooker().Path;
+            runtime.EnableCooker(cooker);
+
+            var runtimeExecutionResults = runtime.Process();
+
+            var eventData = runtimeExecutionResults.QueryOutput<AndroidLogcatParsedResult>(
+                new DataOutputPath(
+                    cooker,
+                    nameof(AndroidLogcatDataCooker.ParsedResult)));
+
+            Assert.IsTrue(eventData.LogEntries.Count >= 0);
+            Assert.IsTrue(eventData.LogEntries.Count == 6061);
+            var noTimestampOrNotParsed = eventData.LogEntries.Where(f => f.Timestamp.ToNanoseconds < 0);
+            Assert.IsTrue(noTimestampOrNotParsed.Count() == 5); // There is 6 entries with no timestamp e.g "--------- beginning of "
+
+            //eventData.LogEntries[1].Timestamp == // Check abs time if/when SDK supports it
+            Assert.IsTrue(eventData.LogEntries[1].LineNumber == 3);
+            Assert.IsTrue(eventData.LogEntries[1].Timestamp == Timestamp.Zero);
+            Assert.IsTrue(eventData.LogEntries[1].PID == 20);
+            Assert.IsTrue(eventData.LogEntries[1].TID == 20);
+            Assert.IsTrue(eventData.LogEntries[1].Priority == "I");
+            Assert.IsTrue(eventData.LogEntries[1].Tag == "auditd");
+            Assert.IsTrue(eventData.LogEntries[1].Message == "type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1");
+
+            //eventData.LogEntries[6].Timestamp == // Check abs time if/when SDK supports it
+            Assert.IsTrue(eventData.LogEntries[6].LineNumber == 13);
+            Assert.IsTrue(eventData.LogEntries[6].Timestamp == new Timestamp(1248000000)); // 1,248,000,000 ns past 1st event
+            Assert.IsTrue(eventData.LogEntries[6].PID == 0);
+            Assert.IsTrue(eventData.LogEntries[6].TID == 0);
+            Assert.IsTrue(eventData.LogEntries[6].Priority == "I");
+            Assert.IsTrue(eventData.LogEntries[6].Tag == "Command line");
+            Assert.IsTrue(!String.IsNullOrWhiteSpace(eventData.LogEntries[6].Message));
         }
 
         [TestMethod]
@@ -47,20 +115,18 @@ namespace LinuxLogParsersUnitTest
             var cloutInitDataPath = new FileInfo(cloudInitData[0]);
             Assert.IsTrue(cloutInitDataPath.Exists);
 
-            using (var runtime = Engine.Create(new FileDataSource(cloutInitDataPath.FullName)))
-            {
-                var cooker = new CloudInitDataCooker().Path;
-                runtime.EnableCooker(cooker);
+            using var runtime = Engine.Create(new FileDataSource(cloutInitDataPath.FullName));
+            var cooker = new CloudInitDataCooker().Path;
+            runtime.EnableCooker(cooker);
 
-                var runtimeExecutionResults = runtime.Process();
+            var runtimeExecutionResults = runtime.Process();
 
-                var eventData = runtimeExecutionResults.QueryOutput<CloudInitLogParsedResult>(
-                    new DataOutputPath(
-                        cooker,
-                        nameof(CloudInitDataCooker.ParsedResult)));
+            var eventData = runtimeExecutionResults.QueryOutput<CloudInitLogParsedResult>(
+                new DataOutputPath(
+                    cooker,
+                    nameof(CloudInitDataCooker.ParsedResult)));
 
-                Assert.IsTrue(eventData.LogEntries.Count >= 0);
-            }
+            Assert.IsTrue(eventData.LogEntries.Count >= 0);
         }
 
         [TestMethod]
@@ -71,20 +137,18 @@ namespace LinuxLogParsersUnitTest
             var waLinuxAgentDataPath = new FileInfo(waLinuxAgentData[0]);
             Assert.IsTrue(waLinuxAgentDataPath.Exists);
 
-            using (var runtime = Engine.Create(new FileDataSource(waLinuxAgentDataPath.FullName)))
-            {
-                var cooker = new WaLinuxAgentDataCooker().Path;
-                runtime.EnableCooker(cooker);
+            using var runtime = Engine.Create(new FileDataSource(waLinuxAgentDataPath.FullName));
+            var cooker = new WaLinuxAgentDataCooker().Path;
+            runtime.EnableCooker(cooker);
 
-                var runtimeExecutionResults = runtime.Process();
+            var runtimeExecutionResults = runtime.Process();
 
-                var eventData = runtimeExecutionResults.QueryOutput<WaLinuxAgentLogParsedResult>(
-                    new DataOutputPath(
-                        cooker,
-                        nameof(WaLinuxAgentDataCooker.ParsedResult)));
+            var eventData = runtimeExecutionResults.QueryOutput<WaLinuxAgentLogParsedResult>(
+                new DataOutputPath(
+                    cooker,
+                    nameof(WaLinuxAgentDataCooker.ParsedResult)));
 
-                Assert.IsTrue(eventData.LogEntries.Count >= 0);
-            }
+            Assert.IsTrue(eventData.LogEntries.Count >= 0);
         }
     }
 }

--- a/LinuxLogParsers/LinuxLogParsersUnitTest/LinuxLogParsersUnitTest.cs
+++ b/LinuxLogParsers/LinuxLogParsersUnitTest/LinuxLogParsersUnitTest.cs
@@ -38,7 +38,7 @@ namespace LinuxLogParsersUnitTest
                     cooker,
                     nameof(DmesgIsoDataCooker.ParsedResult)));
 
-            Assert.IsTrue(eventData.LogEntries.Count >= 0);
+            Assert.IsTrue(eventData.LogEntries.Count == 1867);
         }
 
         [TestMethod]
@@ -83,10 +83,10 @@ namespace LinuxLogParsersUnitTest
                     cooker,
                     nameof(AndroidLogcatDataCooker.ParsedResult)));
 
-            Assert.IsTrue(eventData.LogEntries.Count >= 0);
+            Assert.IsTrue(eventData.LogEntries.Count > 0);
             Assert.IsTrue(eventData.LogEntries.Count == 6061);
             var noTimestampOrNotParsed = eventData.LogEntries.Where(f => f.Timestamp.ToNanoseconds < 0);
-            Assert.IsTrue(noTimestampOrNotParsed.Count() == 5); // There is 6 entries with no timestamp e.g "--------- beginning of "
+            Assert.IsTrue(noTimestampOrNotParsed.Count() == 5); // There is 5 entries with no timestamp e.g "--------- beginning of "
 
             //eventData.LogEntries[1].Timestamp == // Check abs time if/when SDK supports it
             Assert.IsTrue(eventData.LogEntries[1].LineNumber == 3);
@@ -105,6 +105,23 @@ namespace LinuxLogParsersUnitTest
             Assert.IsTrue(eventData.LogEntries[6].Priority == "I");
             Assert.IsTrue(eventData.LogEntries[6].Tag == "Command line");
             Assert.IsTrue(!String.IsNullOrWhiteSpace(eventData.LogEntries[6].Message));
+
+            Assert.IsTrue(eventData.DurationLogEntries.Count > 0);
+            // Service 'exec 1 (/system/bin/linkerconfig --target /linkerconfig/bootstrap)' (pid 4) exited with status 0 waiting took 0.015000 seconds
+            Assert.IsTrue(eventData.DurationLogEntries[0].Name == "exec 1 (/system/bin/linkerconfig --target /linkerconfig/bootstrap)");
+            Assert.IsTrue(eventData.DurationLogEntries[0].Duration.ToMilliseconds == 15);
+
+            // Service 'apexd-bootstrap' (pid 6) exited with status 0 waiting took 0.053000 seconds
+            Assert.IsTrue(eventData.DurationLogEntries[1].Name == "apexd-bootstrap");
+            Assert.IsTrue(eventData.DurationLogEntries[1].Duration.ToMilliseconds == 53);
+            Assert.IsTrue((eventData.DurationLogEntries[1].EndTimestamp - eventData.DurationLogEntries[1].StartTimestamp).ToMilliseconds == 53);
+
+            Assert.IsTrue(eventData.DurationLogEntries.Count == 1011);
+
+            // MakeWindowManagerServiceReady took to complete: 3ms
+            Assert.IsTrue(eventData.DurationLogEntries[443].Name == "MakeWindowManagerServiceReady");
+            Assert.IsTrue(eventData.DurationLogEntries[443].Duration.ToMilliseconds == 3);
+            Assert.IsTrue((eventData.DurationLogEntries[443].EndTimestamp - eventData.DurationLogEntries[443].StartTimestamp).ToMilliseconds == 3);
         }
 
         [TestMethod]
@@ -126,7 +143,7 @@ namespace LinuxLogParsersUnitTest
                     cooker,
                     nameof(CloudInitDataCooker.ParsedResult)));
 
-            Assert.IsTrue(eventData.LogEntries.Count >= 0);
+            Assert.IsTrue(eventData.LogEntries.Count == 937);
         }
 
         [TestMethod]
@@ -148,7 +165,7 @@ namespace LinuxLogParsersUnitTest
                     cooker,
                     nameof(WaLinuxAgentDataCooker.ParsedResult)));
 
-            Assert.IsTrue(eventData.LogEntries.Count >= 0);
+            Assert.IsTrue(eventData.LogEntries.Count == 773); // Should be 795 - bug?
         }
     }
 }

--- a/LinuxLogParsers/LinuxLogParsersUnitTest/LinuxLogParsersUnitTest.csproj
+++ b/LinuxLogParsers/LinuxLogParsersUnitTest/LinuxLogParsersUnitTest.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\UnitTestCommon\UnitTestCommon.csproj" />
+    <ProjectReference Include="..\LinuxPlugins-MicrosoftPerformanceToolkSDK\AndroidLogCat\AndroidLogcat.csproj" />
     <ProjectReference Include="..\LinuxPlugins-MicrosoftPerformanceToolkSDK\Cloud-init\Cloud-Init.csproj" />
     <ProjectReference Include="..\LinuxPlugins-MicrosoftPerformanceToolkSDK\DmesgIsoLog\Dmesg.csproj" />
     <ProjectReference Include="..\LinuxPlugins-MicrosoftPerformanceToolkSDK\WaLinuxAgent\WaLinuxAgent.csproj" />

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcat.csproj
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcat.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+	  <Version>1.2</Version>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RootNamespace>Android Logcat</RootNamespace>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft Corp.</Company>
+    <Product>Performance ToolKit</Product>
+    <Description>Contains the datasource plugin to parse Android Logcat log files.</Description>
+    <PackageId>Microsoft.Performance.Toolkit.Plugins.Android LogcatPlugin</PackageId>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <RepositoryUrl>https://github.com/microsoft/Microsoft-Performance-Tools-Linux-Android</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Microsoft-Performance-Tools-Linux-Android</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.9-rc1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\LinuxLogParser\LinuxLogParser.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatCustomDataProcessor.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatCustomDataProcessor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using LinuxLogParser.AndroidLogcat;
+using LinuxLogParserCore;
+using Microsoft.Performance.SDK.Extensibility.SourceParsing;
+using Microsoft.Performance.SDK.Processing;
+
+namespace AndroidLogcatMPTAddin
+{
+    public sealed class AndroidLogcatCustomDataProcessor
+         : CustomDataProcessorWithSourceParser<AndroidLogcatLogParsedEntry, LogContext, LogParsedDataKey>
+    {
+        public AndroidLogcatCustomDataProcessor(
+            ISourceParser<AndroidLogcatLogParsedEntry, LogContext, LogParsedDataKey> sourceParser,
+            ProcessorOptions options,
+            IApplicationEnvironment applicationEnvironment,
+            IProcessorEnvironment processorEnvironment)
+            : base(sourceParser, options, applicationEnvironment, processorEnvironment)
+        {
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatDataCooker.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatDataCooker.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using LinuxLogParser;
+using LinuxLogParser.AndroidLogcat;
+using LinuxLogParserCore;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace AndroidLogcatMPTAddin
+{
+    public class AndroidLogcatDataCooker :
+        CookedDataReflector,
+        ISourceDataCooker<AndroidLogcatLogParsedEntry, LogContext, LogParsedDataKey>
+    {
+        public const string CookerId = "AndroidLogcatCooker";
+
+        public ReadOnlyHashSet<LogParsedDataKey> DataKeys => new ReadOnlyHashSet<LogParsedDataKey>(
+            new HashSet<LogParsedDataKey>(
+                new[] {
+                    LogParsedDataKey.GeneralLog
+                }
+            )
+        );
+
+        public SourceDataCookerOptions Options => SourceDataCookerOptions.None;
+
+        public string Description => "Parsed information of Android logcat log.";
+
+        public string SourceParserId => Path.SourceParserId;
+
+        public DataCookerPath Path { get; }
+
+        public IReadOnlyDictionary<DataCookerPath, DataCookerDependencyType> DependencyTypes =>
+            new Dictionary<DataCookerPath, DataCookerDependencyType>();
+
+        public IReadOnlyCollection<DataCookerPath> RequiredDataCookers => new HashSet<DataCookerPath>();
+
+        public DataProductionStrategy DataProductionStrategy => DataProductionStrategy.PostSourceParsing;
+
+        [DataOutput]
+        public AndroidLogcatParsedResult ParsedResult { get; private set; }
+
+        private List<LogEntry> logEntries;
+        private LogContext context;
+
+        public AndroidLogcatDataCooker() : this(DataCookerPath.ForSource(SourceParserIds.AndroidLogcatLog, CookerId))
+        {
+        }
+
+        private AndroidLogcatDataCooker(DataCookerPath dataCookerPath) : base(dataCookerPath)
+        {
+            Path = dataCookerPath;
+        }
+
+        public void BeginDataCooking(ICookedDataRetrieval dependencyRetrieval, CancellationToken cancellationToken)
+        {
+            logEntries = new List<LogEntry>();
+        }
+
+        public DataProcessingResult CookDataElement(AndroidLogcatLogParsedEntry data, LogContext context,
+            CancellationToken cancellationToken)
+        {
+            DataProcessingResult result = DataProcessingResult.Processed;
+
+            if (data is LogEntry logEntry)
+            {
+                logEntries.Add(logEntry);
+                this.context = context;
+            }
+            else
+            {
+                result = DataProcessingResult.Ignored;
+            }
+
+            return result;
+        }
+
+        public void EndDataCooking(CancellationToken cancellationToken)
+        {
+            ParsedResult = new AndroidLogcatParsedResult(logEntries, context.FileToMetadata);
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatDataCooker.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatDataCooker.cs
@@ -46,6 +46,7 @@ namespace AndroidLogcatMPTAddin
         public AndroidLogcatParsedResult ParsedResult { get; private set; }
 
         private List<LogEntry> logEntries;
+        private List<DurationLogEntry> durationLogEntries;
         private LogContext context;
 
         public AndroidLogcatDataCooker() : this(DataCookerPath.ForSource(SourceParserIds.AndroidLogcatLog, CookerId))
@@ -60,6 +61,7 @@ namespace AndroidLogcatMPTAddin
         public void BeginDataCooking(ICookedDataRetrieval dependencyRetrieval, CancellationToken cancellationToken)
         {
             logEntries = new List<LogEntry>();
+            durationLogEntries = new List<DurationLogEntry>();
         }
 
         public DataProcessingResult CookDataElement(AndroidLogcatLogParsedEntry data, LogContext context,
@@ -72,6 +74,11 @@ namespace AndroidLogcatMPTAddin
                 logEntries.Add(logEntry);
                 this.context = context;
             }
+            else if (data is DurationLogEntry durationLogEntry)
+            {
+                durationLogEntries.Add(durationLogEntry);
+                this.context = context;
+            }
             else
             {
                 result = DataProcessingResult.Ignored;
@@ -82,7 +89,7 @@ namespace AndroidLogcatMPTAddin
 
         public void EndDataCooking(CancellationToken cancellationToken)
         {
-            ParsedResult = new AndroidLogcatParsedResult(logEntries, context.FileToMetadata);
+            ParsedResult = new AndroidLogcatParsedResult(logEntries, durationLogEntries, context.FileToMetadata);
         }
     }
 }

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatDataSource.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatDataSource.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using LinuxLogParser.AndroidLogcat;
+using Microsoft.Performance.SDK.Processing;
+
+namespace AndroidLogcatMPTAddin
+{
+    [ProcessingSource(
+    "{DC6FAB5D-D839-4745-8F6C-5BF6941E0DB4}",
+    "Android Logcat (Txt)",
+    "A data source to parse logcat events in a text file")]
+    [FileDataSource(
+    "log",
+    "Log files")]
+    public class AndroidLogcatDataSource : ProcessingSource
+    {
+        private IApplicationEnvironment applicationEnvironment;
+
+        protected override ICustomDataProcessor CreateProcessorCore(IEnumerable<IDataSource> dataSources, IProcessorEnvironment processorEnvironment, ProcessorOptions options)
+        {
+            string[] filePaths = dataSources.Select(x => x.Uri.LocalPath).ToArray();
+            var sourceParser = new AndroidLogcatLogParser(filePaths);
+
+            return new AndroidLogcatCustomDataProcessor(
+                sourceParser,
+                options,
+                this.applicationEnvironment,
+                processorEnvironment);
+        }
+
+        protected override bool IsDataSourceSupportedCore(IDataSource dataSource)
+        {
+            return dataSource.IsFile() && 
+                   (Path.GetExtension(dataSource.Uri.LocalPath) == ".log");
+        }
+
+        protected override void SetApplicationEnvironmentCore(IApplicationEnvironment applicationEnvironment)
+        {
+            this.applicationEnvironment = applicationEnvironment;
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatParsedResult.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatParsedResult.cs
@@ -10,11 +10,13 @@ namespace AndroidLogcatMPTAddin
     public class AndroidLogcatParsedResult
     {
         public List<LogEntry> LogEntries { get; }
+        public List<DurationLogEntry> DurationLogEntries;
         public IReadOnlyDictionary<string, FileMetadata> FileToMetadata { get; }
 
-        public AndroidLogcatParsedResult(List<LogEntry> logEntries, Dictionary<string, FileMetadata> fileToMetadata)
+        public AndroidLogcatParsedResult(List<LogEntry> logEntries, List<DurationLogEntry> durationLogEntries, Dictionary<string, FileMetadata> fileToMetadata)
         {
             LogEntries = logEntries;
+            DurationLogEntries = durationLogEntries;
             FileToMetadata = fileToMetadata;
         }
     }

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatParsedResult.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcatParsedResult.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using LinuxLogParser.AndroidLogcat;
+using LinuxLogParserCore;
+using System.Collections.Generic;
+
+namespace AndroidLogcatMPTAddin
+{
+    public class AndroidLogcatParsedResult
+    {
+        public List<LogEntry> LogEntries { get; }
+        public IReadOnlyDictionary<string, FileMetadata> FileToMetadata { get; }
+
+        public AndroidLogcatParsedResult(List<LogEntry> logEntries, Dictionary<string, FileMetadata> fileToMetadata)
+        {
+            LogEntries = logEntries;
+            FileToMetadata = fileToMetadata;
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/DurationTable.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/DurationTable.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using LinuxLogParser;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+
+namespace AndroidLogcatMPTAddin.Tables
+{
+    [Table]
+    public static class DurationTable
+    {
+        public static readonly TableDescriptor TableDescriptor = new TableDescriptor(
+            Guid.Parse("{9C29BFFE-2678-4C84-A9B5-19313C5EB4F9}"),
+            "Android Logcat Durations",
+            "Android Logcat Durations",
+            category: "Android",
+            requiredDataCookers: new List<DataCookerPath> {
+                DataCookerPath.ForSource(SourceParserIds.AndroidLogcatLog, AndroidLogcatDataCooker.CookerId)
+            });
+
+        private static readonly ColumnConfiguration FileNameColumn = new ColumnConfiguration(
+           new ColumnMetadata(new Guid("{E550F06E-523C-47FA-BB19-1929D9F42754}"), "FileName", "File Name"),
+           new UIHints { Width = 80 });
+
+        private static readonly ColumnConfiguration NameColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{DF14D97F-866E-4DEC-8ECA-88DEB60CFFDF}"), "Name", "Name of the duration"),
+            new UIHints { Width = 80, });
+
+        private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{83DDA2B5-FB97-4BD1-B139-B42321B47AA1}"), "Start Timestamp", "Timestamp when the duration started."),
+            new UIHints { Width = 80 });
+
+        private static readonly ColumnConfiguration StartTimestampColumnSorted = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{83DDA2B5-FB97-4BD1-B139-B42321B47AA1}"), "Start Timestamp", "Timestamp when the duration started."),
+            new UIHints { Width = 80, SortOrder = SortOrder.Ascending, SortPriority = 0 });
+
+        private static readonly ColumnConfiguration EndTimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{FDEAAF97-F0C0-4567-AA45-6574D10D3523}"), "End Timestamp", "Timestamp when the duration ended"),
+            new UIHints { Width = 80, });
+
+        private static readonly ColumnConfiguration DurationColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{3894B186-D168-4E46-B0B5-0091BD5807A1}"), "Duration", "Duration of the event"),
+            new UIHints { Width = 80, CellFormat = "ms" });
+
+        private static readonly ColumnConfiguration DurationColumnOrderedMax = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{3894B186-D168-4E46-B0B5-0091BD5807A1}"), "Duration", "Duration of the event"),
+            new UIHints 
+            {
+                SortOrder = SortOrder.Descending,
+                SortPriority = 0,
+                Width = 80, 
+                CellFormat = TimestampFormatter.FormatMillisecondsGrouped, 
+                AggregationMode = AggregationMode.Max 
+            });
+
+        private static readonly ColumnConfiguration LineNumberColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{EDBD9BAF-0BD8-43D7-9752-BFCEF3FCBC13}"), "Line Number", "Ordering of the lines in the file"),
+            new UIHints { Width = 80 });
+
+        private static readonly ColumnConfiguration PIDColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{F75CD977-60C7-4CC3-9AB4-94ED44FFDC21}"), "PID", "The process ID that produced the message."),
+            new UIHints { Width = 40, });
+
+        private static readonly ColumnConfiguration TIDColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{8BBD6094-9772-4790-B4B8-C5EAAA6D67E1}"), "TID", "The thread ID that produced the message."),
+            new UIHints { Width = 40, });
+
+        private static readonly ColumnConfiguration PriorityColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{3FD930DE-AFC1-4C62-832F-C7AEE8081162}"), "Priority", "The priority of the message (V)erbose (D)ebug (I)nfo (W)arning (E)rror (A)ssert"),
+            new UIHints { Width = 20, });
+
+        private static readonly ColumnConfiguration TagColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{F541B9A7-EEDD-42AC-B3AB-F353E93169EB}"), "Tag", "Indicates which system component logged the message"),
+            new UIHints { Width = 120, });
+
+        private static readonly ColumnConfiguration MessageColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{43D28B83-AE40-4989-8E32-8837B0BB10D7}"), "Message", "Logged message."),
+            new UIHints { Width = 600, });
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            var parsedResult = tableData.QueryOutput<AndroidLogcatParsedResult>(
+               DataOutputPath.ForSource(SourceParserIds.AndroidLogcatLog, AndroidLogcatDataCooker.CookerId, nameof(AndroidLogcatDataCooker.ParsedResult)));
+
+            var durationEntries = parsedResult.DurationLogEntries;
+
+            var baseProjection = Projection.Index(durationEntries);
+
+            var nameProjection = baseProjection.Compose(x => x.Name);
+            var startTimestampProjection = baseProjection.Compose(x => x.StartTimestamp);
+            var endTimestampProjection = baseProjection.Compose(x => x.EndTimestamp);
+            var durationProjection = baseProjection.Compose(x => x.Duration);
+            var fileNameProjection = baseProjection.Compose(x => x.FilePath);
+            var lineNumberProjection = baseProjection.Compose(x => x.LineNumber);
+            var pidProjection = baseProjection.Compose(x => x.PID);
+            var tidProjection = baseProjection.Compose(x => x.TID);
+            var priorityProjection = baseProjection.Compose(x => x.Priority);
+            var tagProjection = baseProjection.Compose(x => x.Tag);
+            var messageProjection = baseProjection.Compose(x => x.Message);
+
+            var timeOrderConfig = new TableConfiguration("Time Order")
+            {
+                Columns = new[]
+                {
+                    FileNameColumn,
+                    NameColumn,
+                    TableConfiguration.PivotColumn,
+                    LineNumberColumn,
+                    PIDColumn,
+                    TIDColumn,
+                    PriorityColumn,
+                    TagColumn,
+                    MessageColumn,
+                    DurationColumn,
+                    TableConfiguration.GraphColumn,
+                    StartTimestampColumnSorted,
+                    EndTimestampColumn
+                },
+            };
+
+            timeOrderConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumnSorted);
+            timeOrderConfig.AddColumnRole(ColumnRole.EndTime, EndTimestampColumn);
+            timeOrderConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            var longestDurationConfig = new TableConfiguration("Longest Duration")
+            {
+                Columns = new[]
+                {
+                    FileNameColumn,
+                    TagColumn,
+                    NameColumn,
+                    TableConfiguration.PivotColumn,
+                    LineNumberColumn,
+                    PIDColumn,
+                    TIDColumn,
+                    PriorityColumn,
+                    MessageColumn,
+                    DurationColumnOrderedMax,
+                    TableConfiguration.GraphColumn,
+                    StartTimestampColumnSorted,
+                    EndTimestampColumn
+                },
+            };
+
+            longestDurationConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumnSorted);
+            longestDurationConfig.AddColumnRole(ColumnRole.EndTime, EndTimestampColumn);
+            longestDurationConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            tableBuilder.AddTableConfiguration(timeOrderConfig)
+                .AddTableConfiguration(longestDurationConfig)
+                .SetDefaultTableConfiguration(timeOrderConfig)
+                .SetRowCount(durationEntries.Count)
+                .AddColumn(NameColumn, nameProjection)
+                .AddColumn(FileNameColumn, fileNameProjection)
+                .AddColumn(LineNumberColumn, lineNumberProjection)
+                .AddColumn(PIDColumn, pidProjection)
+                .AddColumn(TIDColumn, pidProjection)
+                .AddColumn(PriorityColumn, priorityProjection)
+                .AddColumn(MessageColumn, messageProjection)
+                .AddColumn(DurationColumn, durationProjection)
+                .AddColumn(StartTimestampColumnSorted, startTimestampProjection)
+                .AddColumn(EndTimestampColumn, endTimestampProjection)
+                .AddColumn(TagColumn, tagProjection);
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/LogTable.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/LogTable.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using LinuxLogParser;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+
+namespace AndroidLogcatMPTAddin.Tables
+{
+    [Table]
+    public static class ParsedTable
+    {
+        public static readonly TableDescriptor TableDescriptor = new TableDescriptor(
+            Guid.Parse("{C2035282-4E3F-4436-821B-46C98D383A56}"),
+            "Android Logcat",
+            "Android Logcat Parsed Log",
+            category: "Android",
+            requiredDataCookers: new List<DataCookerPath> {
+                DataCookerPath.ForSource(SourceParserIds.AndroidLogcatLog, AndroidLogcatDataCooker.CookerId)
+            });
+
+        private static readonly ColumnConfiguration FileNameColumn = new ColumnConfiguration(
+           new ColumnMetadata(new Guid("{E550F06E-523C-47FA-BB19-1929D9F42754}"), "FileName", "File Name"),
+           new UIHints { Width = 80 });
+
+        private static readonly ColumnConfiguration TimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{B5896C69-020C-40A0-9BDC-C34A19011C28}"), "Timestamp", "Timestamp when the message was created."),
+            new UIHints { Width = 80, });
+
+        // todo: needs to be changed by user manually to DateTime UTC format. SDK doesn't yet support specifying this <DateTimeTimestampOptionsParameter DateTimeEnabled="true" />
+        private static readonly ColumnConfiguration TimestampAbsColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{B5896C69-020C-40A0-9BDC-C34A19011C28}"), "Timestamp", "Timestamp when the message was created."),
+            new UIHints { Width = 80, });
+
+        private static readonly ColumnConfiguration LineNumberColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{EDBD9BAF-0BD8-43D7-9752-BFCEF3FCBC13}"), "Line Number", "Ordering of the lines in the file"),
+            new UIHints { Width = 80, SortOrder = SortOrder.Ascending, SortPriority = 0 });
+
+        private static readonly ColumnConfiguration PIDColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{F75CD977-60C7-4CC3-9AB4-94ED44FFDC21}"), "PID", "The process ID that produced the message."),
+            new UIHints { Width = 40, });
+
+        private static readonly ColumnConfiguration TIDColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{8BBD6094-9772-4790-B4B8-C5EAAA6D67E1}"), "TID", "The thread ID that produced the message."),
+            new UIHints { Width = 40, });
+
+        private static readonly ColumnConfiguration PriorityColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{3FD930DE-AFC1-4C62-832F-C7AEE8081162}"), "Priority", "The priority of the message (V)erbose (D)ebug (I)nfo (W)arning (E)rror (A)ssert"),
+            new UIHints { Width = 20, });
+
+        private static readonly ColumnConfiguration TagColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{F541B9A7-EEDD-42AC-B3AB-F353E93169EB}"), "Tag", "Indicates which system component logged the message"),
+            new UIHints { Width = 120, });
+
+        private static readonly ColumnConfiguration MessageColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{43D28B83-AE40-4989-8E32-8837B0BB10D7}"), "Message", "Logged message."),
+            new UIHints { Width = 600, });
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            var parsedResult = tableData.QueryOutput<AndroidLogcatParsedResult>(
+               DataOutputPath.ForSource(SourceParserIds.AndroidLogcatLog, AndroidLogcatDataCooker.CookerId, nameof(AndroidLogcatDataCooker.ParsedResult)));
+            var logEntries = parsedResult.LogEntries;
+
+            var baseProjection = Projection.Index(logEntries);
+
+            var timestampProjection = baseProjection.Compose(x => x.Timestamp);
+            var fileNameProjection = baseProjection.Compose(x => x.FilePath);
+            var lineNumberProjection = baseProjection.Compose(x => x.LineNumber);
+            var pidProjection = baseProjection.Compose(x => x.PID);
+            var tidProjection = baseProjection.Compose(x => x.TID);
+            var priorityProjection = baseProjection.Compose(x => x.Priority);
+            var tagProjection = baseProjection.Compose(x => x.Tag);
+            var messageProjection = baseProjection.Compose(x => x.Message);
+
+            var config = new TableConfiguration("Default")
+            {
+                Columns = new[]
+                {
+                    FileNameColumn,
+                    TableConfiguration.PivotColumn,
+                    LineNumberColumn,
+                    TimestampAbsColumn,
+                    PIDColumn,
+                    TIDColumn,
+                    PriorityColumn,
+                    TagColumn,
+                    MessageColumn,
+                    TableConfiguration.GraphColumn,
+                    TimestampColumn
+                },
+            };
+
+            config.AddColumnRole(ColumnRole.StartTime, TimestampColumn);
+
+            tableBuilder.AddTableConfiguration(config)
+                .SetDefaultTableConfiguration(config)
+                .SetRowCount(logEntries.Count)
+                .AddColumn(FileNameColumn, fileNameProjection)
+                .AddColumn(LineNumberColumn, lineNumberProjection)
+                .AddColumn(PIDColumn, pidProjection)
+                .AddColumn(TIDColumn, pidProjection)
+                .AddColumn(PriorityColumn, priorityProjection)
+                .AddColumn(MessageColumn, messageProjection)
+                .AddColumn(TimestampColumn, timestampProjection)
+                .AddColumn(TagColumn, tagProjection);
+        }
+    }
+}

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/LogTable.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/LogTable.cs
@@ -10,7 +10,7 @@ using Microsoft.Performance.SDK.Processing;
 namespace AndroidLogcatMPTAddin.Tables
 {
     [Table]
-    public static class ParsedTable
+    public static class LogTable
     {
         public static readonly TableDescriptor TableDescriptor = new TableDescriptor(
             Guid.Parse("{C2035282-4E3F-4436-821B-46C98D383A56}"),

--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/Metadata/FileStatsMetadataTable.cs
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/Tables/Metadata/FileStatsMetadataTable.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LinuxLogParser;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+
+namespace AndroidLogcatMPTAddin.Tables.Metadata
+{
+    [Table]
+    public sealed class FileStatsMetadataTable
+    {
+        public static readonly TableDescriptor TableDescriptor = new TableDescriptor(
+            Guid.Parse("{8D9DA96E-07D9-4C13-9F38-C1A2F4E70578}"),
+            "File Stats",
+            "Statistics for Android logcat .log files",
+            isMetadataTable: true,
+            requiredDataCookers: new List<DataCookerPath> {
+                DataCookerPath.ForSource(SourceParserIds.AndroidLogcatLog, AndroidLogcatDataCooker.CookerId)
+            });
+
+        private static readonly ColumnConfiguration FileNameColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{3DF95CE9-1BB4-428E-AF75-E8D53526ABA7}"), "File Name", "The name of the file."),
+            new UIHints { Width = 80, });
+
+        private static readonly ColumnConfiguration LineCountColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{5D78C14B-2CEF-4C1F-9D3B-FC713992D3C6}"), "Line Count", "The number of lines in the file."),
+            new UIHints { Width = 80, });
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            var parsedResult = tableData.QueryOutput<AndroidLogcatParsedResult>(
+                DataOutputPath.ForSource(SourceParserIds.AndroidLogcatLog, AndroidLogcatDataCooker.CookerId, nameof(AndroidLogcatDataCooker.ParsedResult)));
+            var fileNames = parsedResult.FileToMetadata.Keys.ToArray();
+            var fileNameProjection = Projection.Index(fileNames.AsReadOnly());
+
+            var lineCountProjection = fileNameProjection.Compose(
+                fileName => parsedResult.FileToMetadata[fileName].LineCount);
+
+            tableBuilder.SetRowCount(fileNames.Length)
+                .AddColumn(FileNameColumn, fileNameProjection)
+                .AddColumn(LineCountColumn, lineCountProjection);
+        }
+    }
+}

--- a/LinuxTraceLogCapture.md
+++ b/LinuxTraceLogCapture.md
@@ -16,6 +16,8 @@ Logs:
   - LogLevel can be turned more verbose in custom image
   - /etc/waagent.conf
   - Logs.Verbose=y
+- [AndroidLogcat](https://developer.android.com/studio/command-line/logcat)
+  - Default format should be supported
 
 # LTTng
 [LTTng](https://lttng.org) (Kernel CPU scheduling, Processes, Threads, Block IO/Disk, Syscalls, File events, etc)

--- a/LinuxTraceLogCapture.md
+++ b/LinuxTraceLogCapture.md
@@ -17,7 +17,12 @@ Logs:
   - /etc/waagent.conf
   - Logs.Verbose=y
 - [AndroidLogcat](https://developer.android.com/studio/command-line/logcat)
-  - Default format should be supported
+  - Default log format should be supported
+  - Durations are supported/parsed if the logging includes init timing or *Timing logs such as SystemServerTiming
+  - Logs are logged in local time zone and default assumed to be loaded in same time zone as captured
+  - To provide a hint on the timezone if in a different zone
+    - Place a "utcoffset.txt" file in the same folder as the trace. Place the UTC+Offset in the file as a double in hours. 
+    - E.g For India Standard Time (IST) offset is UTC+5.5 so place "5.5" in the file. If logs are in UTC place 0 in the file
 
 # LTTng
 [LTTng](https://lttng.org) (Kernel CPU scheduling, Processes, Threads, Block IO/Disk, Syscalls, File events, etc)
@@ -63,7 +68,7 @@ $ sudo lttng create my-kernel-session --output=lttng-kernel-trace
 ### Add the desired events to be recorded:
 ```bash
 $ sudo lttng enable-event --kernel block_rq_complete,block_rq_insert,block_rq_issue,printk_console,sched_wak*,sched_switch,sched_process_fork,sched_process_exit,sched_process_exec,lttng_statedump*
-$ sudo lttng enable-event --kernel --syscall –-all
+$ sudo lttng enable-event --kernel --syscall ï¿½-all
 ```
 
 ### Add context fields to the channel:

--- a/Microsoft-Perf-Tools-Linux-Android.sln
+++ b/Microsoft-Perf-Tools-Linux-Android.sln
@@ -68,6 +68,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AndroidLogcat", "LinuxLogParsers\LinuxPlugins-MicrosoftPerformanceToolkSDK\AndroidLogCat\AndroidLogcat.csproj", "{9FD0BECC-AC5E-46A8-9749-46CD82BA89DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -155,6 +156,10 @@ Global
 		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FD0BECC-AC5E-46A8-9749-46CD82BA89DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FD0BECC-AC5E-46A8-9749-46CD82BA89DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FD0BECC-AC5E-46A8-9749-46CD82BA89DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FD0BECC-AC5E-46A8-9749-46CD82BA89DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -167,6 +172,7 @@ Global
 		{75AF82A4-AF0E-425F-8CF5-62F4F54380B9} = {9B2D4167-1CC7-4D8B-A01C-E9919E809A0A}
 		{F910A8EA-9B0F-4BDA-87D4-0765EE973421} = {9B2D4167-1CC7-4D8B-A01C-E9919E809A0A}
 		{DB7FCF02-C949-4545-B58C-F514E85AB1FA} = {6A9515FC-D4B2-4221-8E74-78E7AFF0E421}
+		{9FD0BECC-AC5E-46A8-9749-46CD82BA89DE} = {9B2D4167-1CC7-4D8B-A01C-E9919E809A0A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E96603EA-8E1D-4AA9-A474-D267A116C316}

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -66,8 +66,10 @@ namespace PerfettoProcessor
         {
             try
             {
-                TraceProcessorRpc rpc = new TraceProcessorRpc();
-                rpc.Request = TraceProcessorRpc.Types.TraceProcessorMethod.TpmGetStatus;
+                TraceProcessorRpc rpc = new TraceProcessorRpc
+                {
+                    Request = TraceProcessorRpc.Types.TraceProcessorMethod.TpmGetStatus
+                };
 
                 // Send the request
                 var rpcResult = SendRpcRequest(rpc);
@@ -133,8 +135,10 @@ namespace PerfettoProcessor
                     CreateNoWindow = true,
                 };
 
-                ShellProcess = new Process();
-                ShellProcess.StartInfo = traceProcessorProcessStartInfo;
+                ShellProcess = new Process
+                {
+                    StartInfo = traceProcessorProcessStartInfo
+                };
 
                 if (outputDataReceivedEventHandler != null)
                 {
@@ -175,8 +179,10 @@ namespace PerfettoProcessor
 
             try
             {
-                TraceProcessorRpc rpc = new TraceProcessorRpc();
-                rpc.Request = TraceProcessorRpc.Types.TraceProcessorMethod.TpmGetStatus;
+                TraceProcessorRpc rpc = new TraceProcessorRpc
+                {
+                    Request = TraceProcessorRpc.Types.TraceProcessorMethod.TpmGetStatus
+                };
 
                 // Send the request
                 var rpcResult = SendRpcRequest(rpc);
@@ -223,9 +229,11 @@ namespace PerfettoProcessor
                 }
             }
 
-            TraceProcessorRpc rpc = new TraceProcessorRpc();
-            rpc.Request = TraceProcessorRpc.Types.TraceProcessorMethod.TpmQueryStreaming;
-            rpc.QueryArgs = new QueryArgs();
+            TraceProcessorRpc rpc = new TraceProcessorRpc
+            {
+                Request = TraceProcessorRpc.Types.TraceProcessorMethod.TpmQueryStreaming,
+                QueryArgs = new QueryArgs()
+            };
             rpc.QueryArgs.SqlQuery = sqlQuery;
             var rpcResult = SendRpcRequest(rpc);
 
@@ -269,77 +277,32 @@ namespace PerfettoProcessor
                     {
                         if (ev == null)
                         {
-                            switch (eventKey)
+                            ev = eventKey switch
                             {
-                                case PerfettoSliceEvent.Key:
-                                    ev = new PerfettoSliceEvent();
-                                    break;
-                                case PerfettoArgEvent.Key:
-                                    ev = new PerfettoArgEvent();
-                                    break;
-                                case PerfettoThreadTrackEvent.Key:
-                                    ev = new PerfettoThreadTrackEvent();
-                                    break;
-                                case PerfettoThreadEvent.Key:
-                                    ev = new PerfettoThreadEvent();
-                                    break;
-                                case PerfettoProcessEvent.Key:
-                                    ev = new PerfettoProcessEvent();
-                                    break;
-                                case PerfettoSchedSliceEvent.Key:
-                                    ev = new PerfettoSchedSliceEvent();
-                                    break;
-                                case PerfettoAndroidLogEvent.Key:
-                                    ev = new PerfettoAndroidLogEvent();
-                                    break;
-                                case PerfettoRawEvent.Key:
-                                    ev = new PerfettoRawEvent();
-                                    break;
-                                case PerfettoCounterEvent.Key:
-                                    ev = new PerfettoCounterEvent();
-                                    break;
-                                case PerfettoCpuCounterTrackEvent.Key:
-                                    ev = new PerfettoCpuCounterTrackEvent();
-                                    break;
-                                case PerfettoGpuCounterTrackEvent.Key:
-                                    ev = new PerfettoGpuCounterTrackEvent();
-                                    break;
-                                case PerfettoClockSnapshotEvent.Key:
-                                    ev = new PerfettoClockSnapshotEvent();
-                                    break;
-                                case PerfettoTraceBoundsEvent.Key:
-                                    ev = new PerfettoTraceBoundsEvent();
-                                    break;
-                                case PerfettoMetadataEvent.Key:
-                                    ev = new PerfettoMetadataEvent();
-                                    break;
-                                case PerfettoProcessCounterTrackEvent.Key:
-                                    ev = new PerfettoProcessCounterTrackEvent();
-                                    break;
-                                case PerfettoCounterTrackEvent.Key:
-                                    ev = new PerfettoCounterTrackEvent();
-                                    break;
-                                case PerfettoProcessTrackEvent.Key:
-                                    ev = new PerfettoProcessTrackEvent();
-                                    break;
-                                case PerfettoPerfSampleEvent.Key:
-                                    ev = new PerfettoPerfSampleEvent();
-                                    break;
-                                case PerfettoStackProfileCallSiteEvent.Key:
-                                    ev = new PerfettoStackProfileCallSiteEvent();
-                                    break;
-                                case PerfettoStackProfileFrameEvent.Key:
-                                    ev = new PerfettoStackProfileFrameEvent();
-                                    break;
-                                case PerfettoStackProfileMappingEvent.Key:
-                                    ev = new PerfettoStackProfileMappingEvent();
-                                    break;
-                                case PerfettoStackProfileSymbolEvent.Key:
-                                    ev = new PerfettoStackProfileSymbolEvent();
-                                    break;
-                                default:
-                                    throw new Exception("Invalid event type");
-                            }
+                                PerfettoSliceEvent.Key => new PerfettoSliceEvent(),
+                                PerfettoArgEvent.Key => new PerfettoArgEvent(),
+                                PerfettoThreadTrackEvent.Key => new PerfettoThreadTrackEvent(),
+                                PerfettoThreadEvent.Key => new PerfettoThreadEvent(),
+                                PerfettoProcessEvent.Key => new PerfettoProcessEvent(),
+                                PerfettoSchedSliceEvent.Key => new PerfettoSchedSliceEvent(),
+                                PerfettoAndroidLogEvent.Key => new PerfettoAndroidLogEvent(),
+                                PerfettoRawEvent.Key => new PerfettoRawEvent(),
+                                PerfettoCounterEvent.Key => new PerfettoCounterEvent(),
+                                PerfettoCpuCounterTrackEvent.Key => new PerfettoCpuCounterTrackEvent(),
+                                PerfettoGpuCounterTrackEvent.Key => new PerfettoGpuCounterTrackEvent(),
+                                PerfettoClockSnapshotEvent.Key => new PerfettoClockSnapshotEvent(),
+                                PerfettoTraceBoundsEvent.Key => new PerfettoTraceBoundsEvent(),
+                                PerfettoMetadataEvent.Key => new PerfettoMetadataEvent(),
+                                PerfettoProcessCounterTrackEvent.Key => new PerfettoProcessCounterTrackEvent(),
+                                PerfettoCounterTrackEvent.Key => new PerfettoCounterTrackEvent(),
+                                PerfettoProcessTrackEvent.Key => new PerfettoProcessTrackEvent(),
+                                PerfettoPerfSampleEvent.Key => new PerfettoPerfSampleEvent(),
+                                PerfettoStackProfileCallSiteEvent.Key => new PerfettoStackProfileCallSiteEvent(),
+                                PerfettoStackProfileFrameEvent.Key => new PerfettoStackProfileFrameEvent(),
+                                PerfettoStackProfileMappingEvent.Key => new PerfettoStackProfileMappingEvent(),
+                                PerfettoStackProfileSymbolEvent.Key => new PerfettoStackProfileSymbolEvent(),
+                                _ => throw new Exception("Invalid event type"),
+                            };
                         }
 
                         var colIndex = cellCount % numColumns;

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Dmesg](https://en.wikipedia.org/wiki/Dmesg)
 - [Cloud-Init](https://cloud-init.io/)
 - [WaLinuxAgent](https://github.com/Azure/WALinuxAgent)
+- [AndroidLogcat](https://developer.android.com/studio/command-line/logcat)
 
 **Optional** WPA GUI:
 ![WpaLinux](Images/WpaLinux.JPG)

--- a/TestData/AndroidLogs/Logcat/AndroidLogcatWSA.log
+++ b/TestData/AndroidLogs/Logcat/AndroidLogcatWSA.log
@@ -1,0 +1,6061 @@
+--------- beginning of events
+12-13 10:32:20.030    20    20 I auditd  : type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1
+--------- beginning of main
+12-13 10:32:20.030    20    20 W auditd  : type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1
+--------- beginning of kernel
+12-13 10:32:21.278     0     0 I         : Linux version 5.10.43-2-windows-subsystem-for-android (oe-user@oe-host) (clang version 10.0.1 (https://github.com/llvm/llvm-project ef32c611aa214dea855364efd7ba451ec5ec3f74), GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP PREEMPT Tue Sep 14 09:09:25 UTC 2021
+12-13 10:32:21.278     0     0 I Command line: initrd=\initrd.img panic=-1 nr_cpus=8 earlycon=uart8250,io,0x3f8,115200 console=hvc0 debug pty.legacy_count=0 androidboot.hardware=windows_x86_64 panic=-1 pty.legacy_count=0 androidboot.veritymode=enforcing androidboot.verifiedbootstate=green loglevel=6 transparent_hugepage=never swiotlb=noforce  androidboot.hardware.egl=emulation androidboot.hardware.gralloc=emulation
+12-13 10:32:21.278     0     0 I         : KERNEL supported cpus:
+12-13 10:32:21.278     0     0 I         : Intel GenuineIntel
+12-13 10:32:21.278     0     0 I         : AMD AuthenticAMD
+12-13 10:32:21.278     0     0 I         : Centaur CentaurHauls
+12-13 10:32:21.278     0     0 I x86/fpu : Supporting XSAVE feature 0x001: 'x87 floating point registers'
+12-13 10:32:21.278     0     0 I x86/fpu : Supporting XSAVE feature 0x002: 'SSE registers'
+12-13 10:32:21.278     0     0 I x86/fpu : Supporting XSAVE feature 0x004: 'AVX registers'
+12-13 10:32:21.278     0     0 I x86/fpu : xstate_offset[2]:  576, xstate_sizes[2]:  256
+12-13 10:32:21.278     0     0 I x86/fpu : Enabled xstate features 0x7, context size is 832 bytes, using 'compacted' format.
+12-13 10:32:21.278     0     0 I         : BIOS-provided physical RAM map:
+12-13 10:32:21.278     0     0 I BIOS-e820: [mem 0x0000000000000000-0x000000000009ffff] usable
+12-13 10:32:21.278     0     0 I BIOS-e820: [mem 0x00000000000e0000-0x00000000000e0fff] reserved
+12-13 10:32:21.278     0     0 I BIOS-e820: [mem 0x0000000000100000-0x00000000001fffff] ACPI data
+12-13 10:32:21.278     0     0 I BIOS-e820: [mem 0x0000000000200000-0x00000000f7ffffff] usable
+12-13 10:32:21.278     0     0 I BIOS-e820: [mem 0x0000000100000000-0x0000000187ffffff] usable
+12-13 10:32:21.278     0     0 I earlycon: uart8250 at I/O port 0x3f8 (options '115200')
+12-13 10:32:21.278     0     0 I printk  : bootconsole [uart8250] enabled
+12-13 10:32:21.278     0     0 I         : NX (Execute Disable) protection: active
+12-13 10:32:21.278     0     0 I         : DMI not present or invalid.
+12-13 10:32:21.278     0     0 I Hypervisor detected: Microsoft Hyper-V
+12-13 10:32:21.278     0     0 I Hyper-V : privilege flags low 0x2e7f, high 0x3b8030, hints 0x20c2c, misc 0xe0bed7b2
+12-13 10:32:21.278     0     0 I         : Hyper-V Host Build:22523-10.0-1-0.1000
+12-13 10:32:21.278     0     0 I Hyper-V : LAPIC Timer Frequency: 0x1e8480
+12-13 10:32:21.278     0     0 I tsc     : Marking TSC unstable due to running on Hyper-V
+12-13 10:32:21.278     0     0 I Hyper-V : Using hypercall for remote TLB flush
+12-13 10:32:21.278     0     0 I clocksource: hyperv_clocksource_tsc_page: mask: 0xffffffffffffffff max_cycles: 0x24e6a1710, max_idle_ns: 440795202120 ns
+12-13 10:32:21.278     0     0 I tsc     : Detected 2111.999 MHz processor
+12-13 10:32:21.278     0     0 D e820    : update [mem 0x00000000-0x00000fff] usable ==> reserved
+12-13 10:32:21.278     0     0 D e820    : remove [mem 0x000a0000-0x000fffff] usable
+12-13 10:32:21.278     0     0 I         : last_pfn = 0x188000 max_arch_pfn = 0x400000000
+12-13 10:32:21.278     0     0 D         : MTRR default type: uncachable
+12-13 10:32:21.278     0     0 D         : MTRR fixed ranges enabled:
+12-13 10:32:21.278     0     0 D         : 00000-3FFFF write-back
+12-13 10:32:21.278     0     0 D         : 40000-7FFFF uncachable
+12-13 10:32:21.278     0     0 D         : 80000-8FFFF write-back
+12-13 10:32:21.278     0     0 D         : 90000-FFFFF uncachable
+12-13 10:32:21.278     0     0 D         : MTRR variable ranges enabled:
+12-13 10:32:21.278     0     0 D         : 0 base 0000000000 mask 7F00000000 write-back
+12-13 10:32:21.278     0     0 D         : 1 base 0100000000 mask 7000000000 write-back
+12-13 10:32:21.278     0     0 D         : 2 disabled
+12-13 10:32:21.278     0     0 D         : 3 disabled
+12-13 10:32:21.278     0     0 D         : 4 disabled
+12-13 10:32:21.278     0     0 D         : 5 disabled
+12-13 10:32:21.278     0     0 D         : 6 disabled
+12-13 10:32:21.278     0     0 D         : 7 disabled
+12-13 10:32:21.278     0     0 I x86/PAT : Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT
+12-13 10:32:21.279     0     0 I         : last_pfn = 0xf8000 max_arch_pfn = 0x400000000
+12-13 10:32:21.279     0     0 I         : Using GB pages for direct mapping
+12-13 10:32:21.279     0     0 I RAMDISK : [mem 0x03d85000-0x03d9cfff]
+12-13 10:32:21.279     0     0 I ACPI    : Early table checksum verification disabled
+12-13 10:32:21.279     0     0 I ACPI    : RSDP 0x00000000000E0000 000024 (v02 VRTUAL)
+12-13 10:32:21.279     0     0 I ACPI    : XSDT 0x0000000000100000 000044 (v01 VRTUAL MICROSFT 00000001 MSFT 00000001)
+12-13 10:32:21.279     0     0 I ACPI    : FACP 0x0000000000101000 000114 (v06 VRTUAL MICROSFT 00000001 MSFT 00000001)
+12-13 10:32:21.279     0     0 I ACPI    : DSDT 0x00000000001011B8 01E184 (v02 MSFTVM DSDT01   00000001 MSFT 05000000)
+12-13 10:32:21.279     0     0 I ACPI    : FACS 0x0000000000101114 000040
+12-13 10:32:21.279     0     0 I ACPI    : OEM0 0x0000000000101154 000064 (v01 VRTUAL MICROSFT 00000001 MSFT 00000001)
+12-13 10:32:21.279     0     0 I ACPI    : SRAT 0x000000000011F33C 000330 (v02 VRTUAL MICROSFT 00000001 MSFT 00000001)
+12-13 10:32:21.279     0     0 I ACPI    : APIC 0x000000000011F66C 000088 (v04 VRTUAL MICROSFT 00000001 MSFT 00000001)
+12-13 10:32:21.279     0     0 I ACPI    : Reserving FACP table memory at [mem 0x101000-0x101113]
+12-13 10:32:21.279     0     0 I ACPI    : Reserving DSDT table memory at [mem 0x1011b8-0x11f33b]
+12-13 10:32:21.279     0     0 I ACPI    : Reserving FACS table memory at [mem 0x101114-0x101153]
+12-13 10:32:21.279     0     0 I ACPI    : Reserving OEM0 table memory at [mem 0x101154-0x1011b7]
+12-13 10:32:21.279     0     0 I ACPI    : Reserving SRAT table memory at [mem 0x11f33c-0x11f66b]
+12-13 10:32:21.279     0     0 I ACPI    : Reserving APIC table memory at [mem 0x11f66c-0x11f6f3]
+12-13 10:32:21.279     0     0 D ACPI    : Local APIC address 0xfee00000
+12-13 10:32:21.280     0     0 I Zone ranges:  
+12-13 10:32:21.280     0     0 I         : DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+12-13 10:32:21.280     0     0 I         : DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+12-13 10:32:21.280     0     0 I         : Normal   [mem 0x0000000100000000-0x0000000187ffffff]
+12-13 10:32:21.280     0     0 I         : Device   empty
+12-13 10:32:21.280     0     0 I         : Movable zone start for each node
+12-13 10:32:21.280     0     0 I         : Early memory node ranges
+12-13 10:32:21.280     0     0 I node   0: [mem 0x0000000000001000-0x000000000009ffff]
+12-13 10:32:21.280     0     0 I node   0: [mem 0x0000000000200000-0x00000000f7ffffff]
+12-13 10:32:21.280     0     0 I node   0: [mem 0x0000000100000000-0x0000000187ffffff]
+12-13 10:32:21.280     0     0 I         : Initmem setup node 0 [mem 0x0000000000001000-0x0000000187ffffff]
+12-13 10:32:21.280     0     0 D         : On node 0 totalpages: 1572511
+12-13 10:32:21.280     0     0 D DMA zone: 59 pages used for memmap
+12-13 10:32:21.280     0     0 D DMA zone: 22 pages reserved
+12-13 10:32:21.280     0     0 D DMA zone: 3743 pages, LIFO batch:0
+12-13 10:32:21.281     0     0 I DMA zone: 29025 pages in unavailable ranges
+12-13 10:32:21.281     0     0 D DMA32 zone: 16320 pages used for memmap
+12-13 10:32:21.281     0     0 D DMA32 zone: 1011712 pages, LIFO batch:63
+12-13 10:32:21.315     0     0 D Normal zone: 8704 pages used for memmap
+12-13 10:32:21.315     0     0 D Normal zone: 557056 pages, LIFO batch:63
+12-13 10:32:21.316     0     0 D ACPI    : Local APIC address 0xfee00000
+12-13 10:32:21.316     0     0 I ACPI    : LAPIC_NMI (acpi_id[0x01] dfl dfl lint[0x1])
+12-13 10:32:21.317     0     0 I IOAPIC[0]: apic_id 8, version 17, address 0xfec00000, GSI 0-23
+12-13 10:32:21.317     0     0 I ACPI    : INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+12-13 10:32:21.317     0     0 D ACPI    : IRQ9 used by override.
+12-13 10:32:21.317     0     0 I         : Using ACPI (MADT) for SMP configuration information
+12-13 10:32:21.317     0     0 I smpboot : Allowing 8 CPUs, 0 hotplug CPUs
+12-13 10:32:21.317     0     0 I         : [mem 0xf8000000-0xffffffff] available for PCI devices
+12-13 10:32:21.317     0     0 I         : Booting paravirtualized kernel on Hyper-V
+12-13 10:32:21.317     0     0 I clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+12-13 10:32:21.327     0     0 I setup_percpu: NR_CPUS:256 nr_cpumask_bits:256 nr_cpu_ids:8 nr_node_ids:1
+12-13 10:32:21.328     0     0 I percpu  : Embedded 53 pages/cpu s177496 r8192 d31400 u262144
+12-13 10:32:21.328     0     0 D pcpu-alloc: s177496 r8192 d31400 u262144 alloc=1*2097152
+12-13 10:32:21.328     0     0 D pcpu-alloc: [0] 0 1 2 3 4 5 6 7
+12-13 10:32:21.328     0     0 I         : Built 1 zonelists, mobility grouping on.  Total pages: 1547406
+12-13 10:32:21.328     0     0 I         : Kernel command line: initrd=\initrd.img panic=-1 nr_cpus=8 earlycon=uart8250,io,0x3f8,115200 console=hvc0 debug pty.legacy_count=0 androidboot.hardware=windows_x86_64 panic=-1 pty.legacy_count=0 androidboot.veritymode=enforcing androidboot.verifiedbootstate=green loglevel=6 transparent_hugepage=never swiotlb=noforce  androidboot.hardware.egl=emulation androidboot.hardware.gralloc=emulation
+12-13 10:32:21.355     0     0 I         : Dentry cache hash table entries: 1048576 (order: 11, 8388608 bytes, linear)
+12-13 10:32:21.356     0     0 I         : Inode-cache hash table entries: 524288 (order: 10, 4194304 bytes, linear)
+12-13 10:32:21.356     0     0 I mem auto-init: stack:off, heap alloc:off, heap free:off
+12-13 10:32:21.369     0     0 I Memory  : 4192444K/6290044K available (20501K kernel code, 2417K rwdata, 9364K rodata, 1524K init, 2096K bss, 155592K reserved, 0K cma-reserved)
+12-13 10:32:21.369     0     0 I SLUB    : HWalign=64, Order=0-3, MinObjects=0, CPUs=8, Nodes=1
+12-13 10:32:21.369     0     0 I         : Kernel/User page tables isolation: enabled
+12-13 10:32:21.369     0     0 I ftrace  : allocating 51191 entries in 200 pages
+12-13 10:32:21.378     0     0 I ftrace  : allocated 200 pages with 3 groups
+12-13 10:32:21.378     0     0 I rcu     : Preemptible hierarchical RCU implementation.
+12-13 10:32:21.378     0     0 I rcu     : RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=8.
+12-13 10:32:21.378     0     0 I         : Trampoline variant of Tasks RCU enabled.
+12-13 10:32:21.378     0     0 I         : Rude variant of Tasks RCU enabled.
+12-13 10:32:21.378     0     0 I         : Tracing variant of Tasks RCU enabled.
+12-13 10:32:21.378     0     0 I rcu     : RCU calculated value of scheduler-enlistment delay is 10 jiffies.
+12-13 10:32:21.378     0     0 I rcu     : Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=8
+12-13 10:32:21.381     0     0 I         : Using NULL legacy PIC
+12-13 10:32:21.381     0     0 I NR_IRQS : 16640, nr_irqs: 488, preallocated irqs: 0
+12-13 10:32:21.381     0     0 I random  : crng done (trusting CPU's manufacturer)
+12-13 10:32:21.384     0     0 I Console : colour dummy device 80x25
+12-13 10:32:21.384     0     0 I ACPI    : Core revision 20200925
+12-13 10:32:21.385     0     0 I         : Failed to register legacy timer interrupt
+12-13 10:32:21.385     0     0 I APIC    : Switch to symmetric I/O mode setup
+12-13 10:32:21.385     0     0 I Hyper-V : Using IPI hypercalls
+12-13 10:32:21.385     0     0 I Hyper-V : Using enlightened APIC (xapic mode)
+12-13 10:32:21.385     0     0 I         : Calibrating delay loop (skipped), value calculated using timer frequency.. 4223.99 BogoMIPS (lpj=21119990)
+12-13 10:32:21.385     0     0 I pid_max : default: 32768 minimum: 301
+12-13 10:32:21.385     0     0 I LSM     : Security Framework initializing
+12-13 10:32:21.385     0     0 I SELinux : Initializing.
+12-13 10:32:21.385     0     0 I         : Mount-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+12-13 10:32:21.385     0     0 I         : Mountpoint-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
+12-13 10:32:21.385     0     0 I         : Last level iTLB entries: 4KB 64, 2MB 8, 4MB 8
+12-13 10:32:21.385     0     0 I         : Last level dTLB entries: 4KB 64, 2MB 0, 4MB 0, 1GB 4
+12-13 10:32:21.385     0     0 I Spectre V1: Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+12-13 10:32:21.385     0     0 I Spectre V2: Mitigation: Full generic retpoline
+12-13 10:32:21.385     0     0 I Spectre V2: Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+12-13 10:32:21.385     0     0 I Spectre V2: Enabling Restricted Speculation for firmware calls
+12-13 10:32:21.385     0     0 I Spectre V2: mitigation: Enabling conditional Indirect Branch Prediction Barrier
+12-13 10:32:21.385     0     0 I Spectre V2: User space: Mitigation: STIBP via seccomp and prctl
+12-13 10:32:21.385     0     0 I         : Speculative Store Bypass: Mitigation: Speculative Store Bypass disabled via prctl and seccomp
+12-13 10:32:21.385     0     0 I TAA     : Vulnerable: Clear CPU buffers attempted, no microcode
+12-13 10:32:21.385     0     0 I SRBDS   : Unknown: Dependent on hypervisor status
+12-13 10:32:21.385     0     0 I MDS     : Vulnerable: Clear CPU buffers attempted, no microcode
+12-13 10:32:21.385     0     0 I         : Freeing SMP alternatives memory: 60K
+12-13 10:32:21.385     0     0 I smpboot : CPU0: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz (family: 0x6, model: 0x8e, stepping: 0xa)
+12-13 10:32:21.386     0     0 I Performance Events: unsupported p6 CPU model 142 no PMU driver, software events only.
+12-13 10:32:21.386     0     0 I rcu     : Hierarchical SRCU implementation.
+12-13 10:32:21.386     0     0 I smp     : Bringing up secondary CPUs ...
+12-13 10:32:21.386     0     0 I         : x86: Booting SMP configuration:
+12-13 10:32:21.386     0     0 I         : .... node  #0, CPUs:      #1
+12-13 10:32:21.387     0     0 W         : MDS CPU bug present and SMT on, data leak possible. See https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html for more details.
+12-13 10:32:21.395     0     0 W         : TAA CPU bug present and SMT on, data leak possible. See https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/tsx_async_abort.html for more details.
+12-13 10:32:21.405     0     0 F         : #2 #3 #4 #5 #6 #7
+12-13 10:32:21.406     0     0 I smp     : Brought up 1 node, 8 CPUs
+12-13 10:32:21.407     0     0 I smpboot : Max logical packages: 1
+12-13 10:32:21.407     0     0 I smpboot : Total of 8 processors activated (33791.98 BogoMIPS)
+12-13 10:32:21.417     0     0 I         : node 0 deferred pages initialised in 10ms
+12-13 10:32:21.418     0     0 I         : pgdatinit0 (51) used greatest stack depth: 14832 bytes left
+12-13 10:32:21.418     0     0 I devtmpfs: initialized
+12-13 10:32:21.418     0     0 I x86/mm  : Memory block size: 128MB
+12-13 10:32:21.418     0     0 I clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+12-13 10:32:21.418     0     0 I         : futex hash table entries: 2048 (order: 5, 131072 bytes, linear)
+12-13 10:32:21.418     0     0 I NET     : Registered protocol family 16
+12-13 10:32:21.418     0     0 I audit   : initializing netlink subsys (disabled)
+12-13 10:32:21.418     0     0 I thermal_sys: Registered thermal governor 'step_wise'
+12-13 10:32:21.425     0     0 I cpuidle : using governor menu
+12-13 10:32:21.425     0     0 I ACPI    : bus type PCI registered
+12-13 10:32:21.425     0     0 E PCI     : Fatal: No config space access function found
+12-13 10:32:21.435     0     0 I         : Kprobes globally optimized
+12-13 10:32:21.435     0     0 I         : HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
+12-13 10:32:21.435     0     0 I         : HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+12-13 10:32:21.435     0     0 I cryptd  : max_cpu_qlen set to 1000
+12-13 10:32:21.435     0     0 I raid6   : skip pq benchmark and using algorithm avx2x4
+12-13 10:32:21.435     0     0 I raid6   : using avx2x2 recovery algorithm
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(Module Device)
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(Processor Device)
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(3.0 _SCP Extensions)
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(Processor Aggregator Device)
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(Linux-Dell-Video)
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+12-13 10:32:21.435     0     0 I ACPI    : Added _OSI(Linux-HPI-Hybrid-Graphics)
+12-13 10:32:21.442     0     0 I ACPI    : 1 ACPI AML tables successfully acquired and loaded
+12-13 10:32:21.443     0     0 I ACPI    : Interpreter enabled
+12-13 10:32:21.443     0     0 I ACPI    : (supports S0 S5)
+12-13 10:32:21.443     0     0 I ACPI    : Using IOAPIC for interrupt routing
+12-13 10:32:21.443     0     0 I PCI     : Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+12-13 10:32:21.443     0     0 I ACPI    : Enabled 2 GPEs in block 00 to 0F
+12-13 10:32:21.445     0     0 I iommu   : Default domain type: Translated
+12-13 10:32:21.445     0     0 I         : SCSI subsystem initialized
+12-13 10:32:21.447     0     0 I ACPI    : bus type USB registered
+12-13 10:32:21.447     0     0 I usbcore : registered new interface driver usbfs
+12-13 10:32:21.447     0     0 I usbcore : registered new interface driver hub
+12-13 10:32:21.447     0     0 I usbcore : registered new device driver usb
+12-13 10:32:21.447     0     0 I videodev: Linux video capture interface: v2.00
+12-13 10:32:21.455     0     0 I hv_vmbus: Vmbus version:5.2
+12-13 10:32:21.455     0     0 I hv_vmbus: Unknown GUID: c376c1c3-d276-48d2-90a9-c04748072c60
+12-13 10:32:21.455     0     0 I         : Advanced Linux Sound Architecture Driver Initialized.
+12-13 10:32:21.455     0     0 I PCI     : Using ACPI for IRQ routing
+12-13 10:32:21.455     0     0 W PCI     : System does not support PCI
+12-13 10:32:21.466     0     0 I clocksource: Switched to clocksource hyperv_clocksource_tsc_page
+12-13 10:32:21.506     0     0 I VFS     : Disk quotas dquot_6.6.0
+12-13 10:32:21.510     0     0 I VFS     : Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+12-13 10:32:21.510     0     0 I FS-Cache: Loaded
+12-13 10:32:21.512     0     0 I pnp     : PnP ACPI init
+12-13 10:32:21.512     0     0 D pnp 00  : 00: Plug and Play ACPI device, IDs PNP0501 (active)
+12-13 10:32:21.512     0     0 D pnp 00  : 01: Plug and Play ACPI device, IDs PNP0501 (active)
+12-13 10:32:21.512     0     0 D pnp 00  : 02: Plug and Play ACPI device, IDs PNP0b00 (active)
+12-13 10:32:21.513     0     0 I pnp     : PnP ACPI: found 3 devices
+12-13 10:32:21.521     0     0 I NET     : Registered protocol family 2
+12-13 10:32:21.521     0     0 I         : IP idents hash table entries: 131072 (order: 8, 1048576 bytes, linear)
+12-13 10:32:21.522     0     0 I         : tcp_listen_portaddr_hash hash table entries: 4096 (order: 4, 65536 bytes, linear)
+12-13 10:32:21.522     0     0 I         : TCP established hash table entries: 65536 (order: 7, 524288 bytes, linear)
+12-13 10:32:21.523     0     0 I         : TCP bind hash table entries: 65536 (order: 8, 1048576 bytes, linear)
+12-13 10:32:21.523     0     0 I TCP     : Hash tables configured (established 65536 bind 65536)
+12-13 10:32:21.523     0     0 I         : UDP hash table entries: 4096 (order: 5, 131072 bytes, linear)
+12-13 10:32:21.523     0     0 I         : UDP-Lite hash table entries: 4096 (order: 5, 131072 bytes, linear)
+12-13 10:32:21.523     0     0 I NET     : Registered protocol family 1
+12-13 10:32:21.524     0     0 I NET     : Registered protocol family 44
+12-13 10:32:21.524     0     0 I PCI     : CLS 0 bytes, default 64
+12-13 10:32:21.524     0     0 I         : Trying to unpack rootfs image as initramfs...
+12-13 10:32:21.524     0     0 I         : Freeing initrd memory: 96K
+12-13 10:32:21.524     0     0 I PCI-DMA : Using software bounce buffering for IO (SWIOTLB)
+12-13 10:32:21.524     0     0 I         : software IO TLB: mapped [mem 0x00000000f7fff000-0x00000000f7fff800] (0MB)
+12-13 10:32:21.524     0     0 E kvm     : no hardware support
+12-13 10:32:21.527     0     0 I has_svm : not amd or hygon
+12-13 10:32:21.527     0     0 E kvm     : no hardware support
+12-13 10:32:21.534     0     0 I         : Initialise system trusted keyrings
+12-13 10:32:21.538     0     0 I workingset: timestamp_bits=46 max_order=21 bucket_order=0
+12-13 10:32:21.540     0     0 I squashfs: version 4.0 (2009/01/31) Phillip Lougher
+12-13 10:32:21.540     0     0 I fuse    : init (API version 7.32)
+12-13 10:32:21.541     0     0 I         : SGI XFS with ACLs, security attributes, realtime, scrub, repair, quota, no debug enabled
+12-13 10:32:21.541     0     0 I         : 9p: Installing v9fs 9p2000 file system support
+12-13 10:32:21.541     0     0 I FS-Cache: Netfs '9p' registered for caching
+12-13 10:32:21.546     0     0 I FS-Cache: Netfs 'ceph' registered for caching
+12-13 10:32:21.552     0     0 I ceph    : loaded (mds proto 32)
+12-13 10:32:21.562     0     0 I NET     : Registered protocol family 38
+12-13 10:32:21.562     0     0 I xor     : automatically using best checksumming function   avx
+12-13 10:32:21.562     0     0 I         : Key type asymmetric registered
+12-13 10:32:21.566     0     0 I         : Asymmetric key parser 'x509' registered
+12-13 10:32:21.571     0     0 I         : Block layer SCSI generic (bsg) driver version 0.4 loaded (major 250)
+12-13 10:32:21.572     0     0 I hv_vmbus: registering driver hv_pci
+12-13 10:32:21.573     0     0 I hv_pci de91b813-677c-41e9-8129-4771abca90f8: PCI VMBus probing: Using version 0x10003
+12-13 10:32:21.576     0     0 I hv_pci de91b813-677c-41e9-8129-4771abca90f8: PCI host bridge to bus 677c:00
+12-13 10:32:21.576     0     0 I pci_bus 677c: 00: root bus resource [mem 0xac7e00000-0xac7e02fff window]
+12-13 10:32:21.578     0     0 I pci 677c: 00:00.0: [1af4:1043] type 00 class 0x010000
+12-13 10:32:21.582     0     0 I pci 677c: 00:00.0: reg 0x10: [mem 0xac7e00000-0xac7e00fff 64bit]
+12-13 10:32:21.583     0     0 I pci 677c: 00:00.0: reg 0x18: [mem 0xac7e01000-0xac7e01fff 64bit]
+12-13 10:32:21.585     0     0 I pci 677c: 00:00.0: reg 0x20: [mem 0xac7e02000-0xac7e02fff 64bit]
+12-13 10:32:21.591     0     0 I pci 677c: 00:00.0: BAR 0: assigned [mem 0xac7e00000-0xac7e00fff 64bit]
+12-13 10:32:21.592     0     0 I pci 677c: 00:00.0: BAR 2: assigned [mem 0xac7e01000-0xac7e01fff 64bit]
+12-13 10:32:21.592     0     0 I pci 677c: 00:00.0: BAR 4: assigned [mem 0xac7e02000-0xac7e02fff 64bit]
+12-13 10:32:21.594     0     0 I ACPI    : AC Adapter [AC1] (on-line)
+12-13 10:32:21.595     0     0 I battery : ACPI: Battery Slot [BAT1] (battery present)
+12-13 10:32:21.603     0     0 I Serial  : 8250/16550 driver, 4 ports, IRQ sharing disabled
+12-13 10:32:21.604     0     0 I         : 00:00: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+12-13 10:32:21.605     0     0 I         : 00:01: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+12-13 10:32:21.607     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #40!!!
+12-13 10:32:21.665     0     0 I         : Non-volatile memory driver v1.3
+12-13 10:32:21.666     0     0 I         : [drm] Initialized vgem 1.0.0 20120112 for vgem on minor 0
+12-13 10:32:21.676     0     0 I brd     : module loaded
+12-13 10:32:21.679     0     0 I printk  : console [hvc0] enabled
+12-13 10:32:21.679     0     0 I printk  : bootconsole [uart8250] disabled
+12-13 10:32:21.690     0     0 I loop    : module loaded
+12-13 10:32:21.690     0     0 I zram    : Added device: zram0
+12-13 10:32:21.690     0     0 I hv_vmbus: registering driver hv_storvsc
+12-13 10:32:21.693     0     0 I tun     : Universal TUN/TAP device driver, 1.6
+12-13 10:32:21.693     0     0 I         : PPP generic driver version 2.4.2
+12-13 10:32:21.693     0     0 I         : PPP BSD Compression module registered
+12-13 10:32:21.693     0     0 I         : PPP Deflate Compression module registered
+12-13 10:32:21.693     0     0 I         : PPP MPPE Compression module registered
+12-13 10:32:21.693     0     0 I NET     : Registered protocol family 24
+12-13 10:32:21.693     0     0 I         : PPTP driver version 0.8.5
+12-13 10:32:21.693     0     0 I hv_vmbus: registering driver hv_netvsc
+12-13 10:32:21.693     0     0 I         : VFIO - User Level meta-driver version: 0.3
+12-13 10:32:21.694     0     0 I hv_vmbus: registering driver hyperv_keyboard
+12-13 10:32:21.694     0     0 I usbcore : registered new interface driver xpad
+12-13 10:32:21.694     0     0 I scsi host0: storvsc_host_t
+12-13 10:32:21.694     0     0 I rtc_cmos 00: 02: RTC can wake from S4
+12-13 10:32:21.697     0     0 I rtc_cmos 00: 02: registered as rtc0
+12-13 10:32:21.698     0     0 I rtc_cmos 00: 02: setting system clock to 2021-12-13T18:32:20 UTC (1639420340)
+12-13 10:32:21.698     0     0 I rtc_cmos 00: 02: alarms up to one month, 114 bytes nvram
+12-13 10:32:21.698     0     0 I device-mapper: uevent: version 1.0.3
+12-13 10:32:21.698     0     0 I device-mapper: ioctl: 4.44.0-ioctl (2021-02-01) initialised: dm-devel@redhat.com
+12-13 10:32:21.699     0     0 I hid     : raw HID events driver (C) Jiri Kosina
+12-13 10:32:21.699     0     0 I usbcore : registered new interface driver usbhid
+12-13 10:32:21.699     0     0 I usbhid  : USB HID core driver
+12-13 10:32:21.700     0     0 I ashmem  : initialized
+12-13 10:32:21.700     0     0 I hv_utils: Registering HyperV Utility Driver
+12-13 10:32:21.700     0     0 I hv_vmbus: registering driver hv_utils
+12-13 10:32:21.700     0     0 I hv_vmbus: registering driver hv_balloon
+12-13 10:32:21.700     0     0 E hv_utils: cannot register PTP clock: 0
+12-13 10:32:21.700     0     0 I hv_vmbus: registering driver dxgkrnl
+12-13 10:32:21.701     0     0 I         : (NULL device *): dxgk: dxg_drv_init  Version: 2108
+12-13 10:32:21.701     0     0 I hv_balloon: Using Dynamic Memory protocol version 2.0
+12-13 10:32:21.701     0     0 I drop_monitor: Initializing network drop monitor service
+12-13 10:32:21.701     0     0 I         : Mirror/redirect action on
+12-13 10:32:21.701     0     0 I netem   : version 1.3
+12-13 10:32:21.701     0     0 I         : u32 classifier
+12-13 10:32:21.701     0     0 I         : input device check on
+12-13 10:32:21.701     0     0 I         : Actions configured
+12-13 10:32:21.702     0     0 I hv_utils: TimeSync IC version 4.0
+12-13 10:32:21.702     0     0 I         : Free page reporting enabled
+12-13 10:32:21.702     0     0 I hv_balloon: Cold memory discard hint enabled
+12-13 10:32:21.702     0     0 I xt_time : kernel timezone is -0000
+12-13 10:32:21.702     0     0 I IPVS    : Registered protocols (TCP, UDP)
+12-13 10:32:21.702     0     0 I IPVS    : Connection hash table configured (size=4096, memory=64Kbytes)
+12-13 10:32:21.702     0     0 I IPVS    : ipvs loaded.
+12-13 10:32:21.702     0     0 I IPVS    : [rr] scheduler registered.
+12-13 10:32:21.702     0     0 I IPVS    : [wrr] scheduler registered.
+12-13 10:32:21.702     0     0 I IPVS    : [sh] scheduler registered.
+12-13 10:32:21.702     0     0 I ipip    : IPv4 and MPLS over IPv4 tunneling driver
+12-13 10:32:21.702     0     0 I gre     : GRE over IPv4 demultiplexor driver
+12-13 10:32:21.702     0     0 I ip_gre  : GRE over IPv4 tunneling driver
+12-13 10:32:21.703     0     0 I         : IPv4 over IPsec tunneling driver
+12-13 10:32:21.703     0     0 I ipt_CLUSTERIP: ClusterIP Version 0.8 loaded successfully
+12-13 10:32:21.703     0     0 I         : Initializing XFRM netlink socket
+12-13 10:32:21.703     0     0 I         : IPsec XFRM device driver
+12-13 10:32:21.703     0     0 I NET     : Registered protocol family 10
+12-13 10:32:21.704     0     0 I         : Segment Routing with IPv6
+12-13 10:32:21.704     0     0 I mip6    : Mobile IPv6
+12-13 10:32:21.704     0     0 I sit     : IPv6, IPv4 and MPLS over IPv4 tunneling driver
+12-13 10:32:21.705     0     0 I ip6_gre : GRE over IPv6 tunneling driver
+12-13 10:32:21.705     0     0 I NET     : Registered protocol family 17
+12-13 10:32:21.705     0     0 I NET     : Registered protocol family 15
+12-13 10:32:21.705     0     0 I         : Bridge firewalling registered
+12-13 10:32:21.706     0     0 I l2tp_core: L2TP core driver, V2.0
+12-13 10:32:21.706     0     0 I l2tp_ppp: PPPoL2TP kernel driver, V2.0
+12-13 10:32:21.706     0     0 I 8021q   : 802.1Q VLAN Support v1.8
+12-13 10:32:21.706     0     0 I sctp    : Hash tables configured (bind 256/256)
+12-13 10:32:21.706     0     0 I tipc    : Activated (version 2.0.0)
+12-13 10:32:21.706     0     0 I NET     : Registered protocol family 30
+12-13 10:32:21.706     0     0 I tipc    : Started in single node mode
+12-13 10:32:21.706     0     0 I 9pnet   : Installing 9P2000 support
+12-13 10:32:21.706     0     0 I         : Key type dns_resolver registered
+12-13 10:32:21.707     0     0 I         : Key type ceph registered
+12-13 10:32:21.708     0     0 I libceph : loaded (mon/osd proto 15/24)
+12-13 10:32:21.708     0     0 I NET     : Registered protocol family 40
+12-13 10:32:21.708     0     0 I hv_vmbus: registering driver hv_sock
+12-13 10:32:21.708     0     0 I         : IPI shorthand broadcast: enabled
+12-13 10:32:21.708     0     0 I         : AVX2 version of gcm_enc/dec engaged.
+12-13 10:32:21.708     0     0 I         : AES CTR mode by8 optimization enabled
+12-13 10:32:21.712     0     0 I         : registered taskstats version 1
+12-13 10:32:21.712     0     0 I         : Loading compiled-in X.509 certificates
+12-13 10:32:21.713     0     0 I         : Key type ._fscrypt registered
+12-13 10:32:21.713     0     0 I         : Key type .fscrypt registered
+12-13 10:32:21.713     0     0 I         : Key type fscrypt-provisioning registered
+12-13 10:32:21.715     0     0 I         : Btrfs loaded, crc32c=crc32c-generic
+12-13 10:32:21.715     0     0 I cfg80211: Loading compiled-in X.509 certificates for regulatory database
+12-13 10:32:21.717     0     0 I cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
+12-13 10:32:21.718     0     0 W platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
+12-13 10:32:21.719     0     0 I cfg80211: failed to load regulatory.db
+12-13 10:32:21.719     0     0 W         : Unstable clock detected, switching default tracing clock to "global"
+12-13 10:32:21.719     0     0 W         : If you want to keep using the local clock, then add:
+12-13 10:32:21.719     0     0 W         : "trace_clock=local"
+12-13 10:32:21.719     0     0 W         : on the kernel command line
+12-13 10:32:21.722     0     0 I         : ALSA device list:
+12-13 10:32:21.722     0     0 I         : No soundcards found.
+12-13 10:32:21.723     0     0 I         : Freeing unused kernel image (initmem) memory: 1524K
+12-13 10:32:21.775     0     0 I         : Write protecting the kernel read-only data: 32768k
+12-13 10:32:21.776     0     0 I         : Freeing unused kernel image (text/rodata gap) memory: 2024K
+12-13 10:32:21.776     0     0 I         : Freeing unused kernel image (rodata/data gap) memory: 876K
+12-13 10:32:21.777     0     0 I         : Run /init as init process
+12-13 10:32:21.777     0     0 D with arguments:  
+12-13 10:32:21.777     0     0 D         : /init
+12-13 10:32:21.777     0     0 D with environment:  
+12-13 10:32:21.777     0     0 D         : HOME=/
+12-13 10:32:21.777     0     0 D         : TERM=linux
+12-13 10:32:22.060     0     0 I         : hv_netvsc 0b115a3e-c0a1-48d9-8bc3-74f530e77916 _wlan0: renamed from eth0
+12-13 10:32:22.252     0     0 I hv_pci 79c1e8db-d117-4afc-8010-e8afa9cb7d61: PCI VMBus probing: Using version 0x10003
+12-13 10:32:22.254     0     0 I hv_pci 79c1e8db-d117-4afc-8010-e8afa9cb7d61: PCI host bridge to bus d117:00
+12-13 10:32:22.254     0     0 I pci_bus d117: 00: root bus resource [mem 0xb00000000-0xb80001fff window]
+12-13 10:32:22.257     0     0 I pci d117: 00:00.0: [1af4:105a] type 00 class 0x088000
+12-13 10:32:22.259     0     0 I pci d117: 00:00.0: reg 0x10: [mem 0xb80000000-0xb80000fff 64bit]
+12-13 10:32:22.261     0     0 I pci d117: 00:00.0: reg 0x18: [mem 0xb80001000-0xb80001fff 64bit]
+12-13 10:32:22.263     0     0 I pci d117: 00:00.0: reg 0x20: [mem 0xb00000000-0xb7fffffff 64bit]
+12-13 10:32:22.267     0     0 I scsi 0  : 0:0:0: Direct-Access     Msft     Virtual Disk     1.0  PQ: 0 ANSI: 5
+12-13 10:32:22.269     0     0 I sd 0    : 0:0:0: Attached scsi generic sg0 type 0
+12-13 10:32:22.270     0     0 I sd 0    : 0:0:0: [sda] 268435456 512-byte logical blocks: (137 GB/128 GiB)
+12-13 10:32:22.272     0     0 I sd 0    : 0:0:0: [sda] Write Protect is off
+12-13 10:32:22.273     0     0 D sd 0    : 0:0:0: [sda] Mode Sense: 0f 00 00 00
+12-13 10:32:22.273     0     0 I sd 0    : 0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+12-13 10:32:22.273     0     0 I pci d117: 00:00.0: BAR 4: assigned [mem 0xb00000000-0xb7fffffff 64bit]
+12-13 10:32:22.276     0     0 I pci d117: 00:00.0: BAR 0: assigned [mem 0xb80000000-0xb80000fff 64bit]
+12-13 10:32:22.277     0     0 I pci d117: 00:00.0: BAR 2: assigned [mem 0xb80001000-0xb80001fff 64bit]
+12-13 10:32:22.303     0     0 I virtiofs virtio1: Cache len: 0x80000000 @ 0xb00000000
+12-13 10:32:22.365     0     0 I         : memmap_init_zone_device initialised 524288 pages in 10ms
+12-13 10:32:22.368     0     0 I hv_pci d783da5e-c616-482b-a765-936d4d686331: PCI VMBus probing: Using version 0x10003
+12-13 10:32:22.370     0     0 I hv_pci d783da5e-c616-482b-a765-936d4d686331: PCI host bridge to bus c616:00
+12-13 10:32:22.370     0     0 I pci_bus c616: 00: root bus resource [mem 0xc00000000-0xc80001fff window]
+12-13 10:32:22.372     0     0 I pci c616: 00:00.0: [1af4:105b] type 00 class 0x088000
+12-13 10:32:22.374     0     0 I pci c616: 00:00.0: reg 0x10: [mem 0xc80000000-0xc80000fff 64bit]
+12-13 10:32:22.375     0     0 I pci c616: 00:00.0: reg 0x18: [mem 0xc80001000-0xc80001fff 64bit]
+12-13 10:32:22.376     0     0 I pci c616: 00:00.0: reg 0x20: [mem 0xc00000000-0xc7fffffff 64bit]
+12-13 10:32:22.382     0     0 I pci c616: 00:00.0: BAR 4: assigned [mem 0xc00000000-0xc7fffffff 64bit]
+12-13 10:32:22.383     0     0 I pci c616: 00:00.0: BAR 0: assigned [mem 0xc80000000-0xc80000fff 64bit]
+12-13 10:32:22.384     0     0 I pci c616: 00:00.0: BAR 2: assigned [mem 0xc80001000-0xc80001fff 64bit]
+12-13 10:32:22.410     0     0 W nd_pmem namespace0.0: unable to guarantee persistence of writes
+12-13 10:32:22.502     0     0 I         : memmap_init_zone_device initialised 524288 pages in 0ms
+12-13 10:32:22.512     0     0 I         : init (183) used greatest stack depth: 14552 bytes left
+12-13 10:32:22.534     0     0 I hv_pci fd0898de-d268-4bcd-9d85-1458677c0aef: PCI VMBus probing: Using version 0x10003
+12-13 10:32:22.536     0     0 I hv_pci fd0898de-d268-4bcd-9d85-1458677c0aef: PCI host bridge to bus d268:00
+12-13 10:32:22.536     0     0 I pci_bus d268: 00: root bus resource [mem 0xba0000000-0xbc0001fff window]
+12-13 10:32:22.539     0     0 I pci d268: 00:00.0: [1af4:105b] type 00 class 0x088000
+12-13 10:32:22.541     0     0 I pci d268: 00:00.0: reg 0x10: [mem 0xbc0000000-0xbc0000fff 64bit]
+12-13 10:32:22.544     0     0 I pci d268: 00:00.0: reg 0x18: [mem 0xbc0001000-0xbc0001fff 64bit]
+12-13 10:32:22.546     0     0 I pci d268: 00:00.0: reg 0x20: [mem 0xba0000000-0xbbfffffff 64bit]
+12-13 10:32:22.555     0     0 I pci d268: 00:00.0: BAR 4: assigned [mem 0xba0000000-0xbbfffffff 64bit]
+12-13 10:32:22.556     0     0 I pci d268: 00:00.0: BAR 0: assigned [mem 0xbc0000000-0xbc0000fff 64bit]
+12-13 10:32:22.557     0     0 I pci d268: 00:00.0: BAR 2: assigned [mem 0xbc0001000-0xbc0001fff 64bit]
+12-13 10:32:22.585     0     0 W nd_pmem namespace1.0: unable to guarantee persistence of writes
+12-13 10:32:22.615     0     0 I sd 0    : 0:0:0: [sda] Attached SCSI disk
+12-13 10:32:22.660     0     0 I         : memmap_init_zone_device initialised 131072 pages in 0ms
+12-13 10:32:22.695     0     0 I IPv6    : ADDRCONF(NETDEV_CHANGE): _wlan0: link becomes ready
+12-13 10:32:22.705     0     0 I hv_pci b5b813f1-a178-47c9-ac90-b13d948834be: PCI VMBus probing: Using version 0x10003
+12-13 10:32:22.705     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #280!!!
+12-13 10:32:22.712     0     0 I hv_pci b5b813f1-a178-47c9-ac90-b13d948834be: PCI host bridge to bus a178:00
+12-13 10:32:22.712     0     0 I pci_bus a178: 00: root bus resource [mem 0xac8000000-0xad0001fff window]
+12-13 10:32:22.715     0     0 I pci a178: 00:00.0: [1af4:105b] type 00 class 0x088000
+12-13 10:32:22.718     0     0 I pci a178: 00:00.0: reg 0x10: [mem 0xad0000000-0xad0000fff 64bit]
+12-13 10:32:22.721     0     0 I pci a178: 00:00.0: reg 0x18: [mem 0xad0001000-0xad0001fff 64bit]
+12-13 10:32:22.723     0     0 I pci a178: 00:00.0: reg 0x20: [mem 0xac8000000-0xacfffffff 64bit]
+12-13 10:32:22.777     0     0 I pci a178: 00:00.0: BAR 4: assigned [mem 0xac8000000-0xacfffffff 64bit]
+12-13 10:32:22.781     0     0 I pci a178: 00:00.0: BAR 0: assigned [mem 0xad0000000-0xad0000fff 64bit]
+12-13 10:32:22.784     0     0 I pci a178: 00:00.0: BAR 2: assigned [mem 0xad0001000-0xad0001fff 64bit]
+12-13 10:32:22.838     0     0 W nd_pmem namespace2.0: unable to guarantee persistence of writes
+12-13 10:32:22.895     0     0 I         : memmap_init_zone_device initialised 32768 pages in 0ms
+12-13 10:32:22.923     0     0 I hv_pci b856592a-8588-4088-a940-82d0fd0004e2: PCI VMBus probing: Using version 0x10003
+12-13 10:32:22.925     0     0 I hv_pci b856592a-8588-4088-a940-82d0fd0004e2: PCI host bridge to bus 8588:00
+12-13 10:32:22.925     0     0 I pci_bus 8588: 00: root bus resource [mem 0xae0000000-0xaf0001fff window]
+12-13 10:32:22.927     0     0 I pci 8588: 00:00.0: [1af4:105b] type 00 class 0x088000
+12-13 10:32:22.929     0     0 I pci 8588: 00:00.0: reg 0x10: [mem 0xaf0000000-0xaf0000fff 64bit]
+12-13 10:32:22.931     0     0 I pci 8588: 00:00.0: reg 0x18: [mem 0xaf0001000-0xaf0001fff 64bit]
+12-13 10:32:22.932     0     0 I pci 8588: 00:00.0: reg 0x20: [mem 0xae0000000-0xaefffffff 64bit]
+12-13 10:32:22.940     0     0 I pci 8588: 00:00.0: BAR 4: assigned [mem 0xae0000000-0xaefffffff 64bit]
+12-13 10:32:22.941     0     0 I pci 8588: 00:00.0: BAR 0: assigned [mem 0xaf0000000-0xaf0000fff 64bit]
+12-13 10:32:22.941     0     0 I pci 8588: 00:00.0: BAR 2: assigned [mem 0xaf0001000-0xaf0001fff 64bit]
+12-13 10:32:22.963     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #40!!!
+12-13 10:32:22.975     0     0 W nd_pmem namespace3.0: unable to guarantee persistence of writes
+12-13 10:32:23.056     0     0 I         : memmap_init_zone_device initialised 65536 pages in 0ms
+12-13 10:32:23.057     0     0 W EXT4-fs (pmem0): DAX enabled. Warning: EXPERIMENTAL, use at your own risk
+12-13 10:32:23.060     0     0 I EXT4-fs (pmem0): mounted filesystem without journal. Opts: dax
+12-13 10:32:23.184     0     0 I init    : init first stage started!
+12-13 10:32:23.184     0     0 I init    : Unable to open /lib/modules, skipping module loading.
+12-13 10:32:23.186     0     0 I init    : [libfs_mgr]ReadFstabFromDt(): failed to read fstab from dt
+12-13 10:32:23.188     0     0 I init    : Using Android DT directory /proc/device-tree/firmware/android/
+12-13 10:32:23.213     0     0 I init    : DSU not detected, proceeding with normal boot
+12-13 10:32:23.215     0     0 I init    : [libfs_mgr]superblock s_max_mnt_count:65535,/dev/block/pmem1
+12-13 10:32:23.215     0     0 W EXT4-fs (pmem1): DAX enabled. Warning: EXPERIMENTAL, use at your own risk
+12-13 10:32:23.217     0     0 I EXT4-fs (pmem1): mounted filesystem without journal. Opts: dax,errors=panic
+12-13 10:32:23.217     0     0 I init    : [libfs_mgr]__mount(source=/dev/block/pmem1,target=/vendor,type=ext4)=0: Success
+12-13 10:32:23.218     0     0 I init    : [libfs_mgr]superblock s_max_mnt_count:65535,/dev/block/pmem2
+12-13 10:32:23.218     0     0 W EXT4-fs (pmem2): DAX enabled. Warning: EXPERIMENTAL, use at your own risk
+12-13 10:32:23.219     0     0 I EXT4-fs (pmem2): mounted filesystem without journal. Opts: dax,errors=panic
+12-13 10:32:23.219     0     0 I init    : [libfs_mgr]__mount(source=/dev/block/pmem2,target=/system_ext,type=ext4)=0: Success
+12-13 10:32:23.219     0     0 I init    : [libfs_mgr]superblock s_max_mnt_count:65535,/dev/block/pmem3
+12-13 10:32:23.219     0     0 W EXT4-fs (pmem3): DAX enabled. Warning: EXPERIMENTAL, use at your own risk
+12-13 10:32:23.221     0     0 I EXT4-fs (pmem3): mounted filesystem without journal. Opts: dax,errors=panic
+12-13 10:32:23.221     0     0 I init    : [libfs_mgr]__mount(source=/dev/block/pmem3,target=/product,type=ext4)=0: Success
+12-13 10:32:23.223     0     0 I init    : Skipped setting INIT_AVB_VERSION (not in recovery mode)
+12-13 10:32:23.237     0     0 I init    : Loading SELinux policy
+12-13 10:32:23.255     0     0 I SELinux : Permission nlmsg_getneigh in class netlink_route_socket not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Permission perfmon in class capability2 not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Permission bpf in class capability2 not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Permission checkpoint_restore in class capability2 not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Permission perfmon in class cap2_userns not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Permission bpf in class cap2_userns not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Permission checkpoint_restore in class cap2_userns not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : Class anon_inode not defined in policy.
+12-13 10:32:23.255     0     0 I SELinux : the above unknown classes and permissions will be denied
+12-13 10:32:23.257     0     0 I SELinux : policy capability network_peer_controls=1
+12-13 10:32:23.257     0     0 I SELinux : policy capability open_perms=1
+12-13 10:32:23.257     0     0 I SELinux : policy capability extended_socket_class=1
+12-13 10:32:23.257     0     0 I SELinux : policy capability always_check_network=0
+12-13 10:32:23.257     0     0 I SELinux : policy capability cgroup_seclabel=0
+12-13 10:32:23.257     0     0 I SELinux : policy capability nnp_nosuid_transition=1
+12-13 10:32:23.257     0     0 I SELinux : policy capability genfs_seclabel_symlinks=0
+12-13 10:32:23.376    20    20 I auditd  : type=1403 audit(0.0:2): auid=4294967295 ses=4294967295 lsm=selinux res=1
+12-13 10:32:23.376    20    20 W auditd  : type=1403 audit(0.0:2): auid=4294967295 ses=4294967295 lsm=selinux res=1
+12-13 10:32:23.376    20    20 I auditd  : type=1404 audit(0.0:3): enforcing=1 old_enforcing=0 auid=4294967295 ses=4294967295 enabled=1 old-enabled=1 lsm=selinux res=1
+12-13 10:32:23.376    20    20 W auditd  : type=1404 audit(0.0:3): enforcing=1 old_enforcing=0 auid=4294967295 ses=4294967295 enabled=1 old-enabled=1 lsm=selinux res=1
+12-13 10:32:23.385     0     0 I selinux : SELinux: Loaded policy from /vendor/etc/selinux/precompiled_sepolicy
+12-13 10:32:23.386     0     0 I selinux :  
+12-13 10:32:23.427     0     0 I selinux : SELinux: Loaded file_contexts
+12-13 10:32:23.427     0     0 I selinux :  
+12-13 10:32:23.440     0     0 I init    : init second stage started!
+12-13 10:32:23.457     0     0 I init    : Using Android DT directory /proc/device-tree/firmware/android/
+12-13 10:32:23.460     0     0 W init    : Overriding previous 'ro.' property 'ro.dalvik.vm.native.bridge':'0' with new value 'libhoudini.so'
+12-13 10:32:23.463     0     0 W init    : Couldn't load property file '/factory/factory.prop': open() failed: No such file or directory: No such file or directory
+12-13 10:32:23.465     0     0 I init    : Setting product property ro.product.brand to 'Windows' (from ro.product.product.brand)
+12-13 10:32:23.465     0     0 I init    : Setting product property ro.product.device to 'windows_x86_64' (from ro.product.product.device)
+12-13 10:32:23.465     0     0 I init    : Setting product property ro.product.manufacturer to 'Microsoft Corporation' (from ro.product.product.manufacturer)
+12-13 10:32:23.465     0     0 I init    : Setting product property ro.product.model to 'Subsystem for Android(TM)' (from ro.product.product.model)
+12-13 10:32:23.465     0     0 I init    : Setting product property ro.product.name to 'windows_x86_64' (from ro.product.product.name)
+12-13 10:32:23.465     0     0 I init    : Setting property 'ro.build.fingerprint' to 'Windows/windows_x86_64/windows_x86_64:11/RD2A.211001.002/eng.latteu.20211023.051150:userdebug/test-keys'
+12-13 10:32:23.466     0     0 I selinux : SELinux: Loaded file_contexts
+12-13 10:32:23.466     0     0 I selinux :  
+12-13 10:32:23.466     0     0 I init    : Running restorecon...
+12-13 10:32:23.468     0     0 E selinux : SELinux: Could not get canonical path for /metadata/ota/rollback-indicator restorecon: No such file or directory.
+12-13 10:32:23.469     0     0 E selinux :  
+12-13 10:32:23.470     0     0 E selinux : SELinux:  Could not stat /metadata/gsi: No such file or directory.
+12-13 10:32:23.470     0     0 E selinux :  
+12-13 10:32:23.471     0     0 I init    : Created socket '/dev/socket/property_service', mode 666, user 0, group 0
+12-13 10:32:23.482     0     0 I init    : SetupMountNamespaces done
+12-13 10:32:23.482     0     0 I init    : Forked subcontext for 'u:r:vendor_init:s0' with pid 3
+12-13 10:32:23.483     0     0 I init    : Parsing file /system/etc/init/hw/init.rc...
+12-13 10:32:23.484     0     0 I init    : Added '/init.environ.rc' to import list
+12-13 10:32:23.484     0     0 I init    : Added '/system/etc/init/hw/init.usb.rc' to import list
+12-13 10:32:23.484     0     0 I init    : Added '/init.windows_x86_64.rc' to import list
+12-13 10:32:23.484     0     0 I init    : Added '/vendor/etc/init/hw/init.windows_x86_64.rc' to import list
+12-13 10:32:23.484     0     0 I init    : Added '/system/etc/init/hw/init.usb.configfs.rc' to import list
+12-13 10:32:23.484     0     0 I init    : Added '/system/etc/init/hw/init.zygote64_32.rc' to import list
+12-13 10:32:23.485     0     0 I init    : Parsing file /init.environ.rc...
+12-13 10:32:23.485     0     0 I init    : Parsing file /system/etc/init/hw/init.usb.rc...
+12-13 10:32:23.485     0     0 I init    : Parsing file /init.windows_x86_64.rc...
+12-13 10:32:23.485     0     0 I init    : Unable to read config file '/init.windows_x86_64.rc': open() failed: No such file or directory
+12-13 10:32:23.485     0     0 I init    : Parsing file /vendor/etc/init/hw/init.windows_x86_64.rc...
+12-13 10:32:23.486     0     0 I init    : Unable to read config file '/vendor/etc/init/hw/init.windows_x86_64.rc': open() failed: No such file or directory
+12-13 10:32:23.486     0     0 I init    : Parsing file /system/etc/init/hw/init.usb.configfs.rc...
+12-13 10:32:23.486     0     0 I init    : Parsing file /system/etc/init/hw/init.zygote64_32.rc...
+12-13 10:32:23.486     0     0 I init    : Parsing directory /system/etc/init...
+12-13 10:32:23.486     0     0 I init    : Parsing file /system/etc/init/android.hidl.allocator@1.0-service.rc...
+12-13 10:32:23.486     0     0 I init    : Parsing file /system/etc/init/android.system.suspend@1.0-service.rc...
+12-13 10:32:23.486     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.487     0     0 I init    : Parsing file /system/etc/init/apexd.rc...
+12-13 10:32:23.488     0     0 I init    : Parsing file /system/etc/init/atrace.rc...
+12-13 10:32:23.488     0     0 I init    : Parsing file /system/etc/init/atrace_userdebug.rc...
+12-13 10:32:23.488     0     0 I init    : Parsing file /system/etc/init/audioserver.rc...
+12-13 10:32:23.488     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.489     0     0 I init    : Parsing file /system/etc/init/blank_screen.rc...
+12-13 10:32:23.489     0     0 I init    : Parsing file /system/etc/init/bootanim.rc...
+12-13 10:32:23.489     0     0 I init    : Parsing file /system/etc/init/bootstat-debug.rc...
+12-13 10:32:23.489     0     0 I init    : Parsing file /system/etc/init/bootstat.rc...
+12-13 10:32:23.489     0     0 I init    : Parsing file /system/etc/init/bpfloader.rc...
+12-13 10:32:23.490     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.490     0     0 I init    : Parsing file /system/etc/init/cameraserver.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/clean_scratch_files.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/credstore.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/drmserver.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/dumpstate.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/flags_health_check.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/gatekeeperd.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/gpuservice.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/gsid.rc...
+12-13 10:32:23.491     0     0 I init    : Parsing file /system/etc/init/heapprofd.rc...
+12-13 10:32:23.491     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.492     0     0 I init    : Parsing file /system/etc/init/hwservicemanager.rc...
+12-13 10:32:23.492     0     0 I init    : Parsing file /system/etc/init/idmap2d.rc...
+12-13 10:32:23.492     0     0 I init    : Parsing file /system/etc/init/incidentd.rc...
+12-13 10:32:23.492     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.493     0     0 I init    : Parsing file /system/etc/init/init-debug.rc...
+12-13 10:32:23.493     0     0 I init    : Parsing file /system/etc/init/installd.rc...
+12-13 10:32:23.493     0     0 I init    : Parsing file /system/etc/init/iorapd.rc...
+12-13 10:32:23.493     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.494     0     0 I init    : Parsing file /system/etc/init/keystore.rc...
+12-13 10:32:23.494     0     0 I init    : Parsing file /system/etc/init/llkd-debuggable.rc...
+12-13 10:32:23.494     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.495     0     0 I init    : Parsing file /system/etc/init/llkd.rc...
+12-13 10:32:23.495     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.496     0     0 I init    : Parsing file /system/etc/init/lmkd.rc...
+12-13 10:32:23.496     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.497     0     0 I init    : Parsing file /system/etc/init/logcatd.rc...
+12-13 10:32:23.497     0     0 I init    : Parsing file /system/etc/init/logd.rc...
+12-13 10:32:23.497     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.498     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/logtagd.rc...
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/lpdumpd.rc...
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/mdnsd.rc...
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/mediaextractor.rc...
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/mediametrics.rc...
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/mediaserver.rc...
+12-13 10:32:23.499     0     0 I init    : Parsing file /system/etc/init/mtpd.rc...
+12-13 10:32:23.499     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.500     0     0 I init    : Parsing file /system/etc/init/netd.rc...
+12-13 10:32:23.500     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.501     0     0 I init    : Parsing file /system/etc/init/perfetto.rc...
+12-13 10:32:23.501     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.501     0     0 I init    : Parsing file /system/etc/init/racoon.rc...
+12-13 10:32:23.501     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.502     0     0 I init    : Parsing file /system/etc/init/recovery-persist.rc...
+12-13 10:32:23.502     0     0 I init    : Parsing file /system/etc/init/rss_hwm_reset.rc...
+12-13 10:32:23.502     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.503     0     0 I init    : Parsing file /system/etc/init/servicemanager.rc...
+12-13 10:32:23.503     0     0 I init    : Parsing file /system/etc/init/storaged.rc...
+12-13 10:32:23.503     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.504     0     0 I init    : Parsing file /system/etc/init/surfaceflinger.rc...
+12-13 10:32:23.504     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.505     0     0 I init    : Parsing file /system/etc/init/tombstoned.rc...
+12-13 10:32:23.505     0     0 I init    : Parsing file /system/etc/init/traced_perf.rc...
+12-13 10:32:23.505     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.506   188   188 I auditd  : type=1400 audit(0.0:4): avc: denied { perfmon } for comm="init" capability=38 scontext=u:r:init:s0 tcontext=u:r:init:s0 tclass=capability2 permissive=0
+12-13 10:32:23.506   188   188 W init    : type=1400 audit(0.0:4): avc: denied { perfmon } for capability=38 scontext=u:r:init:s0 tcontext=u:r:init:s0 tclass=capability2 permissive=0
+12-13 10:32:23.506     0     0 I init    : Parsing file /system/etc/init/traceur.rc...
+12-13 10:32:23.506     0     0 I init    : Parsing file /system/etc/init/uncrypt.rc...
+12-13 10:32:23.506     0     0 I init    : Parsing file /system/etc/init/usbd.rc...
+12-13 10:32:23.506     0     0 I init    : Parsing file /system/etc/init/vdc.rc...
+12-13 10:32:23.506     0     0 I init    : Parsing file /system/etc/init/vold.rc...
+12-13 10:32:23.506     0     0 I init    : Parsing file /system/etc/init/wait_for_keymaster.rc...
+12-13 10:32:23.507     0     0 I init    : Parsing file /system/etc/init/wifi.rc...
+12-13 10:32:23.507     0     0 I init    : Parsing file /system/etc/init/wificond.rc...
+12-13 10:32:23.507     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.507     0     0 I init    : Parsing file /system_ext/etc/init...
+12-13 10:32:23.507     0     0 I init    : Unable to read config file '/system_ext/etc/init': open() failed: No such file or directory
+12-13 10:32:23.507     0     0 I init    : Parsing directory /product/etc/init...
+12-13 10:32:23.507     0     0 I init    : Parsing file /product/etc/init/diagnostics_service.rc...
+12-13 10:32:23.508     0     0 I init    : Parsing file /product/etc/init/windows.services.rcm@1.0-service.rc...
+12-13 10:32:23.508     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.508     0     0 I init    : Parsing file /odm/etc/init...
+12-13 10:32:23.508     0     0 I init    : Unable to read config file '/odm/etc/init': open() failed: No such file or directory
+12-13 10:32:23.508     0     0 I init    : Parsing directory /vendor/etc/init...
+12-13 10:32:23.508     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.audio.service.rc...
+12-13 10:32:23.508     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.509     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.cas@1.2-service.rc...
+12-13 10:32:23.509     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.drm@1.3-service.clearkey.rc...
+12-13 10:32:23.509     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.gatekeeper@1.0-service.software.rc...
+12-13 10:32:23.509     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.graphics.allocator@2.0-service.rc...
+12-13 10:32:23.509     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.510     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.health@2.1-service.rc...
+12-13 10:32:23.510     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.511     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.keymaster@4.1-service.rc...
+12-13 10:32:23.511     0     0 I init    : Parsing file /vendor/etc/init/android.hardware.media.omx@1.0-service.rc...
+12-13 10:32:23.511     0     0 I init    : Parsing file /vendor/etc/init/boringssl_self_test.rc...
+12-13 10:32:23.511     0     0 I init    : Parsing file /vendor/etc/init/camera-service.windows.rc...
+12-13 10:32:23.512     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.512     0     0 I init    : Parsing file /vendor/etc/init/gnss-service.windows.rc...
+12-13 10:32:23.512     0     0 I init    : Parsing file /vendor/etc/init/hwcomposer-service.windows.rc...
+12-13 10:32:23.512     0     0 W init    : last valid run-time capability is larger than CAP_LAST_CAP
+12-13 10:32:23.513     0     0 I init    : Parsing file /vendor/etc/init/init.windows_x86_64.rc...
+12-13 10:32:23.513     0     0 I init    : Added 'logcat.windows.rc' to import list
+12-13 10:32:23.513     0     0 I init    : Parsing file logcat.windows.rc...
+12-13 10:32:23.513     0     0 I init    : Unable to read config file 'logcat.windows.rc': open() failed: No such file or directory
+12-13 10:32:23.513     0     0 I init    : Parsing file /vendor/etc/init/inputsvc.rc...
+12-13 10:32:23.513     0     0 I init    : Parsing file /vendor/etc/init/logcat.windows.rc...
+12-13 10:32:23.513     0     0 I init    : Parsing file /vendor/etc/init/power-service.windows.rc...
+12-13 10:32:23.514     0     0 I init    : Parsing file /vendor/etc/init/vendor_flash_recovery.rc...
+12-13 10:32:23.514     0     0 I init    : Parsing file /vendor/etc/init/wait_for_rcm.rc...
+12-13 10:32:23.514     0     0 I init    : processing action (SetupCgroups) from (<Builtin Action>:0)
+12-13 10:32:23.516     0     0 E libprocessgroup: restored ownership for cgroup2 cgroup
+12-13 10:32:23.517     0     0 E cgroup  : Unknown subsys name 'schedtune'
+12-13 10:32:23.518     0     0 E libprocessgroup: Failed to mount schedtune cgroup: Invalid argument
+12-13 10:32:23.518     0     0 W libprocessgroup: Failed to setup schedtune cgroup
+12-13 10:32:23.520     0     0 I init    : processing action (SetKptrRestrict) from (<Builtin Action>:0)
+12-13 10:32:23.521     0     0 I init    : processing action (TestPerfEventSelinux) from (<Builtin Action>:0)
+12-13 10:32:23.521     0     0 I init    : processing action (early-init) from (/system/etc/init/hw/init.rc:15)
+12-13 10:32:23.525     0     0 I init    : starting service 'exec 1 (/system/bin/linkerconfig --target /linkerconfig/bootstrap)'...
+12-13 10:32:23.526     0     0 I init    : SVC_EXEC service 'exec 1 (/system/bin/linkerconfig --target /linkerconfig/bootstrap)' pid 4 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:23.541     0     0 I         : linkerconfig (195) used greatest stack depth: 13040 bytes left
+12-13 10:32:23.541     0     0 I init    : Service 'exec 1 (/system/bin/linkerconfig --target /linkerconfig/bootstrap)' (pid 4) exited with status 0 waiting took 0.015000 seconds
+12-13 10:32:23.541     0     0 I init    : Sending signal 9 to service 'exec 1 (/system/bin/linkerconfig --target /linkerconfig/bootstrap)' (pid 4) process group...
+12-13 10:32:23.541     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 4 in 0ms
+12-13 10:32:23.542     0     0 I init    : starting service 'ueventd'...
+12-13 10:32:23.544     0     0 I init    : starting service 'apexd-bootstrap'...
+12-13 10:32:23.545     0     0 I init    : SVC_EXEC service 'apexd-bootstrap' pid 6 (uid 0 gid 1000+0 context default) started; waiting...
+12-13 10:32:23.555     0     0 I ueventd : ueventd started!
+12-13 10:32:23.556     0     0 I selinux : SELinux: Loaded file_contexts
+12-13 10:32:23.556     0     0 I selinux :  
+12-13 10:32:23.556     0     0 I ueventd : Parsing file /system/etc/ueventd.rc...
+12-13 10:32:23.557     0     0 I ueventd : Parsing file /vendor/ueventd.rc...
+12-13 10:32:23.557     0     0 I ueventd : Parsing file /odm/ueventd.rc...
+12-13 10:32:23.557     0     0 I ueventd : Unable to read config file '/odm/ueventd.rc': open() failed: No such file or directory
+12-13 10:32:23.557     0     0 I ueventd : Parsing file /ueventd.windows_x86_64.rc...
+12-13 10:32:23.557     0     0 I ueventd : Unable to read config file '/ueventd.windows_x86_64.rc': open() failed: No such file or directory
+12-13 10:32:23.595     0     0 I ueventd : Coldboot took 0.036 seconds
+12-13 10:32:23.596     0     0 I apexd   : This device does not support updatable APEX. Exiting
+12-13 10:32:23.597     0     0 I init    : Service 'apexd-bootstrap' (pid 6) exited with status 0 waiting took 0.053000 seconds
+12-13 10:32:23.597     0     0 I init    : Sending signal 9 to service 'apexd-bootstrap' (pid 6) process group...
+12-13 10:32:23.597     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 6 in 0ms
+12-13 10:32:23.599     0     0 I init    : processing action (ro.product.cpu.abilist32=* && early-init) from (/system/etc/init/hw/init.rc:85)
+12-13 10:32:23.599     0     0 I init    : starting service 'boringssl_self_test32'...
+12-13 10:32:23.600     0     0 I init    : SVC_EXEC service 'boringssl_self_test32' pid 16 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:23.649     0     0 I init    : Service 'boringssl_self_test32' (pid 16) exited with status 0 waiting took 0.050000 seconds
+12-13 10:32:23.649     0     0 I init    : Sending signal 9 to service 'boringssl_self_test32' (pid 16) process group...
+12-13 10:32:23.649     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 16 in 0ms
+12-13 10:32:23.650     0     0 I init    : processing action (ro.product.cpu.abilist64=* && early-init) from (/system/etc/init/hw/init.rc:87)
+12-13 10:32:23.650     0     0 I init    : starting service 'boringssl_self_test64'...
+12-13 10:32:23.651     0     0 I init    : SVC_EXEC service 'boringssl_self_test64' pid 17 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:23.676     0     0 I init    : Service 'boringssl_self_test64' (pid 17) exited with status 0 waiting took 0.025000 seconds
+12-13 10:32:23.676     0     0 I init    : Sending signal 9 to service 'boringssl_self_test64' (pid 17) process group...
+12-13 10:32:23.676     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 17 in 0ms
+12-13 10:32:23.676     0     0 I init    : processing action (early-init) from (/init.environ.rc:2)
+12-13 10:32:23.676     0     0 I init    : processing action (ro.product.cpu.abilist32=* && early-init) from (/vendor/etc/init/boringssl_self_test.rc:2)
+12-13 10:32:23.677     0     0 I init    : starting service 'boringssl_self_test32_vendor'...
+12-13 10:32:23.678     0     0 I init    : SVC_EXEC service 'boringssl_self_test32_vendor' pid 18 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:23.700     0     0 I init    : Service 'boringssl_self_test32_vendor' (pid 18) exited with status 0 waiting took 0.022000 seconds
+12-13 10:32:23.700     0     0 I init    : Sending signal 9 to service 'boringssl_self_test32_vendor' (pid 18) process group...
+12-13 10:32:23.700     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 18 in 0ms
+12-13 10:32:23.700     0     0 I init    : processing action (ro.product.cpu.abilist64=* && early-init) from (/vendor/etc/init/boringssl_self_test.rc:4)
+12-13 10:32:23.701     0     0 I init    : starting service 'boringssl_self_test64_vendor'...
+12-13 10:32:23.702     0     0 I init    : SVC_EXEC service 'boringssl_self_test64_vendor' pid 19 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:23.725     0     0 I init    : Service 'boringssl_self_test64_vendor' (pid 19) exited with status 0 waiting took 0.023000 seconds
+12-13 10:32:23.725     0     0 I init    : Sending signal 9 to service 'boringssl_self_test64_vendor' (pid 19) process group...
+12-13 10:32:23.725     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 19 in 0ms
+12-13 10:32:23.725     0     0 I init    : processing action (early-init) from (/vendor/etc/init/init.windows_x86_64.rc:1)
+12-13 10:32:23.727     0     0 I init    : processing action (wait_for_coldboot_done) from (<Builtin Action>:0)
+12-13 10:32:23.727     0     0 I init    : start_waiting_for_property("ro.cold_boot_done", "true"): already set
+12-13 10:32:23.727     0     0 I init    : processing action (MixHwrngIntoLinuxRng) from (<Builtin Action>:0)
+12-13 10:32:23.727     0     0 I init    : /dev/hw_random not found
+12-13 10:32:23.727     0     0 I init    : processing action (SetMmapRndBits) from (<Builtin Action>:0)
+12-13 10:32:23.727     0     0 I init    : processing action (KeychordInit) from (<Builtin Action>:0)
+12-13 10:32:23.727     0     0 I init    : processing action (init) from (/system/etc/init/hw/init.rc:114)
+12-13 10:32:23.729     0     0 I init    : Command 'write /dev/blkio/blkio.weight 1000' action=init (/system/etc/init/hw/init.rc:164) took 0ms and failed: Unable to write to file '/dev/blkio/blkio.weight': open() failed: Permission denied
+12-13 10:32:23.729     0     0 I init    : Command 'write /dev/blkio/background/blkio.weight 200' action=init (/system/etc/init/hw/init.rc:165) took 0ms and failed: Unable to write to file '/dev/blkio/background/blkio.weight': open() failed: Permission denied
+12-13 10:32:23.729     0     0 I init    : Command 'write /dev/blkio/blkio.group_idle 0' action=init (/system/etc/init/hw/init.rc:166) took 0ms and failed: Unable to write to file '/dev/blkio/blkio.group_idle': open() failed: Permission denied
+12-13 10:32:23.729     0     0 I init    : Command 'write /dev/blkio/background/blkio.group_idle 0' action=init (/system/etc/init/hw/init.rc:167) took 0ms and failed: Unable to write to file '/dev/blkio/background/blkio.group_idle': open() failed: Permission denied
+12-13 10:32:23.733     0     0 I init    : Command 'write /dev/cpuctl/cpu.rt_period_us 1000000' action=init (/system/etc/init/hw/init.rc:271) took 0ms and failed: Unable to write to file '/dev/cpuctl/cpu.rt_period_us': open() failed: Permission denied
+12-13 10:32:23.733     0     0 I init    : Command 'write /dev/cpuctl/cpu.rt_runtime_us 950000' action=init (/system/etc/init/hw/init.rc:272) took 0ms and failed: Unable to write to file '/dev/cpuctl/cpu.rt_runtime_us': open() failed: Permission denied
+12-13 10:32:23.736     0     0 I init    : Command 'write /dev/cpu_variant:${ro.bionic.arch} ${ro.bionic.cpu_variant}' action=init (/system/etc/init/hw/init.rc:370) took 0ms and failed: property 'ro.bionic.cpu_variant' doesn't exist while expanding '${ro.bionic.cpu_variant}'
+12-13 10:32:23.736     0     0 I init    : Command 'write /dev/cpu_variant:${ro.bionic.2nd_arch} ${ro.bionic.2nd_cpu_variant}' action=init (/system/etc/init/hw/init.rc:372) took 0ms and failed: property 'ro.bionic.2nd_cpu_variant' doesn't exist while expanding '${ro.bionic.2nd_cpu_variant}'
+12-13 10:32:23.736     0     0 I init    : starting service 'logd'...
+12-13 10:32:23.736     0     0 I init    : Created socket '/dev/socket/logd', mode 666, user 1036, group 1036
+12-13 10:32:23.736     0     0 I init    : Created socket '/dev/socket/logdr', mode 666, user 1036, group 1036
+12-13 10:32:23.736     0     0 I init    : Created socket '/dev/socket/logdw', mode 222, user 1036, group 1036
+12-13 10:32:23.736     0     0 I init    : Opened file '/proc/kmsg', flags 0
+12-13 10:32:23.737     0     0 I init    : Opened file '/dev/kmsg', flags 1
+12-13 10:32:23.738     0     0 I init    : starting service 'lmkd'...
+12-13 10:32:23.738     0     0 I init    : Created socket '/dev/socket/lmkd', mode 660, user 1000, group 1000
+12-13 10:32:23.740     0     0 I init    : starting service 'servicemanager'...
+12-13 10:32:23.741     0     0 I init    : starting service 'hwservicemanager'...
+12-13 10:32:23.742     0     0 I init    : Command 'start vndservicemanager' action=init (/system/etc/init/hw/init.rc:397) took 0ms and failed: service vndservicemanager not found
+12-13 10:32:23.742     0     0 I init    : processing action (ro.debuggable=1 && init) from (/system/etc/init/hw/init.rc:1053)
+12-13 10:32:23.742     0     0 I init    : starting service 'console'...
+12-13 10:32:23.744     0     0 I init    : processing action (init) from (/system/etc/init/hw/init.usb.rc:24)
+12-13 10:32:23.744     0     0 I init    : processing action (init) from (/system/etc/init/audioserver.rc:56)
+12-13 10:32:23.744    21    21 I lowmemorykiller: Using psi monitors for memory pressure detection
+12-13 10:32:23.745     0     0 I init    : processing action (init) from (/vendor/etc/init/init.windows_x86_64.rc:9)
+12-13 10:32:23.745    21    21 I lowmemorykiller: Process polling is supported
+12-13 10:32:23.747     0     0 I init    : processing action (MixHwrngIntoLinuxRng) from (<Builtin Action>:0)
+12-13 10:32:23.748     0     0 I init    : /dev/hw_random not found
+12-13 10:32:23.748     0     0 I init    : processing action (late-init) from (/system/etc/init/hw/init.rc:415)
+12-13 10:32:23.748     0     0 I init    : processing action (late-init) from (/system/etc/init/atrace.rc:3)
+12-13 10:32:23.752     0     0 I init    : processing action (queue_property_triggers) from (<Builtin Action>:0)
+12-13 10:32:23.752     0     0 I init    : processing action (early-fs) from (/system/etc/init/hw/init.rc:451)
+12-13 10:32:23.752     0     0 I init    : starting service 'vold'...
+12-13 10:32:23.753     0     0 I logd.auditd: start
+12-13 10:32:23.753     0     0 I init    : processing action (fs) from (/system/etc/init/logd.rc:28)
+12-13 10:32:23.754     0     0 I init    : processing action (fs) from (/system/etc/init/wifi.rc:25)
+12-13 10:32:23.754     0     0 I init    : processing action (fs) from (/vendor/etc/init/init.windows_x86_64.rc:13)
+12-13 10:32:23.755     0     0 I init    : Calling: /system/bin/vdc checkpoint restoreCheckpoint /dev/block/sda
+12-13 10:32:23.758    22    22 I snet_event_log: [121035042,-1,]
+12-13 10:32:23.760    22    22 I SELinux : SELinux: Loaded service_contexts from:
+12-13 10:32:23.760    22    22 I auditd  : SELinux: Loaded service_contexts from:
+12-13 10:32:23.760    22    22 I SELinux :     /system/etc/selinux/plat_service_contexts
+12-13 10:32:23.760    22    22 I auditd  :     /system/etc/selinux/plat_service_contexts
+12-13 10:32:23.760    22    22 I SELinux :     /system_ext/etc/selinux/system_ext_service_contexts
+12-13 10:32:23.760    22    22 I auditd  :     /system_ext/etc/selinux/system_ext_service_contexts
+12-13 10:32:23.760    22    22 I SELinux :     /product/etc/selinux/product_service_contexts
+12-13 10:32:23.760    22    22 I auditd  :     /product/etc/selinux/product_service_contexts
+12-13 10:32:23.760    22    22 I SELinux :     /vendor/etc/selinux/vendor_service_contexts
+12-13 10:32:23.760    22    22 I auditd  :     /vendor/etc/selinux/vendor_service_contexts
+12-13 10:32:23.768    23    23 I hwservicemanager: hwservicemanager is ready now.
+--------- beginning of system
+12-13 10:32:23.791    26    26 I vold    : Vold 3.0 (the awakening) firing up
+12-13 10:32:23.792    26    26 D vold    : Detected support for: ext4 f2fs vfat
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop5: No such device or address
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop0: No such device or address
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop13: No such device or address
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop4: No such device or address
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop10: No such device or address
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop1: No such device or address
+12-13 10:32:23.793    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop14: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop2: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop6: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop3: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop11: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop15: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop12: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop7: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop9: No such device or address
+12-13 10:32:23.794    26    26 W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop8: No such device or address
+12-13 10:32:23.796    26    26 D vold    : VoldNativeService::start() completed OK
+12-13 10:32:23.804    26    26 I Checkpoint: Validating checkpoint on /dev/block/sda
+12-13 10:32:23.807     0     0 D vdc     : Waited 40ms for vold
+12-13 10:32:23.822    26    26 E Checkpoint: No magic
+12-13 10:32:23.825     0     0 E vdc     : Command: checkpoint restoreCheckpoint /dev/block/sda Failed: Status(-8, EX_SERVICE_SPECIFIC): '22: No magic'
+12-13 10:32:23.827     0     0 I vdc     : vdc terminated by exit(25)
+12-13 10:32:23.827     0     0 I vdc     :  
+12-13 10:32:23.827     0     0 E init    : vdc call failed with error code: 25
+12-13 10:32:23.828     0     0 I init    : Calling: /system/bin/vdc checkpoint needsCheckpoint
+12-13 10:32:23.832    23    23 E cutils-trace: Error opening trace file: Permission denied (13)
+12-13 10:32:23.833    23    23 I hwservicemanager: getFrameworkHalManifest: Reading VINTF information.
+12-13 10:32:23.834     0     0 D vdc     : Waited 0ms for vold
+12-13 10:32:23.838    23    23 I hwservicemanager: getFrameworkHalManifest: Successfully processed VINTF information
+12-13 10:32:23.838    23    23 I hwservicemanager: getDeviceHalManifest: Reading VINTF information.
+12-13 10:32:23.839    23    23 I hwservicemanager: getDeviceHalManifest: Successfully processed VINTF information
+12-13 10:32:23.839    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.boot@1.0::IBootControl/default in either framework or device manifest.
+12-13 10:32:23.895     0     0 I init    : [libfs_mgr]superblock s_max_mnt_count:65535,/dev/block/sda
+12-13 10:32:23.995     0     0 W EXT4-fs (sda): Ignoring removed nomblk_io_submit option
+12-13 10:32:23.996     0     0 I EXT4-fs (sda): Using encoding defined by superblock: utf8-12.1.0 with flags 0x0
+12-13 10:32:24.397     0     0 I EXT4-fs (sda): mounted filesystem with ordered data mode. Opts: errors=remount-ro,nomblk_io_submit
+12-13 10:32:24.397     0     0 I init    : [libfs_mgr]check_fs(): mount(/dev/block/sda,/data,ext4)=0: Success
+12-13 10:32:24.678     0     0 I init    : [libfs_mgr]check_fs(): unmount(/data) succeeded
+12-13 10:32:24.679     0     0 I init    : [libfs_mgr]Running /system/bin/e2fsck on /dev/block/sda
+12-13 10:32:24.724     0     0 I e2fsck  : e2fsck 1.45.4 (23-Sep-2019)
+12-13 10:32:24.782     0     0 I e2fsck  : data: clean, 13438/8388608 files, 2169335/33554432 blocks
+12-13 10:32:24.792     0     0 I init    : [libfs_mgr]superblock s_max_mnt_count:65535,/dev/block/sda
+12-13 10:32:24.793     0     0 I EXT4-fs (sda): Using encoding defined by superblock: utf8-12.1.0 with flags 0x0
+12-13 10:32:24.804     0     0 I EXT4-fs (sda): mounted filesystem with ordered data mode. Opts: discard,errors=panic
+12-13 10:32:24.804     0     0 I init    : [libfs_mgr]__mount(source=/dev/block/sda,target=/data,type=ext4)=0: Success
+12-13 10:32:24.805     0     0 I init    : [libfs_mgr]/data is file encrypted
+12-13 10:32:24.805     0     0 I init    : [libfs_mgr]__mount(source=none,target=/cache,type=tmpfs)=0: Success
+12-13 10:32:24.805     0     0 I init    : [libfs_mgr]__mount(source=latte,target=/mnt/shared_mem,type=virtiofs)=0: Success
+12-13 10:32:24.808     0     0 I init    : Keyring created with id 536555016 in process 1
+12-13 10:32:24.808     0     0 I init    : Command 'mount_all /fstab.${ro.hardware}' action=fs (/vendor/etc/init/init.windows_x86_64.rc:14) took 1054ms and succeeded
+12-13 10:32:24.833     0     0 I init    : starting service 'label_virtio_ports'...
+12-13 10:32:24.835     0     0 I init    : SVC_EXEC service 'label_virtio_ports' pid 38 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:24.838    38    38 I virtio_ports_create_links: Completed successfully.
+12-13 10:32:24.842     0     0 I init    : Service 'label_virtio_ports' (pid 38) exited with status 0 waiting took 0.008000 seconds
+12-13 10:32:24.842     0     0 I init    : Sending signal 9 to service 'label_virtio_ports' (pid 38) process group...
+12-13 10:32:24.843     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 38 in 0ms
+12-13 10:32:24.843     0     0 I init    : starting service 'disable_lro'...
+12-13 10:32:24.844     0     0 I init    : processing action (post-fs) from (/system/etc/init/hw/init.rc:455)
+12-13 10:32:24.845     0     0 I init    : starting service 'exec 2 (/system/bin/vdc checkpoint markBootAttempt)'...
+12-13 10:32:24.845     0     0 I init    : SVC_EXEC service 'exec 2 (/system/bin/vdc checkpoint markBootAttempt)' pid 40 (uid 1000 gid 1000+0 context default) started; waiting...
+12-13 10:32:24.846    39    39 I disable_lro: LRO is disabled
+12-13 10:32:24.850     0     0 I init    : Service 'disable_lro' (pid 39) exited with status 0 oneshot service took 0.006000 seconds in background
+12-13 10:32:24.850     0     0 I init    : Sending signal 9 to service 'disable_lro' (pid 39) process group...
+12-13 10:32:24.851     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 39 in 0ms
+12-13 10:32:24.854     0     0 I init    : Service 'exec 2 (/system/bin/vdc checkpoint markBootAttempt)' (pid 40) exited with status 0 waiting took 0.008000 seconds
+12-13 10:32:24.854     0     0 I init    : Sending signal 9 to service 'exec 2 (/system/bin/vdc checkpoint markBootAttempt)' (pid 40) process group...
+12-13 10:32:24.854     0     0 I libprocessgroup: Successfully killed process cgroup uid 1000 pid 40 in 0ms
+12-13 10:32:24.857     0     0 E selinux : SELinux:  setxattr failed: /metadata:  Read-only file system
+12-13 10:32:24.858     0     0 E selinux :  
+12-13 10:32:24.858     0     0 I init    : Command 'mkdir /metadata/vold' action=post-fs (/system/etc/init/hw/init.rc:502) took 0ms and failed: mkdir() failed on /metadata/vold: Read-only file system
+12-13 10:32:24.858     0     0 I init    : Command 'mkdir /metadata/password_slots 0771 root system' action=post-fs (/system/etc/init/hw/init.rc:504) took 0ms and failed: mkdir() failed on /metadata/password_slots: Read-only file system
+12-13 10:32:24.858     0     0 I init    : Command 'mkdir /metadata/bootstat 0750 system log' action=post-fs (/system/etc/init/hw/init.rc:505) took 0ms and failed: mkdir() failed on /metadata/bootstat: Read-only file system
+12-13 10:32:24.858     0     0 I init    : Command 'mkdir /metadata/ota 0700 root system' action=post-fs (/system/etc/init/hw/init.rc:506) took 0ms and failed: mkdir() failed on /metadata/ota: Read-only file system
+12-13 10:32:24.858     0     0 I init    : Command 'mkdir /metadata/apex 0700 root system' action=post-fs (/system/etc/init/hw/init.rc:509) took 0ms and failed: mkdir() failed on /metadata/apex: Read-only file system
+12-13 10:32:24.858     0     0 E selinux : SELinux:  Could not stat /metadata/apex: No such file or directory.
+12-13 10:32:24.859     0     0 E selinux :  
+12-13 10:32:24.859     0     0 I init    : Command 'mkdir /metadata/staged-install 0770 root system' action=post-fs (/system/etc/init/hw/init.rc:518) took 0ms and failed: mkdir() failed on /metadata/staged-install: Read-only file system
+12-13 10:32:24.859     0     0 I init    : processing action (post-fs) from (/system/etc/init/atrace_userdebug.rc:7)
+12-13 10:32:24.859     0     0 I init    : processing action (post-fs) from (/system/etc/init/gsid.rc:8)
+12-13 10:32:24.860     0     0 I init    : Command 'mkdir /metadata/gsi 0771 root system' action=post-fs (/system/etc/init/gsid.rc:9) took 0ms and failed: mkdir() failed on /metadata/gsi: Read-only file system
+12-13 10:32:24.860     0     0 I init    : processing action (late-fs) from (/system/etc/init/hw/init.rc:519)
+12-13 10:32:24.860     0     0 I init    : starting service 'system_suspend'...
+12-13 10:32:24.862     0     0 I init    : starting service 'rcmsvc'...
+12-13 10:32:24.864     0     0 I init    : starting service 'vendor.keymaster-4-1'...
+12-13 10:32:24.865     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/hw/init.rc:528)
+12-13 10:32:24.865     0     0 I init    : starting service 'exec 3 (/system/bin/vdc checkpoint prepareCheckpoint)'...
+12-13 10:32:24.866     0     0 I init    : SVC_EXEC service 'exec 3 (/system/bin/vdc checkpoint prepareCheckpoint)' pid 44 (uid 1000 gid 1000+0 context default) started; waiting...
+12-13 10:32:24.869    26    26 I Checkpoint: cp_prepareCheckpoint called
+12-13 10:32:24.870    41    41 I HidlServiceManagement: Registered android.system.suspend@1.0::ISystemSuspend/default
+12-13 10:32:24.870    41    41 I HidlServiceManagement: Removing namespace from process name android.system.suspend@1.0-service to suspend@1.0-service.
+12-13 10:32:24.873     0     0 I init    : Service 'exec 3 (/system/bin/vdc checkpoint prepareCheckpoint)' (pid 44) exited with status 0 waiting took 0.007000 seconds
+12-13 10:32:24.873     0     0 I init    : Sending signal 9 to service 'exec 3 (/system/bin/vdc checkpoint prepareCheckpoint)' (pid 44) process group...
+12-13 10:32:24.874     0     0 I libprocessgroup: Successfully killed process cgroup uid 1000 pid 44 in 0ms
+12-13 10:32:24.875     0     0 I init    : starting service 'exec 4 (/system/bin/vdc --wait cryptfs enablefilecrypto)'...
+12-13 10:32:24.876     0     0 I init    : SVC_EXEC service 'exec 4 (/system/bin/vdc --wait cryptfs enablefilecrypto)' pid 47 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:24.880    26    26 I vold    : fscrypt_initialize_systemwide_keys
+12-13 10:32:24.881    26    26 D vold    : Key exists, using: /data/unencrypted/key
+12-13 10:32:24.883     0     0 D vdc     : Waited 0ms for vold
+12-13 10:32:24.885     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #280!!!
+12-13 10:32:24.886    23    23 I hwservicemanager: Since android.hardware.keymaster@4.0::IKeymasterDevice/default is not registered, trying to start it as a lazy HAL.
+12-13 10:32:24.887    23    23 I hwservicemanager: Since android.hardware.keymaster@4.0::IKeymasterDevice/default is not registered, trying to start it as a lazy HAL.
+12-13 10:32:24.887    26    26 I HidlServiceManagement: getService: Trying again for android.hardware.keymaster@4.0::IKeymasterDevice/default...
+12-13 10:32:24.891     0     0 I init    : Control message: Processed ctl.interface_start for 'android.hardware.keymaster@4.0::IKeymasterDevice/default' from pid: 23 (/system/bin/hwservicemanager)
+12-13 10:32:24.891     0     0 I init    : Control message: Processed ctl.interface_start for 'android.hardware.keymaster@4.0::IKeymasterDevice/default' from pid: 23 (/system/bin/hwservicemanager)
+12-13 10:32:24.899    43    43 I HidlServiceManagement: Registered android.hardware.keymaster@4.1::IKeymasterDevice/default
+12-13 10:32:24.899    42    42 I HidlServiceManagement: Registered windows.services.rcm@1.0::IRemoteConnectionManager/default
+12-13 10:32:24.900    43    43 I HidlServiceManagement: Removing namespace from process name android.hardware.keymaster@4.1-service to keymaster@4.1-service.
+12-13 10:32:24.900    42    42 I HidlServiceManagement: Removing namespace from process name windows.services.rcm@1.0-service to rcm@1.0-service.
+12-13 10:32:24.900    42    42 D RemoteConnectionManager: Initializing client connection.
+12-13 10:32:24.900    42    51 D librcm  : Waiting for client connection.
+12-13 10:32:24.901    23    23 I hw-BpHwBinder: onLastStrongRef automatically unlinking death recipients
+12-13 10:32:24.901    42    51 D windows.services.rcm@1.0-service: SocketClient connected to host port 35002
+12-13 10:32:24.901    42    51 D librcm  : Client has connected
+12-13 10:32:24.901    42    51 D librcm  : Starting receive loop
+12-13 10:32:24.902    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.keymaster@3.0::IKeymasterDevice/default in either framework or device manifest.
+12-13 10:32:24.903    26    26 I vold    : List of Keymaster HALs found:
+12-13 10:32:24.903    26    26 I vold    : Keymaster HAL #1: SoftwareKeymasterDevice from Google SecurityLevel: SOFTWARE HAL: android.hardware.keymaster@4.1::IKeymasterDevice/default
+12-13 10:32:24.904    26    26 D vold    : Computing HMAC with params { (seed: , nonce: 9629476b66175641a55caf57f511677ba52caa1b287424680568ed08958c22b) }
+12-13 10:32:24.904    26    26 D vold    : Computing HMAC for SoftwareKeymasterDevice from Google SecurityLevel: SOFTWARE HAL: android.hardware.keymaster@4.1::IKeymasterDevice/default
+12-13 10:32:24.904    26    26 I vold    : Using SoftwareKeymasterDevice from Google for encryption.  Security level: SOFTWARE, HAL: android.hardware.keymaster@4.1::IKeymasterDevice/default
+12-13 10:32:24.907    26    26 D vold    : Installed fscrypt key with ref ab821d9df022fa689c9fe7123d4648ab to /data
+12-13 10:32:24.907    26    26 D vold    : Added fscrypt-provisioning key for ab821d9df022fa689c9fe7123d4648ab to session keyring
+12-13 10:32:24.958    26    26 I vold    : Wrote system DE key reference to:/data/unencrypted/ref
+12-13 10:32:24.958    26    26 D vold    : Installed fscrypt key with ref f52e6a9f88161d08951df724bcdfd122 to /data
+12-13 10:32:24.958    26    26 D vold    : Added fscrypt-provisioning key for f52e6a9f88161d08951df724bcdfd122 to session keyring
+12-13 10:32:24.970    26    26 I vold    : Wrote per boot key reference to:/data/unencrypted/per_boot_ref
+12-13 10:32:24.974     0     0 I init    : Service 'exec 4 (/system/bin/vdc --wait cryptfs enablefilecrypto)' (pid 47) exited with status 0 waiting took 0.098000 seconds
+12-13 10:32:24.974     0     0 I init    : Sending signal 9 to service 'exec 4 (/system/bin/vdc --wait cryptfs enablefilecrypto)' (pid 47) process group...
+12-13 10:32:24.974     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 47 in 0ms
+12-13 10:32:24.975     0     0 I init    : Verified that /data/bootchart has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.976     0     0 I fscrypt : AES-256-CTS-CBC using implementation "cts(cbc-aes-aesni)"
+12-13 10:32:24.976     0     0 I init    : Switched to default mount namespace
+12-13 10:32:24.976     0     0 I init    : Not setting encryption policy on: /data/apex
+12-13 10:32:24.977     0     0 I init    : Not setting encryption policy on: /data/app-staging
+12-13 10:32:24.977     0     0 I init    : starting service 'apexd'...
+12-13 10:32:24.980     0     0 I fscrypt : AES-256-XTS using implementation "xts-aes-aesni"
+12-13 10:32:24.982     0     0 I init    : Verified that /data/misc has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.989     0     0 I init    : Verified that /data/local has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.990     0     0 I init    : Not setting encryption policy on: /data/preloads
+12-13 10:32:24.990     0     0 I apexd   : This device does not support updatable APEX. Exiting
+12-13 10:32:24.991     0     0 I apexd   : Marking APEXd as activated
+12-13 10:32:24.991     0     0 I init    : Verified that /data/vendor has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.991     0     0 I init    : Not setting encryption policy on: /data/vendor_ce
+12-13 10:32:24.991     0     0 I init    : Not setting encryption policy on: /data/vendor_de
+12-13 10:32:24.992     0     0 I init    : Service 'apexd' (pid 52) exited with status 0 oneshot service took 0.014000 seconds in background
+12-13 10:32:24.992     0     0 I init    : Sending signal 9 to service 'apexd' (pid 52) process group...
+12-13 10:32:24.992     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 52 in 0ms
+12-13 10:32:24.994     0     0 I init    : Not setting encryption policy on: /data/data
+12-13 10:32:24.995     0     0 I init    : Verified that /data/app-private has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.995     0     0 I init    : Verified that /data/app-ephemeral has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.996     0     0 I init    : Verified that /data/app-asec has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.996     0     0 I init    : Verified that /data/app-lib has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.997     0     0 I init    : Verified that /data/app has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.997     0     0 I init    : Verified that /data/property has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.997     0     0 I init    : Verified that /data/tombstones has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.998     0     0 I init    : Verified that /data/dalvik-cache has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.999     0     0 I init    : Verified that /data/ota has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.999     0     0 I init    : Verified that /data/ota_package has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:24.999     0     0 I init    : Verified that /data/resource-cache has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.000     0     0 I init    : Not setting encryption policy on: /data/lost+found
+12-13 10:32:25.000     0     0 I init    : Verified that /data/drm has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.000     0     0 I init    : Verified that /data/mediadrm has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.001     0     0 I init    : Verified that /data/anr has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.001     0     0 I init    : Verified that /data/nfc has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.002     0     0 I init    : Verified that /data/backup has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.002     0     0 I init    : Verified that /data/ss has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.002     0     0 I init    : Verified that /data/system has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.002     0     0 I init    : Not setting encryption policy on: /data/system_de
+12-13 10:32:25.002     0     0 I init    : Not setting encryption policy on: /data/system_ce
+12-13 10:32:25.003     0     0 I init    : Not setting encryption policy on: /data/misc_de
+12-13 10:32:25.003     0     0 I init    : Not setting encryption policy on: /data/misc_ce
+12-13 10:32:25.004     0     0 I init    : Not setting encryption policy on: /data/user
+12-13 10:32:25.004     0     0 I init    : Not setting encryption policy on: /data/user_de
+12-13 10:32:25.005     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #80!!!
+12-13 10:32:25.006     0     0 I init    : Command 'rm /data/user/0' action=post-fs-data (/system/etc/init/hw/init.rc:706) took 1ms and failed: unlink() failed: Is a directory
+12-13 10:32:25.010     0     0 I init    : Verified that /data/cache has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.011     0     0 I init    : Verified that /data/rollback has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.011     0     0 I init    : Verified that /data/rollback-observer has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.012     0     0 I init    : Verified that /data/incremental has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.012     0     0 I init    : start_waiting_for_property("apexd.status", "activated"): already set
+12-13 10:32:25.015     0     0 I init    : Parsing file /apex/com.android.adbd/etc/init.rc...
+12-13 10:32:25.015     0     0 I init    : Parsing file /apex/com.android.media.swcodec/etc/init.rc...
+12-13 10:32:25.015     0     0 I init    : Parsing file /apex/com.android.os.statsd/etc/init.rc...
+12-13 10:32:25.015     0     0 I init    : Parsing file /apex/com.android.sdkext/etc/derive_sdk.rc...
+12-13 10:32:25.015     0     0 I init    : Not setting encryption policy on: /data/media
+12-13 10:32:25.016     0     0 I init    : starting service 'exec 5 (/system/bin/chattr +F /data/media)'...
+12-13 10:32:25.017     0     0 I init    : SVC_EXEC service 'exec 5 (/system/bin/chattr +F /data/media)' pid 53 (uid 1023 gid 1023+0 context default) started; waiting...
+12-13 10:32:25.028     0     0 I init    : Service 'exec 5 (/system/bin/chattr +F /data/media)' (pid 53) exited with status 0 waiting took 0.010000 seconds
+12-13 10:32:25.028     0     0 I init    : Sending signal 9 to service 'exec 5 (/system/bin/chattr +F /data/media)' (pid 53) process group...
+12-13 10:32:25.028     0     0 I libprocessgroup: Successfully killed process cgroup uid 1023 pid 53 in 0ms
+12-13 10:32:25.030     0     0 I init    : Encryption policy of /data/media/obb set to ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.031     0     0 I init    : starting service 'derive_sdk'...
+12-13 10:32:25.032     0     0 I init    : SVC_EXEC service 'derive_sdk' pid 54 (uid 9999 gid 9999+0 context default) started; waiting...
+12-13 10:32:25.034    54    54 I derive_sdk: Read version 0 from /apex/com.android.sdkext/etc/sdkinfo.binarypb
+12-13 10:32:25.035    54    54 I derive_sdk: R extension version is 0
+12-13 10:32:25.039     0     0 I init    : Service 'derive_sdk' (pid 54) exited with status 0 waiting took 0.007000 seconds
+12-13 10:32:25.039     0     0 I init    : Sending signal 9 to service 'derive_sdk' (pid 54) process group...
+12-13 10:32:25.039     0     0 I libprocessgroup: Successfully killed process cgroup uid 9999 pid 54 in 0ms
+12-13 10:32:25.039     0     0 I init    : starting service 'exec 6 (/system/bin/vdc --wait cryptfs init_user0)'...
+12-13 10:32:25.040     0     0 I init    : SVC_EXEC service 'exec 6 (/system/bin/vdc --wait cryptfs init_user0)' pid 55 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:25.042    26    26 D vold    : fscrypt_init_user0
+12-13 10:32:25.043    26    26 D vold    : Preparing: /data/misc/vold/user_keys
+12-13 10:32:25.043    26    26 D vold    : Preparing: /data/misc/vold/user_keys/ce
+12-13 10:32:25.043    26    26 D vold    : Preparing: /data/misc/vold/user_keys/de
+12-13 10:32:25.046     0     0 D vdc     : Waited 0ms for vold
+12-13 10:32:25.047    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.keymaster@3.0::IKeymasterDevice/default in either framework or device manifest.
+12-13 10:32:25.047    26    26 I vold    : List of Keymaster HALs found:
+12-13 10:32:25.047    26    26 I vold    : Keymaster HAL #1: SoftwareKeymasterDevice from Google SecurityLevel: SOFTWARE HAL: android.hardware.keymaster@4.1::IKeymasterDevice/default
+12-13 10:32:25.047    26    26 I vold    : Using SoftwareKeymasterDevice from Google for encryption.  Security level: SOFTWARE, HAL: android.hardware.keymaster@4.1::IKeymasterDevice/default
+12-13 10:32:25.048    26    26 D vold    : Installed fscrypt key with ref def96e015042a3169eae9b3601cfb45f to /data
+12-13 10:32:25.048    26    26 D vold    : Added fscrypt-provisioning key for def96e015042a3169eae9b3601cfb45f to session keyring
+12-13 10:32:25.048    26    26 D vold    : Installed de key for user 0
+12-13 10:32:25.048    26    26 D vold    : Skipping non-de-key ..
+12-13 10:32:25.048    26    26 D vold    : Skipping non-de-key .
+12-13 10:32:25.048    26    26 D vold    : fscrypt_prepare_user_storage for volume null, user 0, serial 0, flags 1
+12-13 10:32:25.049    26    26 D vold    : Preparing: /data/system/users/0
+12-13 10:32:25.049    26    26 D vold    : Preparing: /data/misc/profiles/cur/0
+12-13 10:32:25.049    26    26 D vold    : Preparing: /data/system_de/0
+12-13 10:32:25.050    26    26 D vold    : Preparing: /data/misc_de/0
+12-13 10:32:25.050    26    26 D vold    : Preparing: /data/vendor_de/0
+12-13 10:32:25.051    26    26 D vold    : Preparing: /data/user_de/0
+12-13 10:32:25.051    26    26 I vold    : Verified that /data/system_de/0 has the encryption policy def96e015042a3169eae9b3601cfb45f v2 modes 1/4 flags 0x2
+12-13 10:32:25.051    26    26 I vold    : Verified that /data/misc_de/0 has the encryption policy def96e015042a3169eae9b3601cfb45f v2 modes 1/4 flags 0x2
+12-13 10:32:25.051    26    26 I vold    : Verified that /data/vendor_de/0 has the encryption policy def96e015042a3169eae9b3601cfb45f v2 modes 1/4 flags 0x2
+12-13 10:32:25.051    26    26 I vold    : Verified that /data/user_de/0 has the encryption policy def96e015042a3169eae9b3601cfb45f v2 modes 1/4 flags 0x2
+12-13 10:32:25.052    26    26 D vold    : /system/bin/vold_prepare_subdirs
+12-13 10:32:25.052    26    26 D vold    :     prepare
+12-13 10:32:25.052    26    26 D vold    :     
+12-13 10:32:25.052    26    26 D vold    :     0
+12-13 10:32:25.052    26    26 D vold    :     1
+12-13 10:32:25.060    56    56 D vold_prepare_subdirs: Setting up mode 700 uid 0 gid 0 context u:object_r:vold_data_file:s0 on path: /data/misc_de/0/vold
+12-13 10:32:25.061    56    56 D vold_prepare_subdirs: Setting up mode 700 uid 0 gid 0 context u:object_r:storaged_data_file:s0 on path: /data/misc_de/0/storaged
+12-13 10:32:25.061    56    56 D vold_prepare_subdirs: Setting up mode 700 uid 0 gid 0 context u:object_r:rollback_data_file:s0 on path: /data/misc_de/0/rollback
+12-13 10:32:25.061    56    56 D vold_prepare_subdirs: Setting up mode 700 uid 0 gid 0 context u:object_r:apex_rollback_data_file:s0 on path: /data/misc_de/0/apexrollback
+12-13 10:32:25.061    56    56 D vold_prepare_subdirs: Setting up mode 711 uid 0 gid 0 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata
+12-13 10:32:25.061    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.microsoft.windows.framework
+12-13 10:32:25.062    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.sdkext
+12-13 10:32:25.062    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.media.swcodec
+12-13 10:32:25.062    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.tzdata
+12-13 10:32:25.062    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.os.statsd
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.art
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.conscrypt
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.neuralnetworks
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.i18n
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.runtime
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.vndk.v30
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.mediaprovider
+12-13 10:32:25.063    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.adbd
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_wifi_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.wifi
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.ipsec
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.resolv
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.extservices
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_permission_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.permission
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.tethering
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 771 uid 0 gid 1000 context u:object_r:apex_module_data_file:s0 on path: /data/misc_de/0/apexdata/com.android.media
+12-13 10:32:25.064    56    56 D vold_prepare_subdirs: Setting up mode 700 uid 1000 gid 1000 context u:object_r:fingerprint_vendor_data_file:s0 on path: /data/vendor_de/0/fpdata
+12-13 10:32:25.065    56    56 D vold_prepare_subdirs: Setting up mode 700 uid 1000 gid 1000 context u:object_r:face_vendor_data_file:s0 on path: /data/vendor_de/0/facedata
+12-13 10:32:25.066    26    26 D vold    : Detected support for FS_IOC_ADD_ENCRYPTION_KEY
+12-13 10:32:25.069     0     0 I         : vold_prepare_su (266) used greatest stack depth: 12712 bytes left
+12-13 10:32:25.071     0     0 I init    : Service 'exec 6 (/system/bin/vdc --wait cryptfs init_user0)' (pid 55) exited with status 0 waiting took 0.030000 seconds
+12-13 10:32:25.071     0     0 I init    : Sending signal 9 to service 'exec 6 (/system/bin/vdc --wait cryptfs init_user0)' (pid 55) process group...
+12-13 10:32:25.071     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 55 in 0ms
+12-13 10:32:25.071     0     0 I init    : starting service 'apexd-snapshotde'...
+12-13 10:32:25.073     0     0 I init    : SVC_EXEC service 'apexd-snapshotde' pid 58 (uid 0 gid 1000+0 context default) started; waiting...
+12-13 10:32:25.083     0     0 I apexd   : This device does not support updatable APEX. Exiting
+12-13 10:32:25.083     0     0 I apexd   : Marking APEXd as ready
+12-13 10:32:25.084     0     0 I init    : Service 'apexd-snapshotde' (pid 58) exited with status 0 waiting took 0.012000 seconds
+12-13 10:32:25.084     0     0 I init    : Sending signal 9 to service 'apexd-snapshotde' (pid 58) process group...
+12-13 10:32:25.084     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 58 in 0ms
+12-13 10:32:25.086     0     0 I selinux : SELinux: Skipping restorecon on directory(/data)
+12-13 10:32:25.086     0     0 I selinux :  
+12-13 10:32:25.086     0     0 I init    : starting service 'exec 7 (/system/bin/tzdatacheck /apex/com.android.tzdata/etc/tz /data/misc/zoneinfo)'...
+12-13 10:32:25.087     0     0 I init    : SVC_EXEC service 'exec 7 (/system/bin/tzdatacheck /apex/com.android.tzdata/etc/tz /data/misc/zoneinfo)' pid 59 (uid 1000 gid 1000+0 context default) started; waiting...
+12-13 10:32:25.089    59    59 I tzdatacheck: timezone distro dir /data/misc/zoneinfo/current does not exist. No action required.
+12-13 10:32:25.093     0     0 I init    : Service 'exec 7 (/system/bin/tzdatacheck /apex/com.android.tzdata/etc/tz /data/misc/zoneinfo)' (pid 59) exited with status 0 waiting took 0.006000 seconds
+12-13 10:32:25.093     0     0 I init    : Sending signal 9 to service 'exec 7 (/system/bin/tzdatacheck /apex/com.android.tzdata/etc/tz /data/misc/zoneinfo)' (pid 59) process group...
+12-13 10:32:25.093     0     0 I libprocessgroup: Successfully killed process cgroup uid 1000 pid 59 in 0ms
+12-13 10:32:25.094     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/hw/init.usb.rc:6)
+12-13 10:32:25.094     0     0 I init    : Verified that /data/adb has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.094     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/bootstat.rc:9)
+12-13 10:32:25.095     0     0 I init    : processing action (ro.debuggable=1 && post-fs-data) from (/system/etc/init/clean_scratch_files.rc:1)
+12-13 10:32:25.095     0     0 I init    : Command 'exec_background - root root -- /system/bin/clean_scratch_files' action=ro.debuggable=1 && post-fs-data (/system/etc/init/clean_scratch_files.rc:2) took 0ms and failed: Could not start exec background service: File /system/bin/clean_scratch_files(labeled "u:object_r:system_file:s0") has incorrect label or no domain transition from u:r:init:s0 to another SELinux domain defined. Have you configured your service correctly? https://source.android.com/security/selinux/device-policy#label_new_services_and_address_denials
+12-13 10:32:25.096     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/gsid.rc:14)
+12-13 10:32:25.096     0     0 I init    : Not setting encryption policy on: /data/gsi
+12-13 10:32:25.096     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/incidentd.rc:21)
+12-13 10:32:25.096     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/iorapd.rc:28)
+12-13 10:32:25.096     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/logtagd.rc:4)
+12-13 10:32:25.097     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/perfetto.rc:67)
+12-13 10:32:25.098     0     0 I init    : Command 'rm /data/misc/perfetto-traces/.guardraildata' action=post-fs-data (/system/etc/init/perfetto.rc:68) took 0ms and failed: unlink() failed: No such file or directory
+12-13 10:32:25.098     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/recovery-persist.rc:1)
+12-13 10:32:25.098     0     0 I init    : starting service 'exec 9 (/system/bin/recovery-persist)'...
+12-13 10:32:25.100     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/tombstoned.rc:10)
+12-13 10:32:25.100     0     0 I init    : starting service 'tombstoned'...
+12-13 10:32:25.100     0     0 I init    : Created socket '/dev/socket/tombstoned_crash', mode 666, user 1000, group 1000
+12-13 10:32:25.100     0     0 I init    : Created socket '/dev/socket/tombstoned_intercept', mode 666, user 1000, group 1000
+12-13 10:32:25.100     0     0 I init    : Created socket '/dev/socket/tombstoned_java_trace', mode 666, user 1000, group 1000
+12-13 10:32:25.101    60    60 E recovery-persist: Failed to unlink /cache/recovery/last_install: No such file or directory
+12-13 10:32:25.102     0     0 I init    : processing action (post-fs-data) from (/system/etc/init/wifi.rc:18)
+12-13 10:32:25.102     0     0 I selinux : SELinux: Skipping restorecon on directory(/data/misc/apexdata/com.android.wifi)
+12-13 10:32:25.102     0     0 I selinux :  
+12-13 10:32:25.102     0     0 I init    : processing action (post-fs-data) from (/vendor/etc/init/init.windows_x86_64.rc:27)
+12-13 10:32:25.103     0     0 I init    : processing action (load_persist_props_action) from (/system/etc/init/hw/init.rc:405)
+12-13 10:32:25.103     0     0 W init    : Couldn't load property file '/data/local.prop': open() failed: No such file or directory: No such file or directory
+12-13 10:32:25.106    61    61 I tombstoned: tombstoned successfully initialized
+12-13 10:32:25.106     0     0 I init    : Service 'exec 9 (/system/bin/recovery-persist)' (pid 60) exited with status 0 oneshot service took 0.006000 seconds in background
+12-13 10:32:25.106     0     0 I init    : Sending signal 9 to service 'exec 9 (/system/bin/recovery-persist)' (pid 60) process group...
+12-13 10:32:25.106     0     0 I libprocessgroup: Successfully killed process cgroup uid 1000 pid 60 in 0ms
+12-13 10:32:25.106     0     0 I init    : Wait for property 'ro.persistent_properties.ready=true' took 3ms
+12-13 10:32:25.106     0     0 I init    : starting service 'logd-reinit'...
+12-13 10:32:25.108     0     0 I init    : processing action (load_persist_props_action) from (/system/etc/init/flags_health_check.rc:1)
+12-13 10:32:25.108     0     0 W init    : Top-level directory needs encryption action, eg mkdir /data/server_configurable_flags <mode> <uid> <gid> encryption=Require
+12-13 10:32:25.110     0     0 I init    : Verified that /data/server_configurable_flags has the encryption policy ab821d9df022fa689c9fe7123d4648ab v2 modes 1/4 flags 0x2
+12-13 10:32:25.110     0     0 I init    : starting service 'exec 10 (/system/bin/flags_health_check BOOT_FAILURE)'...
+12-13 10:32:25.111     0     0 I init    : SVC_EXEC service 'exec 10 (/system/bin/flags_health_check BOOT_FAILURE)' pid 63 (uid 1000 gid 1000+0 context default) started; waiting...
+12-13 10:32:25.113    63    63 I flags_health_check: ServerConfigurableFlagsReset reset_mode value: 0
+12-13 10:32:25.113    63    63 I flags_health_check: ServerConfigurableFlagsReset attempted boot count is under threshold, skipping reset.
+12-13 10:32:25.113     0     0 I logd.daemon: reinit
+12-13 10:32:25.114     0     0 I init    : Service 'logd-reinit' (pid 62) exited with status 0 oneshot service took 0.006000 seconds in background
+12-13 10:32:25.114     0     0 I init    : Sending signal 9 to service 'logd-reinit' (pid 62) process group...
+12-13 10:32:25.114     0     0 I libprocessgroup: Successfully killed process cgroup uid 1036 pid 62 in 0ms
+12-13 10:32:25.140     0     0 I init    : Service 'exec 10 (/system/bin/flags_health_check BOOT_FAILURE)' (pid 63) exited with status 0 waiting took 0.029000 seconds
+12-13 10:32:25.140     0     0 I init    : Sending signal 9 to service 'exec 10 (/system/bin/flags_health_check BOOT_FAILURE)' (pid 63) process group...
+12-13 10:32:25.141     0     0 I libprocessgroup: Successfully killed process cgroup uid 1000 pid 63 in 0ms
+12-13 10:32:25.141     0     0 I init    : processing action (load_persist_props_action) from (/system/etc/init/logcatd.rc:29)
+12-13 10:32:25.141     0     0 I init    : processing action (load_bpf_programs) from (/system/etc/init/bpfloader.rc:20)
+12-13 10:32:25.141     0     0 I init    : starting service 'bpfloader'...
+12-13 10:32:25.143     0     0 I init    : processing action (persist.sys.fuse=true && zygote-start) from (/system/etc/init/hw/init.rc:797)
+12-13 10:32:25.143     0     0 I init    : processing action (ro.crypto.state=encrypted && ro.crypto.type=file && zygote-start) from (/system/etc/init/hw/init.rc:828)
+12-13 10:32:25.143     0     0 I init    : Command 'exec_start update_verifier_nonencrypted' action=ro.crypto.state=encrypted && ro.crypto.type=file && zygote-start (/system/etc/init/hw/init.rc:830) took 0ms and failed: Service not found
+12-13 10:32:25.143     0     0 I init    : starting service 'statsd'...
+12-13 10:32:25.144     0     0 I init    : Created socket '/dev/socket/statsdw', mode 222, user 1066, group 1066
+12-13 10:32:25.145     0     0 I init    : starting service 'netd'...
+12-13 10:32:25.145     0     0 I init    : Created socket '/dev/socket/dnsproxyd', mode 660, user 0, group 3003
+12-13 10:32:25.145     0     0 I init    : Created socket '/dev/socket/mdns', mode 660, user 0, group 1000
+12-13 10:32:25.145     0     0 I init    : Created socket '/dev/socket/fwmarkd', mode 660, user 0, group 3003
+12-13 10:32:25.147     0     0 I init    : starting service 'zygote'...
+12-13 10:32:25.147     0     0 I init    : Created socket '/dev/socket/zygote', mode 660, user 0, group 1000
+12-13 10:32:25.147     0     0 I init    : Created socket '/dev/socket/usap_pool_primary', mode 660, user 0, group 1000
+12-13 10:32:25.148     0     0 I init    : starting service 'zygote_secondary'...
+12-13 10:32:25.148     0     0 I init    : Created socket '/dev/socket/zygote_secondary', mode 660, user 0, group 1000
+12-13 10:32:25.148     0     0 I init    : Created socket '/dev/socket/usap_pool_secondary', mode 660, user 0, group 1000
+12-13 10:32:25.148     0     0 W libprocessgroup: Failed to open /dev/stune/top-app/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.150     0     0 W libprocessgroup: Failed to apply MaxPerformance task profile: No such file or directory
+12-13 10:32:25.151    64    64 D LibBpfLoader: Loading critical for netd ELF object /system/etc/bpf/clatd.o with license Apache 2.0
+12-13 10:32:25.151     0     0 I init    : processing action (firmware_mounts_complete) from (/system/etc/init/hw/init.rc:411)
+12-13 10:32:25.151     0     0 I init    : processing action (early-boot) from (/system/etc/init/installd.rc:5)
+12-13 10:32:25.151     0     0 W libprocessgroup: Failed to open /dev/stune/top-app/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.152    64    64 E LibBpfLoader: No progs section could be found in elf object
+12-13 10:32:25.152    64    64 D LibBpfLoader: Loaded code section 3 (schedcls_ingress_clat_ether)
+12-13 10:32:25.153    64    64 D LibBpfLoader: Loaded relo section 3 (.relschedcls/ingress/clat_ether)
+12-13 10:32:25.153    64    64 D LibBpfLoader: Adding section 3 to cs list
+12-13 10:32:25.153    64    64 D LibBpfLoader: Loaded code section 5 (schedcls_ingress_clat_rawip)
+12-13 10:32:25.153     0     0 W libprocessgroup: Failed to apply MaxPerformance task profile: No such file or directory
+12-13 10:32:25.153    64    64 D LibBpfLoader: Loaded relo section 5 (.relschedcls/ingress/clat_rawip)
+12-13 10:32:25.153    64    64 D LibBpfLoader: Adding section 5 to cs list
+12-13 10:32:25.153    64    64 D LibBpfLoader: Loaded code section 7 (schedcls_egress_clat_ether)
+12-13 10:32:25.153    64    64 D LibBpfLoader: Adding section 7 to cs list
+12-13 10:32:25.154    64    64 D LibBpfLoader: Loaded code section 8 (schedcls_egress_clat_rawip)
+12-13 10:32:25.154    64    64 D LibBpfLoader: Loaded relo section 8 (.relschedcls/egress/clat_rawip)
+12-13 10:32:25.154    64    64 D LibBpfLoader: Adding section 8 to cs list
+12-13 10:32:25.155    64    64 D LibBpfLoader: bpf_create_map name clat_ingress_map, ret: 6
+12-13 10:32:25.155    64    64 D LibBpfLoader: bpf_create_map name clat_egress_map, ret: 7
+12-13 10:32:25.155    64    64 D LibBpfLoader: map_fd found at 0 is 6 in /system/etc/bpf/clatd.o
+12-13 10:32:25.155    64    64 D LibBpfLoader: map_fd found at 1 is 7 in /system/etc/bpf/clatd.o
+12-13 10:32:25.155    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 392, 	       insn offset 49 , insn 118
+12-13 10:32:25.155    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 352, 	       insn offset 44 , insn 118
+12-13 10:32:25.155    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 520, 	       insn offset 65 , insn 118
+12-13 10:32:25.157    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/clatd.o (schedcls_ingress_clat_ether) returned fd: 8 (no error)
+12-13 10:32:25.158    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/clatd.o (schedcls_ingress_clat_rawip) returned fd: 9 (no error)
+12-13 10:32:25.159    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/clatd.o (schedcls_egress_clat_ether) returned fd: 10 (no error)
+12-13 10:32:25.160    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/clatd.o (schedcls_egress_clat_rawip) returned fd: 11 (no error)
+12-13 10:32:25.160    64    64 I bpfloader: Loaded object: /system/etc/bpf/clatd.o
+12-13 10:32:25.161    64    64 D LibBpfLoader: Loading critical for netd ELF object /system/etc/bpf/offload.o with license Apache 2.0
+12-13 10:32:25.161    64    64 D LibBpfLoader: Loaded code section 3 (schedcls_ingress_tether_ether)
+12-13 10:32:25.161     0     0 I init    : processing action (early-boot) from (/vendor/etc/init/init.windows_x86_64.rc:31)
+12-13 10:32:25.161    64    64 D LibBpfLoader: Loaded relo section 3 (.relschedcls/ingress/tether_ether)
+12-13 10:32:25.161    64    64 D LibBpfLoader: Adding section 3 to cs list
+12-13 10:32:25.162    64    64 D LibBpfLoader: Loaded code section 5 (schedcls_ingress_tether_rawip$5_4)
+12-13 10:32:25.162     0     0 I init    : starting service 'wait_for_rcm'...
+12-13 10:32:25.162    64    64 D LibBpfLoader: Loaded relo section 5 (.relschedcls/ingress/tether_rawip$5_4)
+12-13 10:32:25.162    64    64 D LibBpfLoader: Adding section 5 to cs list
+12-13 10:32:25.162    64    64 D LibBpfLoader: Loaded code section 7 (schedcls_ingress_tether_rawip$4_14)
+12-13 10:32:25.162    64    64 D LibBpfLoader: Loaded relo section 7 (.relschedcls/ingress/tether_rawip$4_14)
+12-13 10:32:25.162    64    64 D LibBpfLoader: Adding section 7 to cs list
+12-13 10:32:25.162    64    64 D LibBpfLoader: Loaded code section 9 (schedcls_ingress_tether_rawip$stub)
+12-13 10:32:25.163    64    64 D LibBpfLoader: Adding section 9 to cs list
+12-13 10:32:25.163    64    64 D LibBpfLoader: bpf_create_map name tether_ingress_map, ret: 6
+12-13 10:32:25.163     0     0 I init    : SVC_EXEC service 'wait_for_rcm' pid 69 (uid 0 gid 0+1 context default) started; waiting...
+12-13 10:32:25.163    64    64 D LibBpfLoader: bpf_create_map name tether_stats_map, ret: 7
+12-13 10:32:25.163    64    64 D LibBpfLoader: bpf_create_map name tether_limit_map, ret: 8
+12-13 10:32:25.163    64    64 D LibBpfLoader: map_fd found at 0 is 6 in /system/etc/bpf/offload.o
+12-13 10:32:25.163    64    64 D LibBpfLoader: map_fd found at 1 is 7 in /system/etc/bpf/offload.o
+12-13 10:32:25.163    64    64 D LibBpfLoader: map_fd found at 2 is 8 in /system/etc/bpf/offload.o
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 304, 	       insn offset 38 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 384, 	       insn offset 48 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 448, 	       insn offset 56 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 264, 	       insn offset 33 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 344, 	       insn offset 43 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 408, 	       insn offset 51 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 264, 	       insn offset 33 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 344, 	       insn offset 43 , insn 118
+12-13 10:32:25.164    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 408, 	       insn offset 51 , insn 118
+12-13 10:32:25.165    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/offload.o (schedcls_ingress_tether_ether) returned fd: 9 (no error)
+12-13 10:32:25.166    64    64 D LibBpfLoader: cs[1].name:schedcls_ingress_tether_rawip$5_4 min_kver:50400 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.167    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/offload.o (schedcls_ingress_tether_rawip$5_4) returned fd: 10 (no error)
+12-13 10:32:25.167    64    64 D LibBpfLoader: cs[2].name:schedcls_ingress_tether_rawip$4_14 min_kver:40e00 .max_kver:50400 (kvers:50a2b)
+12-13 10:32:25.167    64    64 D LibBpfLoader: cs[3].name:schedcls_ingress_tether_rawip$stub min_kver:0 .max_kver:50400 (kvers:50a2b)
+12-13 10:32:25.167    64    64 I bpfloader: Loaded object: /system/etc/bpf/offload.o
+12-13 10:32:25.168    64    64 D LibBpfLoader: Loading critical for netd ELF object /system/etc/bpf/netd.o with license Apache 2.0
+12-13 10:32:25.168    64    64 D LibBpfLoader: Loaded code section 3 (cgroupskb_ingress_stats)
+12-13 10:32:25.169    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.170    64    64 D LibBpfLoader: Loaded relo section 3 (.relcgroupskb/ingress/stats)
+12-13 10:32:25.170    64    64 D LibBpfLoader: Adding section 3 to cs list
+12-13 10:32:25.170    64    64 D LibBpfLoader: Loaded code section 5 (cgroupskb_egress_stats)
+12-13 10:32:25.170    64    64 D LibBpfLoader: Loaded relo section 5 (.relcgroupskb/egress/stats)
+12-13 10:32:25.171    64    64 D LibBpfLoader: Adding section 5 to cs list
+12-13 10:32:25.171    64    64 D LibBpfLoader: Loaded code section 7 (skfilter_egress_xtbpf)
+12-13 10:32:25.171    64    64 D LibBpfLoader: Loaded relo section 7 (.relskfilter/egress/xtbpf)
+12-13 10:32:25.171    64    64 D LibBpfLoader: Adding section 7 to cs list
+12-13 10:32:25.171    64    64 D LibBpfLoader: Loaded code section 9 (skfilter_ingress_xtbpf)
+12-13 10:32:25.172    64    64 D LibBpfLoader: Loaded relo section 9 (.relskfilter/ingress/xtbpf)
+12-13 10:32:25.172    64    64 D LibBpfLoader: Adding section 9 to cs list
+12-13 10:32:25.172    64    64 D LibBpfLoader: Loaded code section 11 (skfilter_whitelist_xtbpf)
+12-13 10:32:25.172    64    64 D LibBpfLoader: Loaded relo section 11 (.relskfilter/whitelist/xtbpf)
+12-13 10:32:25.172    64    64 D LibBpfLoader: Adding section 11 to cs list
+12-13 10:32:25.172    64    64 D LibBpfLoader: Loaded code section 13 (skfilter_blacklist_xtbpf)
+12-13 10:32:25.172    64    64 D LibBpfLoader: Loaded relo section 13 (.relskfilter/blacklist/xtbpf)
+12-13 10:32:25.172    64    64 D LibBpfLoader: Adding section 13 to cs list
+12-13 10:32:25.172    64    64 D LibBpfLoader: Loaded code section 15 (cgroupsock_inet_create)
+12-13 10:32:25.173    66    66 I netdClient: Skipping libnetd_client init since *we* are netd
+12-13 10:32:25.173    64    64 D LibBpfLoader: Loaded relo section 15 (.relcgroupsock/inet/create)
+12-13 10:32:25.173    64    64 D LibBpfLoader: Adding section 15 to cs list
+12-13 10:32:25.174    64    64 D LibBpfLoader: bpf_create_map name cookie_tag_map, ret: 6
+12-13 10:32:25.174    64    64 D LibBpfLoader: bpf_create_map name uid_counterset_map, ret: 7
+12-13 10:32:25.175    64    64 D LibBpfLoader: bpf_create_map name app_uid_stats_map, ret: 8
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name stats_map_A, ret: 9
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name stats_map_B, ret: 10
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name iface_stats_map, ret: 11
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name configuration_map, ret: 12
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name uid_owner_map, ret: 13
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name iface_index_name_map, ret: 14
+12-13 10:32:25.176    64    64 D LibBpfLoader: bpf_create_map name uid_permission_map, ret: 15
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 0 is 6 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 1 is 7 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 2 is 8 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 3 is 9 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 4 is 10 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 5 is 11 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 6 is 12 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 7 is 13 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 8 is 14 in /system/etc/bpf/netd.o
+12-13 10:32:25.176    64    64 D LibBpfLoader: map_fd found at 9 is 15 in /system/etc/bpf/netd.o
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 664, 	       insn offset 83 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 736, 	       insn offset 92 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1088, 	       insn offset 136 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1384, 	       insn offset 173 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1464, 	       insn offset 183 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1576, 	       insn offset 197 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1688, 	       insn offset 211 , insn 118
+12-13 10:32:25.177    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1728, 	       insn offset 216 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1880, 	       insn offset 235 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1992, 	       insn offset 249 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2032, 	       insn offset 254 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2312, 	       insn offset 289 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2416, 	       insn offset 302 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2456, 	       insn offset 307 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2600, 	       insn offset 325 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2704, 	       insn offset 338 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2744, 	       insn offset 343 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2976, 	       insn offset 372 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 3080, 	       insn offset 385 , insn 118
+12-13 10:32:25.178    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 3120, 	       insn offset 390 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 648, 	       insn offset 81 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 720, 	       insn offset 90 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 944, 	       insn offset 118 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1216, 	       insn offset 152 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1296, 	       insn offset 162 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1400, 	       insn offset 175 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1504, 	       insn offset 188 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1544, 	       insn offset 193 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1688, 	       insn offset 211 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1792, 	       insn offset 224 , insn 118
+12-13 10:32:25.179    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1832, 	       insn offset 229 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2104, 	       insn offset 263 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2208, 	       insn offset 276 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2248, 	       insn offset 281 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2392, 	       insn offset 299 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2496, 	       insn offset 312 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2536, 	       insn offset 317 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2768, 	       insn offset 346 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2872, 	       insn offset 359 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2912, 	       insn offset 364 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 88, 	       insn offset 11 , insn 118
+12-13 10:32:25.180    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 192, 	       insn offset 24 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 232, 	       insn offset 29 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 40, 	       insn offset 5 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 144, 	       insn offset 18 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 184, 	       insn offset 23 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 136, 	       insn offset 17 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 32, 	       insn offset 4 , insn 118
+12-13 10:32:25.181    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 80, 	       insn offset 10 , insn 118
+12-13 10:32:25.183    66    66 I netd    : netd 1.0 starting
+12-13 10:32:25.184    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (cgroupskb_ingress_stats) returned fd: 16 (no error)
+12-13 10:32:25.186    69    69 D wait_for_rcm: Waiting for rcmsvc
+12-13 10:32:25.188    69    69 D wait_for_rcm: rcmsvc started
+12-13 10:32:25.188    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (cgroupskb_egress_stats) returned fd: 17 (no error)
+12-13 10:32:25.188    64    64 D LibBpfLoader: cs[2].name:skfilter_egress_xtbpf min_kver:0 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.190    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (skfilter_egress_xtbpf) returned fd: 18 (no error)
+12-13 10:32:25.190    64    64 D LibBpfLoader: cs[3].name:skfilter_ingress_xtbpf min_kver:0 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.191    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (skfilter_ingress_xtbpf) returned fd: 19 (no error)
+12-13 10:32:25.191    64    64 D LibBpfLoader: cs[4].name:skfilter_whitelist_xtbpf min_kver:0 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.191    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (skfilter_whitelist_xtbpf) returned fd: 20 (no error)
+12-13 10:32:25.191    64    64 D LibBpfLoader: cs[5].name:skfilter_blacklist_xtbpf min_kver:0 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.192    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (skfilter_blacklist_xtbpf) returned fd: 21 (no error)
+12-13 10:32:25.193    64    64 D LibBpfLoader: cs[6].name:cgroupsock_inet_create min_kver:40e00 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.193     0     0 I init    : Service 'wait_for_rcm' (pid 69) exited with status 0 waiting took 0.030000 seconds
+12-13 10:32:25.193     0     0 I init    : Sending signal 9 to service 'wait_for_rcm' (pid 69) process group...
+12-13 10:32:25.193     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 69 in 0ms
+12-13 10:32:25.193    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/netd.o (cgroupsock_inet_create) returned fd: 22 (no error)
+12-13 10:32:25.193     0     0 I init    : processing action (boot) from (/system/etc/init/hw/init.rc:836)
+12-13 10:32:25.194    64    64 I bpfloader: Loaded object: /system/etc/bpf/netd.o
+12-13 10:32:25.194    64    64 D LibBpfLoader: Loading optional ELF object /system/etc/bpf/time_in_state.o with license GPL
+12-13 10:32:25.194    64    64 D LibBpfLoader: Loaded code section 3 (tracepoint_sched_sched_switch)
+12-13 10:32:25.195    64    64 D LibBpfLoader: Loaded relo section 3 (.reltracepoint/sched/sched_switch)
+12-13 10:32:25.195    64    64 D LibBpfLoader: Adding section 3 to cs list
+12-13 10:32:25.195    64    64 D LibBpfLoader: Loaded code section 5 (tracepoint_power_cpu_frequency)
+12-13 10:32:25.195    64    64 D LibBpfLoader: Loaded relo section 5 (.reltracepoint/power/cpu_frequency)
+12-13 10:32:25.195    64    64 D LibBpfLoader: Adding section 5 to cs list
+12-13 10:32:25.196     0     0 I init    : starting service 'hidl_memory'...
+12-13 10:32:25.197     0     0 I init    : starting service 'vendor.audio-hal'...
+12-13 10:32:25.197    64    64 D LibBpfLoader: bpf_create_map name uid_time_in_state_map, ret: 6
+12-13 10:32:25.199     0     0 I init    : starting service 'vendor.cas-hal-1-2'...
+12-13 10:32:25.199    64    64 D LibBpfLoader: bpf_create_map name uid_concurrent_times_map, ret: 7
+12-13 10:32:25.199     0     0 W libprocessgroup: Failed to open /dev/stune/foreground/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.199    64    64 D LibBpfLoader: bpf_create_map name uid_last_update_map, ret: 8
+12-13 10:32:25.199    64    64 D LibBpfLoader: bpf_create_map name cpu_last_update_map, ret: 9
+12-13 10:32:25.200    64    64 D LibBpfLoader: bpf_create_map name cpu_policy_map, ret: 10
+12-13 10:32:25.200    64    64 D LibBpfLoader: bpf_create_map name policy_freq_idx_map, ret: 11
+12-13 10:32:25.200    64    64 D LibBpfLoader: bpf_create_map name freq_to_idx_map, ret: 12
+12-13 10:32:25.200    64    64 D LibBpfLoader: bpf_create_map name nr_active_map, ret: 13
+12-13 10:32:25.200    64    64 D LibBpfLoader: bpf_create_map name policy_nr_active_map, ret: 14
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 0 is 6 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 1 is 7 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 2 is 8 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 3 is 9 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 4 is 10 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 5 is 11 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 6 is 12 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 7 is 13 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: map_fd found at 8 is 14 in /system/etc/bpf/time_in_state.o
+12-13 10:32:25.200    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 40, 	       insn offset 5 , insn 118
+12-13 10:32:25.200    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 128, 	       insn offset 16 , insn 118
+12-13 10:32:25.200    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 200, 	       insn offset 25 , insn 118
+12-13 10:32:25.200    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 264, 	       insn offset 33 , insn 118
+12-13 10:32:25.200    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 520, 	       insn offset 65 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 656, 	       insn offset 82 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1008, 	       insn offset 126 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1048, 	       insn offset 131 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1240, 	       insn offset 155 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1440, 	       insn offset 180 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1480, 	       insn offset 185 , insn 118
+12-13 10:32:25.201     0     0 W libprocessgroup: Failed to apply HighPerformance task profile: No such file or directory
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1656, 	       insn offset 207 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1864, 	       insn offset 233 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 1904, 	       insn offset 238 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2024, 	       insn offset 253 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 2112, 	       insn offset 264 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 40, 	       insn offset 5 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 120, 	       insn offset 15 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: applying relo to instruction at byte offset: 200, 	       insn offset 25 , insn 118
+12-13 10:32:25.201    64    64 D LibBpfLoader: cs[0].name:tracepoint_sched_sched_switch min_kver:0 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.202     0     0 I init    : starting service 'vendor.drm-clearkey-hal-1-3'...
+12-13 10:32:25.204    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/time_in_state.o (tracepoint_sched_sched_switch) returned fd: 15 (no error)
+12-13 10:32:25.204     0     0 I init    : starting service 'vendor.gatekeeper-1-0'...
+12-13 10:32:25.204    64    64 D LibBpfLoader: cs[1].name:tracepoint_power_cpu_frequency min_kver:0 .max_kver:ffffffff (kvers:50a2b)
+12-13 10:32:25.206    64    64 D LibBpfLoader: bpf_prog_load lib call for /system/etc/bpf/time_in_state.o (tracepoint_power_cpu_frequency) returned fd: 16 (no error)
+12-13 10:32:25.206     0     0 I init    : starting service 'vendor.gralloc-2-0'...
+12-13 10:32:25.206    64    64 I bpfloader: Loaded object: /system/etc/bpf/time_in_state.o
+12-13 10:32:25.209    73    73 I HidlServiceManagement: Registered android.hidl.allocator@1.0::IAllocator/ashmem
+12-13 10:32:25.209    73    73 I HidlServiceManagement: Removing namespace from process name android.hidl.allocator@1.0-service to allocator@1.0-service.
+12-13 10:32:25.210     0     0 I init    : starting service 'health-hal-2-1'...
+12-13 10:32:25.210     0     0 I init    : Opened file '/dev/kmsg', flags 1
+12-13 10:32:25.210    66    66 D TetherController: Setting IP forward enable = 0
+12-13 10:32:25.224     0     0 I init    : starting service 'windows-gnss-hal'...
+12-13 10:32:25.226     0     0 I init    : starting service 'windows-composer-hal'...
+12-13 10:32:25.228     0     0 I init    : starting service 'windows-power-hal'...
+12-13 10:32:25.229     0     0 I init    : Service 'bpfloader' (pid 64) exited with status 0 oneshot service took 0.087000 seconds in background
+12-13 10:32:25.229     0     0 I init    : Sending signal 9 to service 'bpfloader' (pid 64) process group...
+12-13 10:32:25.230     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 64 in 0ms
+12-13 10:32:25.230     0     0 I init    : starting service 'audioserver'...
+12-13 10:32:25.236     0     0 I init    : starting service 'credstore'...
+12-13 10:32:25.239     0     0 I init    : starting service 'gpu'...
+12-13 10:32:25.242    77    77 I HidlServiceManagement: Registered android.hardware.gatekeeper@1.0::IGatekeeper/default
+12-13 10:32:25.243    77    77 I HidlServiceManagement: Removing namespace from process name android.hardware.gatekeeper@1.0-service.software to gatekeeper@1.0-service.software.
+12-13 10:32:25.246     0     0 I init    : starting service 'surfaceflinger'...
+12-13 10:32:25.246     0     0 I init    : Could not create socket 'pdx/system/vr/display/client': Failed to bind socket 'pdx/system/vr/display/client': No such file or directory
+12-13 10:32:25.246     0     0 I init    : Could not create socket 'pdx/system/vr/display/manager': Failed to bind socket 'pdx/system/vr/display/manager': No such file or directory
+12-13 10:32:25.246     0     0 I init    : Could not create socket 'pdx/system/vr/display/vsync': Failed to bind socket 'pdx/system/vr/display/vsync': No such file or directory
+12-13 10:32:25.246    22    22 I servicemanager: getDeviceHalManifest: Reading VINTF information.
+12-13 10:32:25.247    22    22 I servicemanager: getDeviceHalManifest: Successfully processed VINTF information
+12-13 10:32:25.247    22    22 I servicemanager: getFrameworkHalManifest: Reading VINTF information.
+12-13 10:32:25.248    22    22 I servicemanager: getFrameworkHalManifest: Successfully processed VINTF information
+12-13 10:32:25.248    22    22 I servicemanager: Found android.hardware.power.IPower/default in device VINTF manifest.
+12-13 10:32:25.248     0     0 I init    : starting service 'exec 11 (/system/bin/fsverity_init)'...
+12-13 10:32:25.249     0     0 I init    : SVC_EXEC service 'exec 11 (/system/bin/fsverity_init)' pid 90 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:25.253    66    66 I netd    : Creating child chains: 33354us
+12-13 10:32:25.253    66    66 I netd    : Setting up OEM hooks: 126us
+12-13 10:32:25.253    66    66 I netd    : Setting up FirewallController hooks: 319us
+12-13 10:32:25.254     0     0 W libprocessgroup: Failed to open /dev/stune/foreground/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.257     0     0 W libprocessgroup: Failed to open /dev/stune/foreground/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.259     0     0 W libprocessgroup: Failed to apply HighPerformance task profile: No such file or directory
+12-13 10:32:25.260     0     0 W healthd : BatteryHealthPath not found
+12-13 10:32:25.261     0     0 W healthd : BatteryTemperaturePath not found
+12-13 10:32:25.261     0     0 W healthd : BatteryCurrentNowPath not found
+12-13 10:32:25.262    66    66 I netd    : Setting up TetherController hooks: 8617us
+12-13 10:32:25.262     0     0 W healthd : BatteryFullChargePath not found
+12-13 10:32:25.263     0     0 W healthd : batteryChargeTimeToFullNowPath. not found
+12-13 10:32:25.263    66    66 I netd    : Setting up BandwidthController hooks: 1033us
+12-13 10:32:25.263    66    66 I netd    : Setting up IdletimerController hooks: 52us
+12-13 10:32:25.263    79    79 I android.hardware.health@2.1-service: default instance initializing with healthd_config...
+12-13 10:32:25.264     0     0 W healthd : batteryFullChargeDesignCapacityUahPath. not found
+12-13 10:32:25.265     0     0 W libprocessgroup: Failed to apply HighPerformance task profile: No such file or directory
+12-13 10:32:25.265    75    75 I HidlServiceManagement: Registered android.hardware.cas@1.2::IMediaCasService/default
+12-13 10:32:25.266    75    75 I HidlServiceManagement: Removing namespace from process name android.hardware.cas@1.2-service to cas@1.2-service.
+12-13 10:32:25.267    79    79 I HidlServiceManagement: Registered android.hardware.health@2.1::IHealth/default
+12-13 10:32:25.267    79    79 I HidlServiceManagement: Removing namespace from process name android.hardware.health@2.1-service to health@2.1-service.
+12-13 10:32:25.268    79    79 I android.hardware.health@2.1-service: default: Hal init done
+12-13 10:32:25.268    66    66 I netd    : Setting up StrictController hooks: 4610us
+12-13 10:32:25.268    66    66 I ClatdController: 4.9+ kernel and device shipped with Q+ - clat ebpf should work.
+12-13 10:32:25.269    66    66 I netd    : Initializing ClatdController: 993us
+12-13 10:32:25.269     0     0 I init    : Service 'exec 11 (/system/bin/fsverity_init)' (pid 90) exited with status 0 waiting took 0.020000 seconds
+12-13 10:32:25.269     0     0 I init    : Sending signal 9 to service 'exec 11 (/system/bin/fsverity_init)' (pid 90) process group...
+12-13 10:32:25.269     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 90 in 0ms
+12-13 10:32:25.269     0     0 I init    : processing action (persist.sys.usb.config=* && boot) from (/system/etc/init/hw/init.usb.rc:105)
+12-13 10:32:25.270     0     0 I init    : processing action (boot) from (/system/etc/init/dumpstate.rc:1)
+12-13 10:32:25.270     0     0 I init    : processing action (boot) from (/system/etc/init/gsid.rc:20)
+12-13 10:32:25.270     0     0 I init    : starting service 'exec 12 (/system/bin/gsid run-startup-tasks)'...
+12-13 10:32:25.270    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.271     0     0 I init    : processing action (boot) from (/vendor/etc/init/init.windows_x86_64.rc:37)
+12-13 10:32:25.272    66    66 I netd    : Initializing traffic control: 2940us
+12-13 10:32:25.274     0     0 W healthd : battery l=100 v=5000 t=0.0 h=1 st=3 cc=-1 chg=a
+12-13 10:32:25.275    66    66 I netd    : Enabling bandwidth control: 3383us
+12-13 10:32:25.275     0     0 I init    : processing action (enable_property_trigger) from (<Builtin Action>:0)
+12-13 10:32:25.276     0     0 I init    : processing action (apexd.status=ready && ro.product.cpu.abilist32=*) from (/system/etc/init/hw/init.rc:89)
+12-13 10:32:25.276     0     0 I init    : starting service 'boringssl_self_test_apex32'...
+12-13 10:32:25.277    66    66 I netd    : Initializing RouteController: 1710us
+12-13 10:32:25.277    66    66 D XfrmController: XfrmController::ipSecAddXfrmInterface, line=1377
+12-13 10:32:25.278     0     0 I init    : SVC_EXEC service 'boringssl_self_test_apex32' pid 97 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:25.279    66    66 D XfrmController: XfrmController::ipSecRemoveTunnelInterface, line=1590
+12-13 10:32:25.279    66    66 D XfrmController: deviceName=ipsec_test
+12-13 10:32:25.296    76    76 I HidlServiceManagement: Registered android.hardware.drm@1.3::IDrmFactory/clearkey
+12-13 10:32:25.297    76    76 I HidlServiceManagement: Removing namespace from process name android.hardware.drm@1.3-service.clearkey to drm@1.3-service.clearkey.
+12-13 10:32:25.297    76    76 I HidlServiceManagement: Registered android.hardware.drm@1.3::ICryptoFactory/clearkey
+12-13 10:32:25.297    76    76 I HidlServiceManagement: Removing namespace from process name android.hardware.drm@1.3-service.clearkey to drm@1.3-service.clearkey.
+12-13 10:32:25.298    95    95 I gsid    : no DSU: No such file or directory
+12-13 10:32:25.302     0     0 I init    : Service 'exec 12 (/system/bin/gsid run-startup-tasks)' (pid 95) exited with status 0 oneshot service took 0.031000 seconds in background
+12-13 10:32:25.302     0     0 I init    : Sending signal 9 to service 'exec 12 (/system/bin/gsid run-startup-tasks)' (pid 95) process group...
+12-13 10:32:25.302     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 95 in 0ms
+12-13 10:32:25.307    74    74 I HidlServiceManagement: Registered android.hardware.audio@6.0::IDevicesFactory/default
+12-13 10:32:25.307    74    74 I HidlServiceManagement: Removing namespace from process name android.hardware.audio.service to audio.service.
+12-13 10:32:25.308    74    74 I LegacySupport: Registration complete for android.hardware.audio@6.0::IDevicesFactory/default.
+12-13 10:32:25.308     0     0 I init    : Service 'boringssl_self_test_apex32' (pid 97) exited with status 0 waiting took 0.031000 seconds
+12-13 10:32:25.308     0     0 I init    : Sending signal 9 to service 'boringssl_self_test_apex32' (pid 97) process group...
+12-13 10:32:25.309     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 97 in 0ms
+12-13 10:32:25.309     0     0 I init    : processing action (apexd.status=ready && ro.product.cpu.abilist64=*) from (/system/etc/init/hw/init.rc:91)
+12-13 10:32:25.309     0     0 I init    : starting service 'boringssl_self_test_apex64'...
+12-13 10:32:25.311     0     0 I init    : SVC_EXEC service 'boringssl_self_test_apex64' pid 100 (uid 0 gid 0+0 context default) started; waiting...
+12-13 10:32:25.317    74    74 I HidlServiceManagement: Registered android.hardware.audio.effect@6.0::IEffectsFactory/default
+12-13 10:32:25.318    74    74 I LegacySupport: Registration complete for android.hardware.audio.effect@6.0::IEffectsFactory/default.
+12-13 10:32:25.318    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.soundtrigger@2.3::ISoundTriggerHw/default in either framework or device manifest.
+12-13 10:32:25.320    74    74 E LegacySupport: Could not get passthrough implementation for android.hardware.soundtrigger@2.3::ISoundTriggerHw/default.
+12-13 10:32:25.321    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.soundtrigger@2.2::ISoundTriggerHw/default in either framework or device manifest.
+12-13 10:32:25.327     0     0 I init    : Service 'boringssl_self_test_apex64' (pid 100) exited with status 0 waiting took 0.017000 seconds
+12-13 10:32:25.327     0     0 I init    : Sending signal 9 to service 'boringssl_self_test_apex64' (pid 100) process group...
+12-13 10:32:25.327     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 100 in 0ms
+12-13 10:32:25.327     0     0 I init    : processing action (sys.init.perf_lsm_hooks=1) from (/system/etc/init/hw/init.rc:1005)
+12-13 10:32:25.328     0     0 I init    : processing action (security.perf_harden=1) from (/system/etc/init/hw/init.rc:1019)
+12-13 10:32:25.328     0     0 I init    : processing action (ro.debuggable=1) from (/system/etc/init/hw/init.rc:1046)
+12-13 10:32:25.328     0     0 I init    : processing action (sys.usb.config=adb && sys.usb.configfs=0) from (/system/etc/init/hw/init.usb.rc:37)
+12-13 10:32:25.329     0     0 I init    : starting service 'adbd'...
+12-13 10:32:25.329     0     0 I init    : Created socket '/dev/socket/adbd', mode 660, user 1000, group 1000
+12-13 10:32:25.331     0     0 I init    : processing action (init.svc.audioserver=running) from (/system/etc/init/audioserver.rc:35)
+12-13 10:32:25.331     0     0 I init    : Command 'start vendor.audio-hal-4-0-msd' action=init.svc.audioserver=running (/system/etc/init/audioserver.rc:37) took 0ms and failed: service vendor.audio-hal-4-0-msd not found
+12-13 10:32:25.331     0     0 I init    : Command 'start vendor.audio-hal-2-0' action=init.svc.audioserver=running (/system/etc/init/audioserver.rc:39) took 0ms and failed: service vendor.audio-hal-2-0 not found
+12-13 10:32:25.331     0     0 I init    : Command 'start audio-hal-2-0' action=init.svc.audioserver=running (/system/etc/init/audioserver.rc:40) took 0ms and failed: service audio-hal-2-0 not found
+12-13 10:32:25.331     0     0 I init    : processing action (ro.persistent_properties.ready=true) from (/system/etc/init/bootstat.rc:67)
+12-13 10:32:25.331     0     0 I init    : processing action (ro.persistent_properties.ready=true) from (/system/etc/init/bootstat.rc:71)
+12-13 10:32:25.331     0     0 I init    : starting service 'exec 13 (/system/bin/bootstat --set_system_boot_reason)'...
+12-13 10:32:25.331    74    74 E LegacySupport: Could not get passthrough implementation for android.hardware.soundtrigger@2.2::ISoundTriggerHw/default.
+12-13 10:32:25.331    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.soundtrigger@2.1::ISoundTriggerHw/default in either framework or device manifest.
+12-13 10:32:25.331    74    74 E LegacySupport: Could not get passthrough implementation for android.hardware.soundtrigger@2.1::ISoundTriggerHw/default.
+12-13 10:32:25.332    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.soundtrigger@2.0::ISoundTriggerHw/default in either framework or device manifest.
+12-13 10:32:25.332    74    74 E LegacySupport: Could not get passthrough implementation for android.hardware.soundtrigger@2.0::ISoundTriggerHw/default.
+12-13 10:32:25.332    74    74 W audiohalservice: Could not register Soundtrigger API
+12-13 10:32:25.332    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.bluetooth.audio@2.0::IBluetoothAudioProvidersFactory/default in either framework or device manifest.
+12-13 10:32:25.332    74    74 E LegacySupport: Could not get passthrough implementation for android.hardware.bluetooth.audio@2.0::IBluetoothAudioProvidersFactory/default.
+12-13 10:32:25.332    74    74 W audiohalservice: Could not register Bluetooth Audio API
+12-13 10:32:25.332    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.bluetooth.a2dp@1.0::IBluetoothAudioOffload/default in either framework or device manifest.
+12-13 10:32:25.332    74    74 E LegacySupport: Could not get passthrough implementation for android.hardware.bluetooth.a2dp@1.0::IBluetoothAudioOffload/default.
+12-13 10:32:25.332    74    74 W audiohalservice: Could not register Bluetooth Audio Offload API
+12-13 10:32:25.332     0     0 I init    : processing action (persist.heapprofd.enable= && traced.lazy.heapprofd=) from (/system/etc/init/heapprofd.rc:34)
+12-13 10:32:25.333     0     0 I init    : processing action (ro.iorapd.enable=false) from (/system/etc/init/iorapd.rc:25)
+12-13 10:32:25.333     0     0 I init    : processing action (ro.debuggable=1) from (/system/etc/init/llkd-debuggable.rc:1)
+12-13 10:32:25.333     0     0 I init    : processing action (ro.debuggable=*) from (/system/etc/init/llkd.rc:2)
+12-13 10:32:25.333     0     0 I init    : processing action (debug.atrace.user_initiated= && persist.traced.enable=1) from (/system/etc/init/perfetto.rc:47)
+12-13 10:32:25.334     0     0 I init    : starting service 'traced_probes'...
+12-13 10:32:25.334     0     0 I init    : Opened file '/dev/kmsg', flags 1
+12-13 10:32:25.336     0     0 I init    : processing action (persist.traced.enable=1) from (/system/etc/init/perfetto.rc:50)
+12-13 10:32:25.337    78    78 D HostConnection: createUnique: call
+12-13 10:32:25.337     0     0 I init    : starting service 'traced'...
+12-13 10:32:25.338     0     0 I init    : Created socket '/dev/socket/traced_consumer', mode 666, user 0, group 0
+12-13 10:32:25.338     0     0 I init    : Created socket '/dev/socket/traced_producer', mode 666, user 0, group 0
+12-13 10:32:25.339    78    78 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:25.341     0     0 I init    : processing action (persist.traced_perf.enable= && sys.init.perf_lsm_hooks=1 && traced.lazy.traced_perf=) from (/system/etc/init/traced_perf.rc:43)
+12-13 10:32:25.341     0     0 I init    : processing action (ro.enable.native.bridge.exec=1) from (/vendor/etc/init/init.windows_x86_64.rc:46)
+12-13 10:32:25.343     0     0 I init    : processing action (ro.enable.native.bridge.exec64=1) from (/vendor/etc/init/init.windows_x86_64.rc:50)
+12-13 10:32:25.343     0     0 I init    : processing action (nonencrypted) from (/system/etc/init/hw/init.rc:941)
+12-13 10:32:25.344     0     0 I init    : starting service 'cameraserver'...
+12-13 10:32:25.346     0     0 I init    : starting service 'drm'...
+12-13 10:32:25.347     0     0 I init    : starting service 'idmap2d'...
+12-13 10:32:25.348     0     0 I init    : starting service 'incidentd'...
+12-13 10:32:25.350     0     0 I init    : starting service 'installd'...
+12-13 10:32:25.351   104   104 I bootstat: Service started: /system/bin/bootstat --set_system_boot_reason 
+12-13 10:32:25.352     0     0 I init    : starting service 'keystore'...
+12-13 10:32:25.355   106   106 W perfetto: service.cc:97           Started traced, listening on /dev/socket/traced_producer /dev/socket/traced_consumer
+12-13 10:32:25.361    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@4.0::IMapper/default in either framework or device manifest.
+12-13 10:32:25.361    84    84 I Gralloc4: mapper 4.x is not supported
+12-13 10:32:25.361     0     0 I init    : starting service 'mediaextractor'...
+12-13 10:32:25.362    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+12-13 10:32:25.362    84    84 W Gralloc3: mapper 3.x is not supported
+12-13 10:32:25.364     0     0 I init    : starting service 'mediametrics'...
+12-13 10:32:25.364   105   105 I perfetto: probes.cc:77            Starting /system/bin/traced_probes service
+12-13 10:32:25.367     0     0 I init    : starting service 'media'...
+12-13 10:32:25.367     0     0 W libprocessgroup: Failed to open /dev/cpuset/camera-daemon/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.369     0     0 W libprocessgroup: Failed to apply CameraServiceCapacity task profile: No such file or directory
+12-13 10:32:25.370     0     0 I init    : starting service 'storaged'...
+12-13 10:32:25.371    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.371     0     0 W libprocessgroup: Failed to open /dev/stune/top-app/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.372    78    78 D HostConnection: HostConnection::get() New Host Connection established 0x70cc726cacd0, tid 78
+12-13 10:32:25.372     0     0 I init    : Could not open file '/d/mmc0/mmc0:0001/ext_csd': Failed to open file '/d/mmc0/mmc0:0001/ext_csd': No such file or directory
+12-13 10:32:25.372     0     0 W libprocessgroup: Failed to apply MaxPerformance task profile: No such file or directory
+12-13 10:32:25.377    84    84 D HostConnection: createUnique: call
+12-13 10:32:25.379    78    78 I HidlServiceManagement: Registered android.hardware.graphics.allocator@2.0::IAllocator/default
+12-13 10:32:25.379   104   104 I bootstat: Canonical boot reason: shutdown,userrequested
+12-13 10:32:25.379   104   104 I bootstat: Canonical boot reason: shutdown,userrequested
+12-13 10:32:25.380    78    78 I HidlServiceManagement: Removing namespace from process name android.hardware.graphics.allocator@2.0-service to allocator@2.0-service.
+12-13 10:32:25.380    78    78 I LegacySupport: Registration complete for android.hardware.graphics.allocator@2.0::IAllocator/default.
+12-13 10:32:25.382   105   105 I perfetto: probes_producer.cc:100  Connected to the service
+12-13 10:32:25.385    84    84 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:25.386     0     0 W libprocessgroup: Failed to open /dev/stune/foreground/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.388     0     0 W libprocessgroup: Failed to apply HighPerformance task profile: No such file or directory
+12-13 10:32:25.388     0     0 W libprocessgroup: Failed to open /dev/stune/foreground/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.391     0     0 W libprocessgroup: Failed to apply HighPerformance task profile: No such file or directory
+12-13 10:32:25.393   103   103 I adbd    : Setup mdns on port= 5555
+12-13 10:32:25.393   103   103 I adbd    : adbd listening on tcp:5555
+12-13 10:32:25.394   103   103 I adbd    : adbd listening on vsock:5555
+12-13 10:32:25.402   103   124 I adbd    : Waiting for persist.adb.tls_server.enable=1
+12-13 10:32:25.402   112   112 I installd: installd firing up
+12-13 10:32:25.415    84    84 D HostConnection: HostConnection::get() New Host Connection established 0x77686be59010, tid 84
+12-13 10:32:25.423   104   104 E bootstat: Failed to read /metadata/bootstat/persist.sys.boot.reason: No such file or directory
+12-13 10:32:25.423   104   104 I bootstat: Value of persist.sys.boot.reason : shutdown,userrequested
+12-13 10:32:25.423   104   104 I bootstat: Normalized last reboot reason : shutdown,userrequested
+12-13 10:32:25.424    42    42 D RemoteConnectionManager: createChannel called for Composition
+12-13 10:32:25.424    42    42 D librcm  : createChannel called with channel name: Composition
+12-13 10:32:25.424    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587750
+12-13 10:32:25.429     0     0 I init    : starting service 'wificond'...
+12-13 10:32:25.430    83    83 I HidlServiceManagement: Registered android.hardware.gnss@2.1::IGnss/default
+12-13 10:32:25.435    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.435    42    42 D librcm  : Returning channel Composition
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 44
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 45
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 46
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 47
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 48
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 49
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 50
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 51
+12-13 10:32:25.444    84    84 E HWC2OnFbAdapter: unknown function descriptor 52
+12-13 10:32:25.446    84    84 I HidlServiceManagement: Registered android.hardware.graphics.composer@2.2::IComposer/default
+12-13 10:32:25.447   113   113 I keystore: found android.hardware.keymaster@4.0::IKeymasterDevice with interface name default and seclevel SOFTWARE
+12-13 10:32:25.449    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.keymaster@3.0::IKeymasterDevice/default in either framework or device manifest.
+12-13 10:32:25.449   104   104 E bootstat: Failed to unlink /metadata/bootstat/persist.sys.boot.reason: No such file or directory
+12-13 10:32:25.450   113   113 W keystore: No secure Keymaster implementation found, but device offers insecure Keymaster HAL. Using as default.
+12-13 10:32:25.452   117   117 V MediaUtils: physMem: 6286368768
+12-13 10:32:25.452   117   117 V MediaUtils: requested limit: 134217728
+12-13 10:32:25.452   117   117 I libc    : malloc_limit: Allocation limit enabled, max size 134217728 bytes
+12-13 10:32:25.455   117   117 D AudioPowerUsage: AudioPowerUsage
+12-13 10:32:25.458   117   117 D AudioAnalytics: AudioAnalytics
+12-13 10:32:25.463     0     0 I init    : starting service 'vendor.media.omx'...
+12-13 10:32:25.463   117   117 D MediaMetricsService: MediaMetricsService
+12-13 10:32:25.464     0     0 I init    : starting service 'windows-logcat'...
+12-13 10:32:25.465     0     0 E init    : Could not start service 'vendor_flash_recovery' as part of class 'main': Cannot find '/vendor/bin/install-recovery.sh': No such file or directory
+12-13 10:32:25.466     0     0 I init    : starting service 'media.swcodec'...
+12-13 10:32:25.468     0     0 I init    : Command 'class_start main' action=nonencrypted (/system/etc/init/hw/init.rc:942) took 123ms and succeeded
+12-13 10:32:25.468     0     0 I init    : Service 'exec 13 (/system/bin/bootstat --set_system_boot_reason)' (pid 104) exited with status 0 oneshot service took 0.135000 seconds in background
+12-13 10:32:25.468     0     0 I init    : Sending signal 9 to service 'exec 13 (/system/bin/bootstat --set_system_boot_reason)' (pid 104) process group...
+12-13 10:32:25.468     0     0 I libprocessgroup: Successfully killed process cgroup uid 1000 pid 104 in 0ms
+12-13 10:32:25.468     0     0 I init    : starting service 'mdnsd'...
+12-13 10:32:25.468     0     0 I init    : Created socket '/dev/socket/mdnsd', mode 660, user 1020, group 3003
+12-13 10:32:25.470     0     0 I init    : Control message: Processed ctl.start for 'mdnsd' from pid: 103 (/apex/com.android.adbd/bin/adbd --root_seclabel=u:r:su:s0)
+12-13 10:32:25.470     0     0 I init    : starting service 'gatekeeperd'...
+12-13 10:32:25.471    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.472     0     0 I init    : starting service 'usbd'...
+12-13 10:32:25.473    66    66 D XfrmController: Sending Netlink XFRM Message: XFRM_MSG_FLUSHSA
+12-13 10:32:25.473    66    66 D XfrmController: Sending Netlink XFRM Message: XFRM_MSG_FLUSHPOLICY
+12-13 10:32:25.473    66    66 I netd    : Initializing XfrmController: 196041us
+12-13 10:32:25.473    66    66 E Netd    : Unable to create netlink socket for family 5: Protocol not supported
+12-13 10:32:25.473    66    66 W Netd    : Unable to open qlog quota socket, check if xt_quota2 can send via UeventHandler
+12-13 10:32:25.474     0     0 I init    : starting service 'diagnostics_service'...
+12-13 10:32:25.477     0     0 I init    : starting service 'inputsvc'...
+12-13 10:32:25.479     0     0 I init    : processing action (llk.enable=1) from (/system/etc/init/llkd.rc:9)
+12-13 10:32:25.479     0     0 I init    : processing action (khungtask.enable=1) from (/system/etc/init/llkd.rc:18)
+12-13 10:32:25.479     0     0 I init    : processing action (llk.enable=0) from (/system/etc/init/llkd.rc:12)
+12-13 10:32:25.479     0     0 I init    : processing action (khungtask.enable=0) from (/system/etc/init/llkd.rc:21)
+12-13 10:32:25.479     0     0 I init    : processing action (init.svc.media=*) from (/system/etc/init/mediaserver.rc:1)
+12-13 10:32:25.480     0     0 I init    : processing action (llk.enable=true) from (/system/etc/init/llkd.rc:34)
+12-13 10:32:25.480     0     0 I init    : starting service 'llkd-1'...
+12-13 10:32:25.480     0     0 I init    : Opened file '/dev/kmsg', flags 1
+12-13 10:32:25.480     0     0 I init    : Opened file '/proc/sysrq-trigger', flags 1
+12-13 10:32:25.481     0     0 I init    : processing action (khungtask.enable=true) from (/system/etc/init/llkd.rc:25)
+12-13 10:32:25.482     0     0 I init    : processing action (khungtask.enable=false) from (/system/etc/init/llkd.rc:31)
+12-13 10:32:25.507   133   133 I wificond: wificond is starting up...
+12-13 10:32:25.514   133   133 I HidlServiceManagement: Registered android.system.wifi.keystore@1.0::IKeystore/default
+12-13 10:32:25.516    66    66 I libnetd_resolv: resolv_init: Initializing resolver
+12-13 10:32:25.520   149   149 I livelock: started
+12-13 10:32:25.521   149   149 W livelock: [khungtaskd] not configurable
+12-13 10:32:25.533   149   149 I livelock: ro.config.low_ram=false
+12-13 10:32:25.533   149   149 I livelock: ro.llk.sysrq_t=true
+12-13 10:32:25.533   149   149 I livelock: ro.llk.enable=true
+12-13 10:32:25.533   149   149 I livelock: ro.khungtask.enable=true
+12-13 10:32:25.533   149   149 I livelock: ro.llk.mlockall=true
+12-13 10:32:25.533   149   149 I livelock: ro.llk.killtest=true
+12-13 10:32:25.533   149   149 I livelock: ro.khungtask.timeout=720s
+12-13 10:32:25.533   149   149 I livelock: ro.llk.timeout_ms=600.000s
+12-13 10:32:25.533   149   149 I livelock: ro.llk.D.timeout_ms=600.000s
+12-13 10:32:25.533   149   149 I livelock: ro.llk.Z.timeout_ms=600.000s
+12-13 10:32:25.533   149   149 I livelock: ro.llk.stack.timeout_ms=600.000s
+12-13 10:32:25.533   149   149 I livelock: ro.llk.check_ms=120.000s
+12-13 10:32:25.533   149   149 I livelock: ro.llk.stack=wait_on_page_bit_killable,bit_wait_io,__get_user_pages,cma_alloc
+12-13 10:32:25.533   149   149 I livelock: ro.llk.ignorelist.process.stack=llkd,lmkd.llkd,apexd,ueventd,keystore,init
+12-13 10:32:25.533   149   149 I livelock: ro.llk.ignorelist.process=[watchdog/5],[watchdog/3],[watchdog/2],[watchdog/1],[watchdog/6],[watchdogd/0],2,[watchdogd],watchdogd,[watchdog/4],llkd,lmkd,[khungtaskd],[kthreadd],init,[watchdog/7],0,149,1
+12-13 10:32:25.533   149   149 I livelock: ro.llk.ignorelist.parent=[kthreadd],2,0,adbd&[setsid]
+12-13 10:32:25.533   149   149 I livelock: ro.llk.ignorelist.uid=
+12-13 10:32:25.536   143   143 I gatekeeperd: Starting gatekeeperd...
+12-13 10:32:25.560    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.configstore@1.0::ISurfaceFlingerConfigs/default in either framework or device manifest.
+12-13 10:32:25.555     0     0 D logd    : logdr: UID=1036 GID=0 PID=139 b tail=0 logMask=ff pid=0 start=0ns timeout=0ns
+12-13 10:32:25.572    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.574    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.usb.gadget@1.0::IUsbGadget/default in either framework or device manifest.
+12-13 10:32:25.576    89    89 I SurfaceFlinger: Using HWComposer service: 'default'
+12-13 10:32:25.578    89    89 I SurfaceFlinger: SurfaceFlinger is starting
+12-13 10:32:25.579    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.configstore@1.1::ISurfaceFlingerConfigs/default in either framework or device manifest.
+12-13 10:32:25.582   144   144 I usbd    : Usb HAL not found
+12-13 10:32:25.590    86    86 I FastMixerState: sMaxFastTracks = 8
+12-13 10:32:25.591    89    89 I SurfaceFlinger: Disabling blur effects, they are not supported.
+12-13 10:32:25.591    89    89 I SurfaceFlinger: Treble testing override: 'false'
+12-13 10:32:25.590     0     0 I init    : Service 'usbd' (pid 144) exited with status 0 oneshot service took 0.116000 seconds in background
+12-13 10:32:25.590     0     0 I init    : Sending signal 9 to service 'usbd' (pid 144) process group...
+12-13 10:32:25.590     0     0 I libprocessgroup: Successfully killed process cgroup uid 0 pid 144 in 0ms
+12-13 10:32:25.594    89    89 I SurfaceFlinger: SurfaceFlinger's main thread ready to run. Initializing graphics H/W...
+12-13 10:32:25.594    89    89 D RenderEngine: RenderEngine GLES Backend
+12-13 10:32:25.610    86    86 V MediaUtils: physMem: 6286368768
+12-13 10:32:25.611    86    86 V MediaUtils: requested limit: 536870912
+12-13 10:32:25.611    86    86 I libc    : malloc_limit: Allocation limit enabled, max size 536870912 bytes
+12-13 10:32:25.612    42    42 D RemoteConnectionManager: createChannel called for Diagnostics
+12-13 10:32:25.613    42    42 D librcm  : createChannel called with channel name: Diagnostics
+12-13 10:32:25.613    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587749
+12-13 10:32:25.617    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.617    42    42 D librcm  : Returning channel Diagnostics
+12-13 10:32:25.620   145   145 I diagnostics_service: file watchers successfully initialized
+12-13 10:32:25.620    89    89 D libEGL  : loaded /vendor/lib64/egl/libEGL_emulation.so
+12-13 10:32:25.621    86    86 I audioserver: ServiceManager: 0x72db1bdeea30
+12-13 10:32:25.624    86    86 W BatteryNotifier: batterystats service unavailable!
+12-13 10:32:25.627     0     0 I input   : virtual_keyboard as /devices/virtual/input/input0
+12-13 10:32:25.632   115   115 V MediaUtils: physMem: 6286368768
+12-13 10:32:25.634   115   115 V MediaUtils: requested limit: 1257273740
+12-13 10:32:25.634   115   115 I libc    : malloc_limit: Allocation limit enabled, max size 1257273740 bytes
+12-13 10:32:25.635    89    89 D libEGL  : loaded /vendor/lib64/egl/libGLESv1_CM_emulation.so
+12-13 10:32:25.640   115   115 W mediaextractor: Could not read additional policy file '/vendor/etc/seccomp_policy/mediaextractor.policy'
+12-13 10:32:25.640    89    89 D libEGL  : loaded /vendor/lib64/egl/libGLESv2_emulation.so
+12-13 10:32:25.641    42    42 D RemoteConnectionManager: createChannel called for UserInputNative
+12-13 10:32:25.641    42    42 D librcm  : createChannel called with channel name: UserInputNative
+12-13 10:32:25.641    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587748
+12-13 10:32:25.642   115   115 W mediaextractor: libminijail[115]: failed to get path of fd 4: No such file or directory
+12-13 10:32:25.642   115   115 W mediaextractor: libminijail[115]: allowing syscall: socket
+12-13 10:32:25.642   115   115 W mediaextractor: libminijail[115]: allowing syscall: connect
+12-13 10:32:25.642   115   115 W mediaextractor: libminijail[115]: allowing syscall: fcntl
+12-13 10:32:25.642   115   115 W mediaextractor: libminijail[115]: allowing syscall: writev
+12-13 10:32:25.643   115   115 W mediaextractor: libminijail[115]: logging seccomp filter failures
+12-13 10:32:25.643    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.643    42    42 D librcm  : Returning channel UserInputNative
+12-13 10:32:25.660     0     0 I input   : virtual_touchscreen as /devices/virtual/input/input1
+12-13 10:32:25.659    67    67 D AndroidRuntime: >>>>>> START com.android.internal.os.ZygoteInit uid 0 <<<<<<
+12-13 10:32:25.659    67    67 I boot_progress_start: 4380
+12-13 10:32:25.672    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.674    86    86 I AudioFlinger: Using default 3000 mSec as standby time.
+12-13 10:32:25.675   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.685    86    86 E APM::Serializer: deserialize: Could not parse /odm/etc/audio_policy_configuration.xml document.
+12-13 10:32:25.688    89    89 D HostConnection: createUnique: call
+12-13 10:32:25.690    89    89 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:25.692   119   119 I mediaserver: ServiceManager: 0xf4d00950
+12-13 10:32:25.692    68    68 D AndroidRuntime: >>>>>> START com.android.internal.os.ZygoteInit uid 0 <<<<<<
+12-13 10:32:25.694   119   119 D mediaserver: Time zone APEX ICU file found: /apex/com.android.tzdata/etc/icu/icu_tzdata.dat
+12-13 10:32:25.697   119   119 D mediaserver: I18n APEX ICU file found: /apex/com.android.i18n/etc/icu/icudt66l.dat
+12-13 10:32:25.700    67    67 I AndroidRuntime: Using default boot image
+12-13 10:32:25.700    67    67 I AndroidRuntime: Leaving lock profiling enabled
+12-13 10:32:25.700    89    89 D HostConnection: HostConnection::get() New Host Connection established 0x7ae2771c0f10, tid 89
+12-13 10:32:25.703    89    89 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:25.707    67    67 I zygote64: option[0]=-Xzygote
+12-13 10:32:25.707    67    67 I zygote64: option[1]=exit
+12-13 10:32:25.707    67    67 I zygote64: option[2]=vfprintf
+12-13 10:32:25.707    67    67 I zygote64: option[3]=sensitiveThread
+12-13 10:32:25.707    67    67 I zygote64: option[4]=-verbose:gc
+12-13 10:32:25.707    67    67 I zygote64: option[5]=-XX:PerfettoHprof=true
+12-13 10:32:25.707    67    67 I zygote64: option[6]=-Xprimaryzygote
+12-13 10:32:25.707    67    67 I zygote64: option[7]=-Xms16m
+12-13 10:32:25.707    67    67 I zygote64: option[8]=-Xmx512m
+12-13 10:32:25.707    67    67 I zygote64: option[9]=-XX:HeapGrowthLimit=192m
+12-13 10:32:25.707    67    67 I zygote64: option[10]=-XX:HeapMinFree=512k
+12-13 10:32:25.707    67    67 I zygote64: option[11]=-XX:HeapMaxFree=8m
+12-13 10:32:25.707    67    67 I zygote64: option[12]=-XX:HeapTargetUtilization=0.75
+12-13 10:32:25.707    67    67 I zygote64: option[13]=-Xusejit:true
+12-13 10:32:25.707    67    67 I zygote64: option[14]=-Xjitsaveprofilinginfo
+12-13 10:32:25.707    67    67 I zygote64: option[15]=-XjdwpOptions:suspend=n,server=y
+12-13 10:32:25.707    67    67 I zygote64: option[16]=-XjdwpProvider:default
+12-13 10:32:25.708    67    67 I zygote64: option[17]=-Xopaque-jni-ids:swapable
+12-13 10:32:25.708    67    67 I zygote64: option[18]=-Xlockprofthreshold:500
+12-13 10:32:25.708    67    67 I zygote64: option[19]=-Xcompiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[20]=--instruction-set-variant=x86_64
+12-13 10:32:25.708    67    67 I zygote64: option[21]=-Xcompiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[22]=--instruction-set-features=default
+12-13 10:32:25.708    67    67 I zygote64: option[23]=-Xcompiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[24]=--generate-mini-debug-info
+12-13 10:32:25.708    67    67 I zygote64: option[25]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[26]=--runtime-arg
+12-13 10:32:25.708    67    67 I zygote64: option[27]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[28]=-Xms64m
+12-13 10:32:25.708    67    67 I zygote64: option[29]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[30]=--runtime-arg
+12-13 10:32:25.708   119   119 W BatteryNotifier: batterystats service unavailable!
+12-13 10:32:25.708    67    67 I zygote64: option[31]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[32]=-Xmx64m
+12-13 10:32:25.708    67    67 I zygote64: option[33]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[34]=--dirty-image-objects=/system/etc/dirty-image-objects
+12-13 10:32:25.708    67    67 I zygote64: option[35]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[36]=--instruction-set-variant=x86_64
+12-13 10:32:25.708    67    67 I zygote64: option[37]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[38]=--instruction-set-features=default
+12-13 10:32:25.708    86    86 D APM_EngineLoader: Loaded engine from libaudiopolicyenginedefault.so
+12-13 10:32:25.708    67    67 I zygote64: option[39]=-Ximage-compiler-option
+12-13 10:32:25.708    67    67 I zygote64: option[40]=--generate-mini-debug-info
+12-13 10:32:25.708    67    67 I zygote64: option[41]=-Duser.locale=en-US
+12-13 10:32:25.708    67    67 I zygote64: option[42]=-XX:NativeBridge=libhoudini.so
+12-13 10:32:25.708    67    67 I zygote64: option[43]=--cpu-abilist=x86_64,arm64-v8a
+12-13 10:32:25.708    67    67 I zygote64: option[44]=-Xcore-platform-api-policy:just-warn
+12-13 10:32:25.708    67    67 I zygote64: option[45]=-Xfingerprint:Windows/windows_x86_64/windows_x86_64:11/RD2A.211001.002/eng.latteu.20211023.051150:userdebug/test-keys
+12-13 10:32:25.709    86    86 E APM::AudioPolicyEngine/Config: parse: Could not parse document /vendor/etc/audio_policy_engine_configuration.xml
+12-13 10:32:25.709    86    86 E libxml2 : I/O warning : failed to load external entity "/vendor/etc/audio_policy_engine_configuration.xml"
+12-13 10:32:25.709    86    86 W APM::AudioPolicyEngine/Base: loadAudioPolicyEngineConfig: No configuration found, using default matching phone experience.
+12-13 10:32:25.709    86    86 E APM::AudioPolicyEngine/Config: parseLegacyVolumeFile: Could not parse document /odm/etc/audio_policy_configuration.xml
+12-13 10:32:25.709    86    86 E libxml2 : I/O warning : failed to load external entity "/odm/etc/audio_policy_configuration.xml"
+12-13 10:32:25.710   119   119 W BatteryNotifier: batterystats service unavailable!
+12-13 10:32:25.710    89    89 I RenderEngine: EGL information:
+12-13 10:32:25.710    89    89 I RenderEngine: vendor    : Android
+12-13 10:32:25.710    89    89 I RenderEngine: version   : 1.4 Android META-EGL
+12-13 10:32:25.710    89    89 I RenderEngine: extensions: EGL_KHR_get_all_proc_addresses EGL_ANDROID_presentation_time EGL_KHR_swap_buffers_with_damage EGL_ANDROID_get_native_client_buffer EGL_ANDROID_front_buffer_auto_refresh EGL_ANDROID_get_frame_timestamps EGL_EXT_surface_SMPTE2086_metadata EGL_EXT_surface_CTA861_3_metadata EGL_KHR_image EGL_KHR_image_base EGL_KHR_gl_texture_2D_image EGL_KHR_fence_sync EGL_KHR_create_context EGL_ANDROID_image_native_buffer EGL_ANDROID_recordable 
+12-13 10:32:25.710    89    89 I RenderEngine: Client API: OpenGL_ES
+12-13 10:32:25.710    89    89 I RenderEngine: EGLSurface: 8-8-8-8, config=0xd
+12-13 10:32:25.711   107   107 I cameraserver: ServiceManager: 0xe95409b0
+12-13 10:32:25.712   107   107 I CameraService: CameraService started (pid=107)
+12-13 10:32:25.712   107   107 I CameraService: CameraService process starting
+12-13 10:32:25.713   107   107 W BatteryNotifier: batterystats service unavailable!
+12-13 10:32:25.713    89    89 E EGL_emulation: eglCreateContext: 0x7ae2771c24d0: maj 3 min 0 rcv 3
+12-13 10:32:25.713   107   107 W BatteryNotifier: batterystats service unavailable!
+12-13 10:32:25.715   115   115 E MediaExtractorFactory: couldn't opendir(/system/lib64/extractors)
+12-13 10:32:25.715   115   115 E MediaExtractorFactory: couldn't opendir(/system_ext/lib64/extractors)
+12-13 10:32:25.719    86    86 W APM::AudioPolicyEngine/Base: loadAudioPolicyEngineConfig: No configuration of AUDIO_STREAM_CALL_ASSISTANT found, using default volume configuration
+12-13 10:32:25.722    89    89 D EGL_emulation: eglMakeCurrent: 0x7ae2771c24d0: ver 3 0 (tinfo 0x7ae3f94cc080) (first time)
+12-13 10:32:25.732    23    23 I hwservicemanager: Since android.hardware.camera.provider@2.4::ICameraProvider/legacy/0 is not registered, trying to start it as a lazy HAL.
+12-13 10:32:25.732   107   107 E CameraProviderManager: addProviderLocked: Camera provider HAL 'legacy/0' is not actually available
+12-13 10:32:25.734   107   107 I cameraserver: Waiting for activity service
+12-13 10:32:25.734   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.735    68    68 I AndroidRuntime: Using default boot image
+12-13 10:32:25.735    68    68 I AndroidRuntime: Leaving lock profiling enabled
+12-13 10:32:25.737   138   138 I android.hardware.media.omx@1.0-service: mediacodecservice starting
+12-13 10:32:25.739    67    67 I zygote64: Core platform API reporting enabled, enforcing=false
+12-13 10:32:25.737     0     0 I init    : starting service 'windows-camera-hal'...
+12-13 10:32:25.740     0     0 I init    : Control message: Processed ctl.interface_start for 'android.hardware.camera.provider@2.4::ICameraProvider/legacy/0' from pid: 23 (/system/bin/hwservicemanager)
+12-13 10:32:25.741   138   138 W android.hardware.media.omx@1.0-service: Could not read additional policy file '/vendor/etc/seccomp_policy/mediacodec.policy'
+12-13 10:32:25.743   140   140 I mediaswcodec: media swcodec service starting
+12-13 10:32:25.744    68    68 I zygote  : option[0]=-Xzygote
+12-13 10:32:25.744    68    68 I zygote  : option[1]=exit
+12-13 10:32:25.744    68    68 I zygote  : option[2]=vfprintf
+12-13 10:32:25.744    68    68 I zygote  : option[3]=sensitiveThread
+12-13 10:32:25.744    68    68 I zygote  : option[4]=-verbose:gc
+12-13 10:32:25.744    68    68 I zygote  : option[5]=-XX:PerfettoHprof=true
+12-13 10:32:25.744    68    68 I zygote  : option[6]=-Xms16m
+12-13 10:32:25.744    68    68 I zygote  : option[7]=-Xmx512m
+12-13 10:32:25.744    68    68 I zygote  : option[8]=-XX:HeapGrowthLimit=192m
+12-13 10:32:25.744    68    68 I zygote  : option[9]=-XX:HeapMinFree=512k
+12-13 10:32:25.744    68    68 I zygote  : option[10]=-XX:HeapMaxFree=8m
+12-13 10:32:25.744    68    68 I zygote  : option[11]=-XX:HeapTargetUtilization=0.75
+12-13 10:32:25.744   140   140 W mediaswcodec: Could not read additional policy file '/vendor/etc/seccomp_policy/mediaswcodec.policy'
+12-13 10:32:25.744    68    68 I zygote  : option[12]=-Xusejit:true
+12-13 10:32:25.744    68    68 I zygote  : option[13]=-Xjitsaveprofilinginfo
+12-13 10:32:25.744    68    68 I zygote  : option[14]=-XjdwpOptions:suspend=n,server=y
+12-13 10:32:25.744    68    68 I zygote  : option[15]=-XjdwpProvider:default
+12-13 10:32:25.744    68    68 I zygote  : option[16]=-Xopaque-jni-ids:swapable
+12-13 10:32:25.744    68    68 I zygote  : option[17]=-Xlockprofthreshold:500
+12-13 10:32:25.744    68    68 I zygote  : option[18]=-Xcompiler-option
+12-13 10:32:25.744    68    68 I zygote  : option[19]=--instruction-set-variant=x86_64
+12-13 10:32:25.744    68    68 I zygote  : option[20]=-Xcompiler-option
+12-13 10:32:25.744    68    68 I zygote  : option[21]=--instruction-set-features=default
+12-13 10:32:25.744    68    68 I zygote  : option[22]=-Xcompiler-option
+12-13 10:32:25.744    68    68 I zygote  : option[23]=--generate-mini-debug-info
+12-13 10:32:25.744    68    68 I zygote  : option[24]=-Ximage-compiler-option
+12-13 10:32:25.745    68    68 I zygote  : option[25]=--runtime-arg
+12-13 10:32:25.745    68    68 I zygote  : option[26]=-Ximage-compiler-option
+12-13 10:32:25.745    68    68 I zygote  : option[27]=-Xms64m
+12-13 10:32:25.745    68    68 I zygote  : option[28]=-Ximage-compiler-option
+12-13 10:32:25.745   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: failed to get path of fd 4: No such file or directory
+12-13 10:32:25.745   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: allowing syscall: socketcall
+12-13 10:32:25.746   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: allowing syscall: writev
+12-13 10:32:25.746   140   140 W mediaswcodec: libminijail[140]: failed to get path of fd 4: No such file or directory
+12-13 10:32:25.746   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: allowing syscall: fcntl64
+12-13 10:32:25.746   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: allowing syscall: clock_gettime
+12-13 10:32:25.746   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: compile_file: <fd>(34): nonexistent syscall 'newfstatat'
+12-13 10:32:25.746    68    68 I zygote  : option[29]=--runtime-arg
+12-13 10:32:25.747    68    68 I zygote  : option[30]=-Ximage-compiler-option
+12-13 10:32:25.747    68    68 I zygote  : option[31]=-Xmx64m
+12-13 10:32:25.747    68    68 I zygote  : option[32]=-Ximage-compiler-option
+12-13 10:32:25.745     0     0 W libprocessgroup: Failed to open /dev/cpuset/camera-daemon/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: allowing syscall: socket
+12-13 10:32:25.747    68    68 I zygote  : option[33]=--dirty-image-objects=/system/etc/dirty-image-objects
+12-13 10:32:25.747    68    68 I zygote  : option[34]=-Ximage-compiler-option
+12-13 10:32:25.747    68    68 I zygote  : option[35]=--instruction-set-variant=x86_64
+12-13 10:32:25.747    68    68 I zygote  : option[36]=-Ximage-compiler-option
+12-13 10:32:25.747    68    68 I zygote  : option[37]=--instruction-set-features=default
+12-13 10:32:25.747    68    68 I zygote  : option[38]=-Ximage-compiler-option
+12-13 10:32:25.747    68    68 I zygote  : option[39]=--generate-mini-debug-info
+12-13 10:32:25.747    68    68 I zygote  : option[40]=-Duser.locale=en-US
+12-13 10:32:25.747    68    68 I zygote  : option[41]=-XX:NativeBridge=libhoudini.so
+12-13 10:32:25.747    68    68 I zygote  : option[42]=--cpu-abilist=x86,armeabi-v7a,armeabi
+12-13 10:32:25.747    68    68 I zygote  : option[43]=-Xcore-platform-api-policy:just-warn
+12-13 10:32:25.747    68    68 I zygote  : option[44]=-Xfingerprint:Windows/windows_x86_64/windows_x86_64:11/RD2A.211001.002/eng.latteu.20211023.051150:userdebug/test-keys
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: allowing syscall: connect
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: allowing syscall: fcntl
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: allowing syscall: writev
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(20): nonexistent syscall 'getuid32'
+12-13 10:32:25.747   138   138 W android.hardware.media.omx@1.0-service: libminijail[138]: logging seccomp filter failures
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(26): nonexistent syscall 'mmap2'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(28): nonexistent syscall 'fstat64'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(30): nonexistent syscall 'stat64'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(31): nonexistent syscall 'statfs64'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(33): nonexistent syscall 'fstatat64'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(38): nonexistent syscall '_llseek'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(47): nonexistent syscall 'ugetrlimit'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(50): nonexistent syscall '_llseek'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(51): nonexistent syscall 'fstatfs64'
+12-13 10:32:25.747   140   140 W mediaswcodec: libminijail[140]: compile_file: <fd>(63): nonexistent syscall 'ftruncate64'
+12-13 10:32:25.748   140   140 W mediaswcodec: libminijail[140]: logging seccomp filter failures
+12-13 10:32:25.755   138   138 D GoldfishOMXPlugin: called createOMXPlugin for Goldfish
+12-13 10:32:25.755   138   138 D GoldfishOMXPlugin: useOmxCodecs 54 found prop debug.stagefright.ccodec val 0
+12-13 10:32:25.755   138   138 D GoldfishOMXPlugin: useAndroidGoldfishComponentInstance 96 found prop debug.latte.hwcodec.avcdec val 2
+12-13 10:32:25.755   138   138 D GoldfishOMXPlugin: found and use kComponents[i].name OMX.android.goldfish.h264.decoder
+12-13 10:32:25.755   138   138 D GoldfishOMXPlugin: enumerate OMX.android.goldfish.h264.decoder component
+12-13 10:32:25.757   140   140 I CodecServiceRegistrant: Creating software Codec2 service...
+12-13 10:32:25.757    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@4.0::IMapper/default in either framework or device manifest.
+12-13 10:32:25.758   138   138 I SoftOMXPlugin: createOMXPlugin
+12-13 10:32:25.747     0     0 W libprocessgroup: Failed to apply CameraServiceCapacity task profile: No such file or directory
+12-13 10:32:25.748     0     0 W libprocessgroup: Failed to open /dev/stune/top-app/tasks: No such file or directory: No such file or directory
+12-13 10:32:25.750     0     0 W libprocessgroup: Failed to apply MaxPerformance task profile: No such file or directory
+12-13 10:32:25.758    89    89 I Gralloc4: mapper 4.x is not supported
+12-13 10:32:25.758   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs.xml...
+12-13 10:32:25.759    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+12-13 10:32:25.759    89    89 W Gralloc3: mapper 3.x is not supported
+12-13 10:32:25.761   140   140 D C2Store : Default ION heapmask = -1
+12-13 10:32:25.761   140   140 D C2Store : Default ION flags = 0
+12-13 10:32:25.761   140   140 D C2Store : Default ION align = 0
+12-13 10:32:25.761   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_google_audio.xml...
+12-13 10:32:25.762   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_google_telephony.xml...
+12-13 10:32:25.762   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_google_video.xml...
+12-13 10:32:25.763    89    89 D HostConnection: createUnique: call
+12-13 10:32:25.763   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_performance.xml...
+12-13 10:32:25.764    89    89 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:25.765   138   138 D MediaCodecsXmlParser: Cannot find /data/misc/media/media_codecs_profiling_results.xml
+12-13 10:32:25.766    74    74 I AudioHAL: Opening audio device audio_hw_if
+12-13 10:32:25.767   140   140 I HidlServiceManagement: Registered android.hardware.media.c2@1.1::IComponentStore/software
+12-13 10:32:25.767    74    74 I AudioHAL: Audio device initialized and opened.
+12-13 10:32:25.768   138   138 I HidlServiceManagement: Registered android.hardware.media.omx@1.0::IOmx/default
+12-13 10:32:25.768   138   138 I HidlServiceManagement: Removing namespace from process name android.hardware.media.omx@1.0-service to omx@1.0-service.
+12-13 10:32:25.768   138   138 I android.hardware.media.omx@1.0-service: IOmx HAL service created.
+12-13 10:32:25.768   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs.xml...
+12-13 10:32:25.769   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_google_audio.xml...
+12-13 10:32:25.769   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_google_telephony.xml...
+12-13 10:32:25.769   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_google_video.xml...
+12-13 10:32:25.769    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.media.c2@1.0::IComponentStore/default in either framework or device manifest.
+12-13 10:32:25.769   138   138 D MediaCodecsXmlParser: parsing /vendor/etc/media_codecs_performance.xml...
+12-13 10:32:25.770   140   140 I CodecServiceRegistrant: Preferred Codec2 store is defaulted to "software".
+12-13 10:32:25.770   140   140 I CodecServiceRegistrant: Software Codec2 service created and registered.
+12-13 10:32:25.770   138   138 D MediaCodecsXmlParser: Cannot find /data/misc/media/media_codecs_profiling_results.xml
+12-13 10:32:25.772   138   138 I HidlServiceManagement: Registered android.hardware.media.omx@1.0::IOmxStore/default
+12-13 10:32:25.772   138   138 I HidlServiceManagement: Removing namespace from process name android.hardware.media.omx@1.0-service to omx@1.0-service.
+12-13 10:32:25.773    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.775    89    89 D HostConnection: HostConnection::get() New Host Connection established 0x7ae2771c1450, tid 89
+12-13 10:32:25.775    86    86 I AudioFlinger: loadHwModule() Loaded primary audio interface, handle 10
+12-13 10:32:25.775   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.776    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.allocator@4.0::IAllocator/default in either framework or device manifest.
+12-13 10:32:25.776    86    86 I AudioFlinger: openOutput() this 0x72dc0bded6e0, module 10 Device type:0x2,@:, SamplingRate 48000, Format 0x000001, Channels 0x3, flags 0x2
+12-13 10:32:25.776    89    89 W Gralloc4: allocator 3.x is not supported
+12-13 10:32:25.776    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.allocator@3.0::IAllocator/default in either framework or device manifest.
+12-13 10:32:25.777    89    89 W Gralloc3: allocator 3.x is not supported
+12-13 10:32:25.777    74   102 I AudioHAL: Output stream REQUESTED with sample rate: 48000, channel mask 0x3
+12-13 10:32:25.777    74   102 D AudioHAL: Creating new audio transporter while opening OUTPUT stream
+12-13 10:32:25.777    74   102 I AudioHAL: Initializing AudioControl channel
+12-13 10:32:25.777    68    68 W zygote  : Could not reserve sentinel fault page
+12-13 10:32:25.778    78   121 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:25.779    42    42 D RemoteConnectionManager: createChannel called for AudioControl
+12-13 10:32:25.779    42    42 D librcm  : createChannel called with channel name: AudioControl
+12-13 10:32:25.779    68    68 I zygote  : Core platform API reporting enabled, enforcing=false
+12-13 10:32:25.779    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587744
+12-13 10:32:25.780    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:25.781    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.781    78   121 D goldfish-address-space: allocate: Ask for block of size 0x4
+12-13 10:32:25.781    42    42 D librcm  : Returning channel AudioControl
+12-13 10:32:25.782    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1fa000000 offset 0x0 size 0x4
+12-13 10:32:25.782    74   102 I AudioHAL: Channel AudioControl initialized.
+12-13 10:32:25.785    74   102 I AudioHAL: Initializing AudioIn channel
+12-13 10:32:25.786    42    42 D RemoteConnectionManager: createChannel called for AudioIn
+12-13 10:32:25.786    42    42 D librcm  : createChannel called with channel name: AudioIn
+12-13 10:32:25.786    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587743
+12-13 10:32:25.791    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.791    42    42 D librcm  : Returning channel AudioIn
+12-13 10:32:25.791    74   102 I AudioHAL: Channel AudioIn initialized.
+12-13 10:32:25.791    74   102 I AudioHAL: Initializing AudioOut channel
+12-13 10:32:25.792    42    42 D RemoteConnectionManager: createChannel called for AudioOut
+12-13 10:32:25.792    42    42 D librcm  : createChannel called with channel name: AudioOut
+12-13 10:32:25.792    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587742
+12-13 10:32:25.799    89    89 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:25.799    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.799    42    42 D librcm  : Returning channel AudioOut
+12-13 10:32:25.799    74   102 I AudioHAL: Channel AudioOut initialized.
+12-13 10:32:25.806    74   102 I AudioHAL: Got ERROR_INVALID_STATE, returning -EAGAIN
+12-13 10:32:25.806    74   102 D AudioHAL: Waiting to get output sample rate...
+12-13 10:32:25.806    89    89 I RenderEngine: OpenGL ES informations:
+12-13 10:32:25.806    89    89 I RenderEngine: vendor    : Microsoft (Google Inc. (Intel))
+12-13 10:32:25.806    89    89 I RenderEngine: renderer  : Android Emulator OpenGL ES Translator
+12-13 10:32:25.806    89    89 I RenderEngine: version   : OpenGL ES 3.0 (OpenGL ES 3.0.0 (ANGLE 2.1.16242 git hash: d9c27d6e073c))
+12-13 10:32:25.806    89    89 I RenderEngine: extensions: GL_EXT_debug_marker GL_EXT_robustness GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_half_float GL_OES_texture_half_float_linear GL_OES_packed_depth_stencil GL_OES_standard_derivatives GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:25.806    89    89 I RenderEngine: GL_MAX_TEXTURE_SIZE = 16384
+12-13 10:32:25.806    89    89 I RenderEngine: GL_MAX_VIEWPORT_DIMS = 32767
+12-13 10:32:25.807     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #2c0!!!
+12-13 10:32:25.811    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@4.0::IMapper/default in either framework or device manifest.
+12-13 10:32:25.811    84   136 I ComposerResources: failed to get mapper 4.0 service, falling back to mapper 3.0
+12-13 10:32:25.811    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+12-13 10:32:25.811    84   136 I ComposerResources: failed to get mapper 3.0 service, falling back to mapper 2.0
+12-13 10:32:25.821    89    89 E HWComposer: loadLayerMetadataSupport: getLayerGenericMetadataKeys failed: UNSUPPORTED (8)
+12-13 10:32:25.826    89    89 I HWComposer: Switching to legacy multi-display mode
+12-13 10:32:25.827    89    89 E HWComposer: isConnected failed for display 0: Invalid display
+12-13 10:32:25.832    89    89 E HWC2    : getDisplayAttribute(0, 0, Unknown) failed: BadParameter (4)
+12-13 10:32:25.835   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.835    89   197 W SurfaceFlinger: Ignoring VSYNC request while display is disconnected
+12-13 10:32:25.836    89   197 W SurfaceFlinger: Ignoring VSYNC request while display is disconnected
+12-13 10:32:25.837    89   198 W SurfaceFlinger: Ignoring VSYNC request while display is disconnected
+12-13 10:32:25.837    89   198 W SurfaceFlinger: Ignoring VSYNC request while display is disconnected
+12-13 10:32:25.837    89    89 E HWComposer: getDisplayConnectionType: getDisplayConnectionType failed for display 0: Unsupported (8)
+12-13 10:32:25.837    89   197 W SurfaceFlinger: Ignoring VSYNC request while display is disconnected
+12-13 10:32:25.837    89   197 W SurfaceFlinger: Ignoring VSYNC request while display is disconnected
+12-13 10:32:25.841    89    89 I FramebufferSurface: framebuffer size has been limited to [3840x2160] from [3840x2160]
+12-13 10:32:25.842    89    89 W HwcComposer: getPerFrameMetadataKeys failed with 8
+12-13 10:32:25.874    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.876   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.875     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #80!!!
+12-13 10:32:25.902   182   182 I android.hardware.camera.provider@2.5-service-lazy: CameraProvider@2.5 legacy service is starting.
+12-13 10:32:25.903   182   182 E CamComm1.0-CamModule: CameraModule: camera hardware module must not be null
+12-13 10:32:25.906    74   102 I AudioHAL: Got ERROR_INVALID_STATE, returning -EAGAIN
+12-13 10:32:25.906    74   102 D AudioHAL: Waiting to get output sample rate...
+12-13 10:32:25.909    42    42 D RemoteConnectionManager: createChannel called for Camera
+12-13 10:32:25.909    42    42 D librcm  : createChannel called with channel name: Camera
+12-13 10:32:25.909    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587741
+12-13 10:32:25.912    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.912    42    42 D librcm  : Returning channel Camera
+12-13 10:32:25.913    42    42 D RemoteConnectionManager: createChannel called for CameraNotification
+12-13 10:32:25.913    42    42 D librcm  : createChannel called with channel name: CameraNotification
+12-13 10:32:25.913    42    42 D windows.services.rcm@1.0-service: SocketClient is acting as a server and waiting for connections on port -866587740
+12-13 10:32:25.916    42    42 D windows.services.rcm@1.0-service: SocketClient accepted a connection
+12-13 10:32:25.916    42    42 D librcm  : Returning channel CameraNotification
+12-13 10:32:25.935   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.974    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:25.976   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:25.992   182   182 E WinCamera: ParseDeviceEnumResponse:876 exit 
+12-13 10:32:25.993   182   182 E CamComm1.0-CamModule: init:313 Enumerate devices got 2 cameras!
+12-13 10:32:25.994   182   182 I CamPrvdr@2.4-legacy: Loaded "Windows Camera Module" camera module
+12-13 10:32:25.994   182   182 E CamPrvdr@2.4-legacy: setUpVendorTags: 355 !
+12-13 10:32:25.994   182   182 I CamPrvdr@2.4-legacy: setUpVendorTags: No vendor tags defined for this device.
+12-13 10:32:25.994   182   182 V CamPrvdr@2.4-legacy: Preferred HAL 3 minor version is 3
+12-13 10:32:25.994   182   182 E CamComm1.0-CamModule: getCameraInfo:0
+12-13 10:32:25.994   182   182 V LtCamera: getStaticDeviceCharacteristics:1455
+12-13 10:32:26.009    74   102 I AudioHAL: Got ERROR_INVALID_STATE, returning -EAGAIN
+12-13 10:32:26.009    74   102 D AudioHAL: Waiting to get output sample rate...
+12-13 10:32:26.036   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:360
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:360
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:640 w:360
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:480
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:480
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:640 w:480
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:640
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:640
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:640 w:640
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:1280 w:720
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:1280 w:720
+12-13 10:32:26.037   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:1280 w:720
+12-13 10:32:26.037   182   182 V LtCamera: constructDefaultRequestSettings:1837
+12-13 10:32:26.038   182   182 E CamComm1.0-CamModule: getCameraInfo:0
+12-13 10:32:26.038   182   182 E CamComm1.0-CamModule: getCameraInfo:1
+12-13 10:32:26.038   182   182 V LtCamera: getStaticDeviceCharacteristics:1455
+12-13 10:32:26.045   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:360
+12-13 10:32:26.045   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:360
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:640 w:360
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:480
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:480
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:640 w:480
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:640
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:640 w:640
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:640 w:640
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:1280 w:720
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:35 h:1280 w:720
+12-13 10:32:26.046   182   182 V LtCamera: PopulateMediaTypeInformation:132 adding config halfmt:34 h:1280 w:720
+12-13 10:32:26.046   182   182 V LtCamera: constructDefaultRequestSettings:1837
+12-13 10:32:26.046   182   182 E CamComm1.0-CamModule: getCameraInfo:1
+12-13 10:32:26.046   182   182 I android.hardware.camera.provider@2.5-service-lazy: CameraProvider@2.5 legacy service is starting in lazy mode.
+12-13 10:32:26.047   182   182 I camera-service.windows: Registering HAL: android.hardware.camera.provider@2.5::ICameraProvider with name: legacy/0
+12-13 10:32:26.048   182   182 I HidlServiceManagement: Registered android.hardware.camera.provider@2.5::ICameraProvider/legacy/0
+12-13 10:32:26.051   107   180 I CameraProviderManager: Connecting to new camera provider: legacy/0, isRemote? 1
+12-13 10:32:26.053   182   182 E CamPrvdr@2.4-legacy: setCallback: 413 !
+12-13 10:32:26.053   182   205 D CamPrvdr@2.5-legacy: notifyDeviceStateChange: New device state: 0x0
+12-13 10:32:26.053   182   205 I CamComm1.0-CamModule: notifyDeviceStateChange: calling notify_device_state_change with state 0
+12-13 10:32:26.053   182   205 E CamComm1.0-CamModule: notifyDeviceStateChange:446 Device state not handled.
+12-13 10:32:26.054   182   205 E CamPrvdr@2.4-legacy: getCameraIdList: returning 2 cameras!
+12-13 10:32:26.054   182   205 E CamPrvdr@2.4-legacy: isSetTorchModeSupported: 453 !
+12-13 10:32:26.055   107   180 I CameraProviderManager: Enumerating new camera device: device@3.5/legacy/0
+12-13 10:32:26.055   182   205 V CamPrvdr@2.4-legacy: getCameraDeviceInterface_V3_x: 474  0!
+12-13 10:32:26.055   182   205 V CamPrvdr@2.4-legacy: Constructing v3.4+ camera device
+12-13 10:32:26.057   182   205 V CamPrvdr@2.4-legacy: Device interface chain:
+12-13 10:32:26.057   182   205 V CamPrvdr@2.4-legacy:   android.hardware.camera.device@3.5::ICameraDevice
+12-13 10:32:26.057   182   205 V CamPrvdr@2.4-legacy:   android.hardware.camera.device@3.2::ICameraDevice
+12-13 10:32:26.057   182   205 V CamPrvdr@2.4-legacy:   android.hidl.base@1.0::IBase
+12-13 10:32:26.057   182   205 E CamComm1.0-CamModule: getCameraInfo:0
+12-13 10:32:26.058   182   205 E CamComm1.0-CamModule: getCameraInfo:0
+12-13 10:32:26.060   107   180 I CameraProviderManager: Enumerating new camera device: device@3.5/legacy/1
+12-13 10:32:26.060   182   205 V CamPrvdr@2.4-legacy: getCameraDeviceInterface_V3_x: 474  1!
+12-13 10:32:26.060   182   205 V CamPrvdr@2.4-legacy: Constructing v3.4+ camera device
+12-13 10:32:26.060   182   205 V CamPrvdr@2.4-legacy: Device interface chain:
+12-13 10:32:26.060   182   205 V CamPrvdr@2.4-legacy:   android.hardware.camera.device@3.5::ICameraDevice
+12-13 10:32:26.060   182   205 V CamPrvdr@2.4-legacy:   android.hardware.camera.device@3.2::ICameraDevice
+12-13 10:32:26.060   182   205 V CamPrvdr@2.4-legacy:   android.hidl.base@1.0::IBase
+12-13 10:32:26.060   182   205 E CamComm1.0-CamModule: getCameraInfo:1
+12-13 10:32:26.061   182   205 E CamComm1.0-CamModule: getCameraInfo:1
+12-13 10:32:26.061   107   180 I CameraProviderManager: Camera provider legacy/0 ready with 2 camera devices
+12-13 10:32:26.062   107   180 I CameraService: onDeviceStatusChanged: Status changed for cameraId=1, newStatus=1
+12-13 10:32:26.062   107   180 I CameraService: onDeviceStatusChanged: Unknown camera ID 1, a new camera is added
+12-13 10:32:26.066   107   180 I CameraService: onDeviceStatusChanged: Status changed for cameraId=0, newStatus=1
+12-13 10:32:26.066   107   180 I CameraService: onDeviceStatusChanged: Unknown camera ID 0, a new camera is added
+12-13 10:32:26.075    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.077   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.113    74   102 I AudioHAL: Got ERROR_INVALID_STATE, returning -EAGAIN
+12-13 10:32:26.113    74   102 D AudioHAL: Waiting to get output sample rate...
+12-13 10:32:26.136   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.175    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.177   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.215    74   102 I AudioHAL: Output stream OPENED with sample rate: 48000, channel mask: 0x3 format: 0x1
+12-13 10:32:26.224    74   102 I AudioHAL: Audio output buffer size set to: 11520
+12-13 10:32:26.224    86    86 I AudioFlinger: HAL output buffer size 2880 frames, normal sink buffer size 2880 frames
+12-13 10:32:26.237   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.242    86    86 I BufferProvider: found effect "Multichannel Downmix To Stereo" from The Android Open Source Project
+12-13 10:32:26.243    86    86 E AudioFlinger: Failed to add event callback
+12-13 10:32:26.244    86   207 I AudioFlinger: AudioFlinger's thread 0x72dd8e88a040 tid=207 ready to run
+12-13 10:32:26.248    86   207 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:26.248    86   207 D AudioFlinger: ro.audio.silent is ignored since no output device is set
+12-13 10:32:26.253    86   207 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:26.253    86   207 D AudioFlinger: ro.audio.silent is ignored since no output device is set
+12-13 10:32:26.254    86    86 V APM_AudioPolicyManager: checkAndSetVolume cannot set volume group 4 volume with force use = 0 for comm
+12-13 10:32:26.258    74    74 W DeviceHAL: Error from HAL Device in function set_voice_volume: Function not implemented
+12-13 10:32:26.261    86    86 W AudioFlinger: moveEffects() bad srcOutput 0
+12-13 10:32:26.261    86    86 V APM_AudioPolicyManager: selectOutputForMusicEffects selected output 13
+12-13 10:32:26.261    86    86 V APM_AudioPolicyManager: setOutputDevices device {type:0x2,@:} delayMs 0
+12-13 10:32:26.261    86    86 V APM_AudioPolicyManager: setOutputDevices() prevDevice {type:0x2,@:}
+12-13 10:32:26.262    86    86 W APM::AudioPolicyEngine: getDevicesForStrategy() unknown strategy: -1
+12-13 10:32:26.262    86    86 V APM_AudioPolicyManager: setOutputDevices changing device to {type:0x2,@:}
+12-13 10:32:26.275    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.278   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.289    86    86 V APM_AudioPolicyManager: setOutputDevices() AF::createAudioPatch returned 0 patchHandle 12 num_sources 1 num_sinks 1
+12-13 10:32:26.291    86    86 V APM_AudioPolicyManager: checkAndSetVolume cannot set volume group 4 volume with force use = 0 for comm
+12-13 10:32:26.294    74    74 D AudioHAL: Opening audio input stream.
+12-13 10:32:26.294    74    74 D AudioHAL: Reusing existing transporter while opening INPUT stream
+12-13 10:32:26.299    74    74 I AudioHAL: Got ERROR_INVALID_STATE, returning -EAGAIN
+12-13 10:32:26.299    74    74 D AudioHAL: Waiting to get INPUT sample rate...
+12-13 10:32:26.338   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.376    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.378   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.411    68    68 D zygote  : Time zone APEX ICU file found: /apex/com.android.tzdata/etc/icu/icu_tzdata.dat
+12-13 10:32:26.411    68    68 D zygote  : I18n APEX ICU file found: /apex/com.android.i18n/etc/icu/icudt66l.dat
+12-13 10:32:26.420    67    67 D zygote64: Time zone APEX ICU file found: /apex/com.android.tzdata/etc/icu/icu_tzdata.dat
+12-13 10:32:26.427    67    67 D zygote64: I18n APEX ICU file found: /apex/com.android.i18n/etc/icu/icudt66l.dat
+12-13 10:32:26.438   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.477   103   126 I adbd    : adbd mDNS service _adb._tcp registered: 1
+12-13 10:32:26.479    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.479   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.539   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.579    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.580   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.639   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.654    68    68 I zygote  : Using memfd for future sealing
+12-13 10:32:26.663    67    67 I zygote64: Using memfd for future sealing
+12-13 10:32:26.674    68    68 W zygote  : Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:26.680   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.683    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.686    67    67 W zygote64: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:26.740   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.784   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.784    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.841   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.884   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.884    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.941   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:26.987    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:26.987   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.045   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.056    68    68 W zygote  : JNI RegisterNativeMethods: attempt to register 0 native methods for android.media.AudioAttributes
+12-13 10:32:27.056    67    67 W zygote64: JNI RegisterNativeMethods: attempt to register 0 native methods for android.media.AudioAttributes
+12-13 10:32:27.087   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.096    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.105    67    67 I boot_progress_preload_start: 5827
+12-13 10:32:27.107    67    67 D Zygote  : begin preload
+12-13 10:32:27.108    67    67 I Zygote  : Calling ZygoteHooks.beginPreload()
+12-13 10:32:27.137    68    68 I zygote  : Explicit concurrent copying GC freed 2355(242KB) AllocSpace objects, 0(0B) LOS objects, 82% free, 333KB/1869KB, paused 713us total 28.802ms
+12-13 10:32:27.148   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.168    68    68 I zygote  : Explicit concurrent copying GC freed 163(57KB) AllocSpace objects, 0(0B) LOS objects, 80% free, 374KB/1910KB, paused 126us total 15.675ms
+12-13 10:32:27.170    68    68 D Zygote32Timing: PostZygoteInitGC took to complete: 61ms
+12-13 10:32:27.170    68    68 D Zygote32Timing: ZygoteInit took to complete: 69ms
+12-13 10:32:27.189   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.198    68    68 I Zygote  : Accepting command socket connections
+12-13 10:32:27.199    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.211    67   209 I zygote64: Verified 1363 classes from mainline modules in 516.887ms
+12-13 10:32:27.215    68   208 I zygote  : Verified 1363 classes from mainline modules in 528.700ms
+12-13 10:32:27.248   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.272    67    67 D Zygote64Timing: BeginPreload took to complete: 164ms
+12-13 10:32:27.273    67    67 I Zygote  : Preloading classes...
+12-13 10:32:27.277    67    67 W Zygote  : Class not found for preloading: android.app.-$$Lambda$ResourcesManager$QJ7UiVk_XS90KuXAsIjIEym1DnM
+12-13 10:32:27.289   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.299    74    74 I AudioHAL: Got sample rate: 8000 (ret = 0)
+12-13 10:32:27.301    74    74 D AudioHAL: Input stream opened.
+12-13 10:32:27.303    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.314    74    74 I AudioHAL: Audio input buffer size set to: 1600
+12-13 10:32:27.318    89    89 D RenderEngine: shader cache generated - 48 shaders in 1471.942627 ms
+12-13 10:32:26.477     0     0 I chatty  : uid=0(root) logd identical 2 lines
+12-13 10:32:26.483     0     0 W         : NOHZ tick-stop error: Non-RCU local softirq work is pending, handler #80!!!
+12-13 10:32:27.324     0     0 I init    : starting service 'bootanim'...
+12-13 10:32:27.322    86   220 I AudioFlinger: AudioFlinger's thread 0x72dd8e7fc040 tid=220 ready to run
+12-13 10:32:27.325    86   220 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:27.328    89    89 I HidlServiceManagement: Registered android.frameworks.displayservice@1.0::IDisplayService/default
+12-13 10:32:27.331    89    89 D SurfaceFlinger: Setting power mode 2 on display 0
+12-13 10:32:27.326     0     0 W libprocessgroup: Failed to open /dev/stune/top-app/tasks: No such file or directory: No such file or directory
+12-13 10:32:27.326     0     0 I init    : Control message: Processed ctl.start for 'bootanim' from pid: 89 (/system/bin/surfaceflinger)
+12-13 10:32:27.330     0     0 W libprocessgroup: Failed to apply MaxPerformance task profile: No such file or directory
+12-13 10:32:27.333    89    89 D SurfaceFlinger: Finished setting power mode 2 on display 0
+12-13 10:32:27.349   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.390   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.403    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.449   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.456   219   219 I BootAnimation: boot animation disabled
+12-13 10:32:27.491   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.504    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.526    86   220 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:27.537    74    74 D AudioHAL: Closing audio input stream.
+12-13 10:32:27.553   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.565     0     0 I init    : Service 'bootanim' (pid 219) exited with status 0 oneshot service took 0.239000 seconds in background
+12-13 10:32:27.565     0     0 I init    : Sending signal 9 to service 'bootanim' (pid 219) process group...
+12-13 10:32:27.565     0     0 I libprocessgroup: Successfully killed process cgroup uid 1003 pid 219 in 0ms
+12-13 10:32:27.571    74    74 D AudioHAL: Cleaning up INPUT stream
+12-13 10:32:27.592   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.595    74   102 I r_submix: adev_open(name=audio_hw_if)
+12-13 10:32:27.602    74   102 I r_submix: adev_init_check()
+12-13 10:32:27.603    86    86 I AudioFlinger: loadHwModule() Loaded r_submix audio interface, handle 18
+12-13 10:32:27.603    74   102 D r_submix: adev_open_input_stream(addr=0)
+12-13 10:32:27.603    74   102 D r_submix: submix_audio_device_create_pipe_l(addr=0, idx=9)
+12-13 10:32:27.603    74   102 D r_submix:   now using address 0 for route 9
+12-13 10:32:27.605    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.617    86   222 I AudioFlinger: AudioFlinger's thread 0x72dd8e7fc040 tid=222 ready to run
+12-13 10:32:27.617    74   102 I r_submix: in_standby()
+12-13 10:32:27.618    86   222 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:27.618    74    74 I r_submix: in_standby()
+12-13 10:32:27.619    86   222 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:27.619    74    74 D r_submix: adev_close_input_stream()
+12-13 10:32:27.619    74    74 D r_submix: submix_audio_device_release_pipe_l(idx=9) addr=0
+12-13 10:32:27.619    74    74 D r_submix: submix_audio_device_destroy_pipe_l(): pipe destroyed
+12-13 10:32:27.620    86    86 W APM::AudioPolicyEngine: getDevicesForStrategy() unknown strategy: -1
+12-13 10:32:27.620    86    86 W APM::AudioPolicyEngine: getDevicesForStrategy() unknown strategy: -1
+12-13 10:32:27.627    86    86 I audioserver: Waiting for activity service
+12-13 10:32:27.653   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.692   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.705    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.754   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.792   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.806    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.854   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.893   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.906    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:27.955   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:27.993   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.007    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.056   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.094   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.107    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.157   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.195   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.208    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.258   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.296   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.309    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.359   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.396   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.409    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.460   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.497   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.509    67    67 E ActivityRecognitionHardware: activity_recognition HAL is deprecated. class_init is effectively a no-op
+12-13 10:32:28.510    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.560   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.597   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.611    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.661   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.698   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.712    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.761   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.768    23    23 I hwservicemanager: Notifying android.hardware.camera.provider@2.5::ICameraProvider/legacy/0 they have clients: 1
+12-13 10:32:28.773   182   205 I camera-service.windows: Process has 1 (of 1 available) client(s) in use after notification android.hardware.camera.provider@2.5::ICameraProvider has clients: 1
+12-13 10:32:28.798   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.813    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.862   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.877    67    67 W Zygote  : Class not found for preloading: android.inputmethodservice.-$$Lambda$InputMethodService$TvVfWDKZ3ljQdrU87qYykg6uD-I
+12-13 10:32:28.899   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.909    67    67 I zygote64: Thread[1,tid=67,Native,Thread*=0x73af4001fbe0,peer=0x12c02e10,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:28.911    67    67 I zygote64: Thread[1,tid=67,Native,Thread*=0x73af4001fbe0,peer=0x12c02e10,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:28.911    67    67 D MtpDeviceJNI: register_android_mtp_MtpDevice
+12-13 10:32:28.911    67    67 I zygote64: Thread[1,tid=67,Native,Thread*=0x73af4001fbe0,peer=0x12c02e10,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:28.911    67    67 I zygote64: Thread[1,tid=67,Native,Thread*=0x73af4001fbe0,peer=0x12c02e10,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:28.913    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:28.937    67    67 W Zygote  : Class not found for preloading: android.media.MediaRouter$Static$Client$1
+12-13 10:32:28.937    67    67 W Zygote  : Class not found for preloading: android.media.MediaRouter$Static$Client$2
+12-13 10:32:28.962   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:28.981    67    67 W Zygote  : Class not found for preloading: android.net.shared.Inet4AddressUtils
+12-13 10:32:28.981    67    67 W Zygote  : Class not found for preloading: android.net.shared.InetAddressUtils
+12-13 10:32:28.999   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+--------- beginning of radio
+12-13 10:32:29.003    67    67 D TelephonyManager: No /proc/cmdline exception=java.io.FileNotFoundException: /proc/cmdline: open failed: EACCES (Permission denied)
+12-13 10:32:29.003    67    67 D TelephonyManager: /proc/cmdline=
+12-13 10:32:29.013    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.062   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.063    67    67 W Zygote  : Class not found for preloading: android.telephony.ims.stub.-$$Lambda$ImsRegistrationImplBase$wwtkoeOtGwMjG5I0-ZTfjNpGU-s
+12-13 10:32:29.082    67    67 W Zygote  : Class not found for preloading: android.view.-$$Lambda$cZhmLzK8aetUdx4VlP9w5jR7En0
+12-13 10:32:29.100   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.100    67    67 W Zygote  : Class not found for preloading: android.view.autofill.-$$Lambda$AutofillManager$AutofillManagerClient$vxNm6RuuD-r5pkiSxNSBBd1w_Qc
+12-13 10:32:29.101    67    67 W Zygote  : Class not found for preloading: android.view.contentcapture.-$$Lambda$MainContentCaptureSession$1$JPRO-nNGZpgXrKr4QC_iQiTbQx0
+12-13 10:32:29.101    67    67 W Zygote  : Class not found for preloading: android.view.contentcapture.-$$Lambda$MainContentCaptureSession$1$Xhq3WJibbalS1G_W3PRC2m7muhM
+12-13 10:32:29.104    67    67 W Zygote  : Class not found for preloading: android.view.contentcapture.MainContentCaptureSession$1
+12-13 10:32:29.114    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.163   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.168    67    67 W Zygote  : Class not found for preloading: com.android.internal.telephony.-$$Lambda$SubscriptionController$VCQsMNqRHpN3RyoXYzh2YUwA2yc
+12-13 10:32:29.169    67    67 W Zygote  : Class not found for preloading: com.android.internal.telephony.-$$Lambda$SubscriptionController$u5xE-urXR6ElZ50305_6guo20Fc
+12-13 10:32:29.200   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.214    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.263   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.300   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.315    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.365   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.401   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.415    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.465   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.501   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.516    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.566   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.602   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.617    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.666   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.702   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.718    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.719    67    67 W Zygote  : Class not found for preloading: com.android.internal.telephony.IccSmsInterfaceManager$2
+12-13 10:32:29.736    67    67 W Zygote  : Class not found for preloading: com.android.internal.telephony.dataconnection.DcTracker$5
+12-13 10:32:29.744    67    67 W Zygote  : Class not found for preloading: com.android.internal.widget.-$$Lambda$gPQuiuEDuOmrh2MixBcV6a5gu5s
+12-13 10:32:29.745    67    67 W Zygote  : Class not found for preloading: com.android.internal.widget.LockPatternUtils$2
+12-13 10:32:29.767   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.796    67    67 I Zygote  : ...preloaded 12107 classes in 2523ms.
+12-13 10:32:29.797    67    67 I zygote64: VMRuntime.preloadDexCaches starting
+12-13 10:32:29.803   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.819    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.836    67    67 I zygote64: VMRuntime.preloadDexCaches strings total=418392 before=11374 after=11374
+12-13 10:32:29.836    67    67 I zygote64: VMRuntime.preloadDexCaches types total=40936 before=11224 after=11399
+12-13 10:32:29.836    67    67 I zygote64: VMRuntime.preloadDexCaches fields total=173763 before=14203 after=15087
+12-13 10:32:29.836    67    67 I zygote64: VMRuntime.preloadDexCaches methods total=316014 before=18080 after=18080
+12-13 10:32:29.836    67    67 I zygote64: VMRuntime.preloadDexCaches finished
+12-13 10:32:29.836    67    67 D Zygote64Timing: PreloadClasses took to complete: 2564ms
+12-13 10:32:29.841    67    67 I zygote64: The ClassLoaderContext is a special shared library.
+12-13 10:32:29.843    67    67 D ApplicationLoaders: Created zygote-cached class loader: /system/framework/android.hidl.base-V1.0-java.jar
+12-13 10:32:29.845    67    67 I zygote64: The ClassLoaderContext is a special shared library.
+12-13 10:32:29.845    67    67 D ApplicationLoaders: Created zygote-cached class loader: /system/framework/android.hidl.manager-V1.0-java.jar
+12-13 10:32:29.846    67    67 I zygote64: The ClassLoaderContext is a special shared library.
+12-13 10:32:29.847    67    67 D ApplicationLoaders: Created zygote-cached class loader: /system/framework/android.test.base.jar
+12-13 10:32:29.847    67    67 D Zygote64Timing: CacheNonBootClasspathClassLoaders took to complete: 11ms
+12-13 10:32:29.847    67    67 I Zygote  : Preloading resources...
+12-13 10:32:29.867   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.873    67    67 W Resources: Preloaded drawable resource #0x108028c (android:drawable/dialog_background_material) that varies with configuration!!
+12-13 10:32:29.899    67    67 I Zygote  : ...preloaded 64 resources in 53ms.
+12-13 10:32:29.902    67    67 I Zygote  : ...preloaded 41 resources in 2ms.
+12-13 10:32:29.902    67    67 D Zygote64Timing: PreloadResources took to complete: 55ms
+12-13 10:32:29.903   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.908    67    67 I Zygote  : Preloading shared libraries...
+12-13 10:32:29.919    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:29.930    67    67 I Zygote  : Called ZygoteHooks.endPreload()
+12-13 10:32:29.931    67    67 I Zygote  : Installed AndroidKeyStoreProvider in 1ms.
+12-13 10:32:29.934    67    67 I Zygote  : Warmed up JCA providers in 3ms.
+12-13 10:32:29.934    67    67 D Zygote  : end preload
+12-13 10:32:29.934    67    67 I boot_progress_preload_end: 8655
+12-13 10:32:29.934    67    67 D Zygote64Timing: ZygotePreload took to complete: 2828ms
+12-13 10:32:29.968   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:29.976    67    67 I zygote64: Explicit concurrent copying GC freed 179812(9118KB) AllocSpace objects, 26(816KB) LOS objects, 49% free, 5058KB/10116KB, paused 161us total 39.181ms
+12-13 10:32:29.990    67    67 I zygote64: Explicit concurrent copying GC freed 8356(286KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 4804KB/9608KB, paused 28us total 10.980ms
+12-13 10:32:29.990    67    67 D Zygote64Timing: PostZygoteInitGC took to complete: 56ms
+12-13 10:32:29.990    67    67 D Zygote64Timing: ZygoteInit took to complete: 2896ms
+12-13 10:32:30.004   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.020    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:30.028    67    67 D Zygote  : Forked child process 226
+12-13 10:32:30.028    67    67 I Zygote  : System server process 226 has been created
+12-13 10:32:30.029    67    67 I Zygote  : Accepting command socket connections
+12-13 10:32:30.034   226   226 W system_server: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:30.041   103   129 I adbd    : jdwp connection from 226
+12-13 10:32:30.068   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.104   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.120    65    65 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:30.168   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.204   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.222    65    65 W ServiceManager: Service statscompanion didn't start. Returning NULL
+12-13 10:32:30.233    65    65 I statsd  : Statsd starts to listen to socket.
+12-13 10:32:30.269   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.295   226   226 I SystemServerTiming: InitBeforeStartServices
+12-13 10:32:30.297   226   226 I system_server_start: [1,9014,9014]
+12-13 10:32:30.297   226   226 I SystemServer: Entered the Android system server!
+12-13 10:32:30.297   226   226 I boot_progress_system_run: 9018
+12-13 10:32:30.305   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.370   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.405   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.470   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.506   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.571   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.606   117   141 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.661   226   226 E UsbAlsaJackDetectorJNI: Can't register UsbAlsaJackDetector native methods
+12-13 10:32:30.671   123   123 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.705   226   226 I SystemServerInitThreadPool: Creating instance with 8 threads
+12-13 10:32:30.705   226   226 D SystemServerTiming: InitBeforeStartServices took to complete: 409ms
+12-13 10:32:30.706   226   226 I SystemServerTiming: StartServices
+12-13 10:32:30.706   226   226 I SystemServerTiming: startBootstrapServices
+12-13 10:32:30.706   226   226 I SystemServerTiming: StartWatchdog
+12-13 10:32:30.707   117   141 W ServiceManager: Service package_native didn't start. Returning NULL
+12-13 10:32:30.707   117   141 E ServiceUtilities: getInfo: Cannot find package_native
+12-13 10:32:30.710   117   141 W AudioAnalytics: (key=audio.flinger) Audioflinger constructor event detected
+12-13 10:32:30.730   226   226 D SystemServerTiming: StartWatchdog took to complete: 24ms
+12-13 10:32:30.730   226   226 I SystemServer: Reading configuration...
+12-13 10:32:30.730   226   226 I SystemServerTiming: ReadingSystemConfig
+12-13 10:32:30.731   226   226 D SystemServerTiming: ReadingSystemConfig took to complete: 1ms
+12-13 10:32:30.731   226   226 I SystemServerTiming: PlatformCompat
+12-13 10:32:30.732   226   253 I SystemServerTimingAsync: InitThreadPoolExec:ReadingSystemConfig
+12-13 10:32:30.732   226   253 D SystemServerInitThreadPool: Started executing ReadingSystemConfig
+12-13 10:32:30.735   226   253 I SystemConfig: Reading permissions from /system/etc/sysconfig/hiddenapi-package-whitelist.xml
+12-13 10:32:30.736   226   226 D CompatConfig: Found a config file: /system/etc/compatconfig/documents-ui-compat-config.xml
+12-13 10:32:30.737   226   253 I SystemConfig: Reading permissions from /system/etc/sysconfig/framework-sysconfig.xml
+12-13 10:32:30.738   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@4f17ece
+12-13 10:32:30.739   226   253 I SystemConfig: Reading permissions from /system/etc/sysconfig/preinstalled-packages-platform.xml
+12-13 10:32:30.740   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/privapp-permissions-platform.xml
+12-13 10:32:30.742   226   226 D CompatConfig: Found a config file: /system/etc/compatconfig/framework-platform-compat-config.xml
+12-13 10:32:30.743   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@52ab9da
+12-13 10:32:30.743   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@62374e8
+12-13 10:32:30.744   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/android.test.runner.xml
+12-13 10:32:30.744   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@e27a701
+12-13 10:32:30.744   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/com.android.location.provider.xml
+12-13 10:32:30.744   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@d382fe7
+12-13 10:32:30.744   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@ae6b23d
+12-13 10:32:30.745   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/com.android.future.usb.accessory.xml
+12-13 10:32:30.745   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@6b6aa32
+12-13 10:32:30.745   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/com.android.nfc_extras.xml
+12-13 10:32:30.745   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@ecdf900
+12-13 10:32:30.746   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@5913539
+12-13 10:32:30.746   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/javax.obex.xml
+12-13 10:32:30.746   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@68134df
+12-13 10:32:30.746   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@bc6ebf5
+12-13 10:32:30.746   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/com.android.documentsui.xml
+12-13 10:32:30.747   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@4154d8a
+12-13 10:32:30.747   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/org.apache.http.legacy.xml
+12-13 10:32:30.747   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@691e818
+12-13 10:32:30.747   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/com.android.mediadrm.signer.xml
+12-13 10:32:30.747   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@a82b856
+12-13 10:32:30.748   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/android.test.mock.xml
+12-13 10:32:30.748   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@8c96dc4
+12-13 10:32:30.748   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/com.android.media.remotedisplay.xml
+12-13 10:32:30.748   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@88a03e2
+12-13 10:32:30.749   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@2beb373
+12-13 10:32:30.749   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/android.software.webview.xml
+12-13 10:32:30.749   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@2c87c2e
+12-13 10:32:30.749   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/android.test.base.xml
+12-13 10:32:30.749   226   253 I SystemConfig: Reading permissions from /system/etc/permissions/platform.xml
+12-13 10:32:30.750   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@3e6b15c
+12-13 10:32:30.750   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@c6bbc65
+12-13 10:32:30.750   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@8642d3a
+12-13 10:32:30.751   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@d4b1deb
+12-13 10:32:30.751   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@adb8748
+12-13 10:32:30.751   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@c60b9e1
+12-13 10:32:30.752   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@2d7e306
+12-13 10:32:30.752   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@2c5cff4
+12-13 10:32:30.752   226   253 I SystemConfig: Reading permissions from /vendor/etc/permissions/android.hardware.wifi.xml
+12-13 10:32:30.753   226   226 D CompatConfig: Found a config file: /system/etc/compatconfig/libcore-platform-compat-config.xml
+12-13 10:32:30.753   226   253 I SystemConfig: Reading permissions from /vendor/etc/permissions/windows.permissions.xml
+12-13 10:32:30.753   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@bbb5f63
+12-13 10:32:30.753   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@f69f760
+12-13 10:32:30.754   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@fe24cde
+12-13 10:32:30.754   226   253 I SystemConfig: Reading permissions from /product/etc/sysconfig/hiddenapi-package-whitelist-venezia.xml
+12-13 10:32:30.754   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@87a8ebf
+12-13 10:32:30.755   226   226 D CompatConfig: Found a config file: /system/etc/compatconfig/services-platform-compat-config.xml
+12-13 10:32:30.755   226   253 I SystemConfig: Reading permissions from /product/etc/permissions/com.android.contacts.xml
+12-13 10:32:30.755   226   253 I SystemConfig: Reading permissions from /product/etc/permissions/privapp-permissions-venezia.xml
+12-13 10:32:30.755   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@dd357db
+12-13 10:32:30.756   226   253 W SystemConfig: No directory /system_ext/etc/sysconfig, skipping
+12-13 10:32:30.756   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@6235278
+12-13 10:32:30.756   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@fadd51
+12-13 10:32:30.756   226   253 I SystemConfig: Reading permissions from /system_ext/etc/permissions/com.android.systemui.xml
+12-13 10:32:30.757   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@32596b7
+12-13 10:32:30.757   226   253 I SystemConfig: Reading permissions from /system_ext/etc/permissions/privapp-permissions-windows.xml
+12-13 10:32:30.757   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@8befd8d
+12-13 10:32:30.758   226   253 I SystemConfig: Reading permissions from /system_ext/etc/permissions/com.android.settings.xml
+12-13 10:32:30.758   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@bf2e753
+12-13 10:32:30.758   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@619f890
+12-13 10:32:30.758   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@22ae589
+12-13 10:32:30.759   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@f29a98e
+12-13 10:32:30.759   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@83aa5af
+12-13 10:32:30.759   226   253 I SystemConfig: Reading permissions from /apex/com.android.ipsec/etc/permissions/android.net.ipsec.ike.xml
+12-13 10:32:30.760   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@2535145
+12-13 10:32:30.760   226   253 D SystemConfig: readAllPermissions took to complete: 28ms
+12-13 10:32:30.760   226   253 D SystemServerInitThreadPool: Finished executing ReadingSystemConfig
+12-13 10:32:30.760   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@9ad09a
+12-13 10:32:30.760   226   253 D SystemServerTimingAsync: InitThreadPoolExec:ReadingSystemConfig took to complete: 28ms
+12-13 10:32:30.760   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@e95edcb
+12-13 10:32:30.761   226   226 D CompatConfig: Found a config file: /system/system_ext/etc/compatconfig/settings-platform-compat-config.xml
+12-13 10:32:30.762   226   226 D CompatConfig: Adding: com.android.server.compat.config.Change@dcbcc1
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.microsoft.windows.framework/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.sdkext/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.media.swcodec/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.tzdata/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.os.statsd/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.art/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.conscrypt/etc/compatconfig, skipping
+12-13 10:32:30.767   226   226 D CompatConfig: No directory /apex/com.android.neuralnetworks/etc/compatconfig, skipping
+12-13 10:32:30.768   226   226 D CompatConfig: No directory /apex/com.android.i18n/etc/compatconfig, skipping
+12-13 10:32:30.768   226   226 D CompatConfig: No directory /apex/com.android.runtime/etc/compatconfig, skipping
+12-13 10:32:30.768   226   226 D CompatConfig: No directory /apex/com.android.vndk.v30/etc/compatconfig, skipping
+12-13 10:32:30.769   226   226 D CompatConfig: Found a config file: /apex/com.android.mediaprovider/etc/compatconfig/media-provider-platform-compat-config.xml
+12-13 10:32:30.770   226   226 D CompatConfig: No directory /apex/com.android.adbd/etc/compatconfig, skipping
+12-13 10:32:30.770   226   226 D CompatConfig: No directory /apex/com.android.wifi/etc/compatconfig, skipping
+12-13 10:32:30.770   226   226 D CompatConfig: No directory /apex/com.android.ipsec/etc/compatconfig, skipping
+12-13 10:32:30.770   226   226 D CompatConfig: No directory /apex/com.android.resolv/etc/compatconfig, skipping
+12-13 10:32:30.770   226   226 D CompatConfig: No directory /apex/com.android.extservices/etc/compatconfig, skipping
+12-13 10:32:30.770   226   226 D CompatConfig: No directory /apex/com.android.permission/etc/compatconfig, skipping
+12-13 10:32:30.771   226   226 D CompatConfig: No directory /apex/com.android.tethering/etc/compatconfig, skipping
+12-13 10:32:30.771   226   226 D CompatConfig: No directory /apex/com.android.media/etc/compatconfig, skipping
+12-13 10:32:30.772   123   123 W ServiceManager: Service package_native didn't start. Returning NULL
+12-13 10:32:30.772   226   226 D SystemServerTiming: PlatformCompat took to complete: 40ms
+12-13 10:32:30.772   226   226 I SystemServerTiming: StartFileIntegrityService
+12-13 10:32:30.772   226   226 I SystemServiceManager: Starting com.android.server.security.FileIntegrityService
+12-13 10:32:30.772   123   123 E storaged: getService package_native failed
+12-13 10:32:30.778   123   255 I storaged: storaged: Start
+12-13 10:32:30.779   226   226 D SystemServerTiming: StartFileIntegrityService took to complete: 7ms
+12-13 10:32:30.779   226   226 I SystemServerTiming: StartInstaller
+12-13 10:32:30.779   226   226 I SystemServiceManager: Starting com.android.server.pm.Installer
+12-13 10:32:30.780   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.783   112   132 D installd: Found quota mount /dev/block/sda at /data
+12-13 10:32:30.784   112   132 D installd: Found quota mount /dev/block/sda at /data/user/0
+12-13 10:32:30.785   226   226 D SystemServerTiming: StartInstaller took to complete: 6ms
+12-13 10:32:30.785   226   226 I SystemServerTiming: DeviceIdentifiersPolicyService
+12-13 10:32:30.785   226   226 I SystemServiceManager: Starting com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:30.786   226   226 D SystemServerTiming: DeviceIdentifiersPolicyService took to complete: 1ms
+12-13 10:32:30.786   226   226 I SystemServerTiming: UriGrantsManagerService
+12-13 10:32:30.786   226   226 I SystemServiceManager: Starting com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:30.792   226   226 D SystemServerTiming: UriGrantsManagerService took to complete: 6ms
+12-13 10:32:30.792   226   226 I SystemServerTiming: StartActivityManager
+12-13 10:32:30.793   226   226 I SystemServiceManager: Starting com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:30.813   226   226 I SystemServiceManager: Starting com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:30.832   226   226 I ActivityManager: Memory class: 192
+12-13 10:32:30.880   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.880   226   226 D BatteryStatsImpl: Reading daily items from /data/system/batterystats-daily.xml
+12-13 10:32:30.892    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power.stats@1.0::IPowerStats/default in either framework or device manifest.
+12-13 10:32:30.893    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power@1.0::IPower/default in either framework or device manifest.
+12-13 10:32:30.893   226   264 E BatteryStatsService: Unable to load Power.Stats.HAL. Setting rail availability to false
+12-13 10:32:30.893   226   264 E BluetoothAdapter: Bluetooth binder is null
+12-13 10:32:30.895   226   264 I KernelCpuUidFreqTimeReader: mPerClusterTimesAvailable=false
+12-13 10:32:30.899   226   264 W KernelCpuProcStringReader: File not found. It's normal if not implemented: /proc/uid_concurrent_policy_time
+12-13 10:32:30.899   226   264 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state: open failed: ENOENT (No such file or directory)
+12-13 10:32:30.901    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup2: Permission denied
+12-13 10:32:30.901    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup0: Permission denied
+12-13 10:32:30.901    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup3: Permission denied
+12-13 10:32:30.901    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup1: Permission denied
+12-13 10:32:30.902   226   264 W KernelMemoryBandwidthStats: No kernel memory bandwidth stats available
+12-13 10:32:30.903    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power.stats@1.0::IPowerStats/default in either framework or device manifest.
+12-13 10:32:30.903    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power@1.0::IPower/default in either framework or device manifest.
+12-13 10:32:30.903   226   264 E BatteryStatsService: Unable to load Power Hal or power.stats HAL
+12-13 10:32:30.919   226   257 I commit_sys_config_file: [batterystats,13]
+12-13 10:32:30.928    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.memtrack@1.0::IMemtrack/default in either framework or device manifest.
+12-13 10:32:30.928   226   226 E memtrack: Couldn't load memtrack module
+12-13 10:32:30.929   226   257 I commit_sys_config_file: [batterystats,10]
+12-13 10:32:30.951   226   226 I service_manager_stats: [100,17,9673]
+12-13 10:32:30.981   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:30.982   226   226 I IntentFirewall: Read new rules (A:0 B:0 S:0)
+12-13 10:32:31.003   226   226 D AppOps  : AppOpsService published
+12-13 10:32:31.007   226   226 D SystemServerTiming: StartActivityManager took to complete: 214ms
+12-13 10:32:31.007   226   226 I SystemServerTiming: StartDataLoaderManagerService
+12-13 10:32:31.007   226   226 I SystemServiceManager: Starting com.android.server.pm.DataLoaderManagerService
+12-13 10:32:31.008   226   226 D SystemServerTiming: StartDataLoaderManagerService took to complete: 1ms
+12-13 10:32:31.008   226   226 I SystemServerTiming: StartIncrementalService
+12-13 10:32:31.009   226   226 D SystemServerTiming: StartIncrementalService took to complete: 1ms
+12-13 10:32:31.009   226   226 I SystemServerTiming: StartPowerManager
+12-13 10:32:31.009   226   226 I SystemServiceManager: Starting com.android.server.power.PowerManagerService
+12-13 10:32:31.021    22    22 I servicemanager: Found android.hardware.power.IPower/default in device VINTF manifest.
+12-13 10:32:31.022    23    23 I hw-BpHwBinder: onLastStrongRef automatically unlinking death recipients
+12-13 10:32:31.024    85    85 I power-service.windows: Power isModeSupported: 7
+12-13 10:32:31.025    85    85 I power-service.windows: Power isModeSupported: 0
+12-13 10:32:31.026   226   226 D SystemServerTiming: StartPowerManager took to complete: 17ms
+12-13 10:32:31.026   226   226 I SystemServerTiming: StartThermalManager
+12-13 10:32:31.026   226   226 I SystemServiceManager: Starting com.android.server.power.ThermalManagerService
+12-13 10:32:31.029   226   226 D SystemServerTiming: StartThermalManager took to complete: 3ms
+12-13 10:32:31.029   226   226 I SystemServerTiming: InitPowerManagement
+12-13 10:32:31.030   226   226 D SystemServerTiming: InitPowerManagement took to complete: 1ms
+12-13 10:32:31.030   226   226 I SystemServerTiming: StartRecoverySystemService
+12-13 10:32:31.030   226   226 I SystemServiceManager: Starting com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:31.033   226   226 D SystemServerTiming: StartRecoverySystemService took to complete: 3ms
+12-13 10:32:31.035   226   226 I PackageWatchdog: Syncing state, reason: added new observer
+12-13 10:32:31.035   226   226 I PackageWatchdog: Not pruning observers, elapsed time: 0ms
+12-13 10:32:31.035   226   226 I PackageWatchdog: Cancelling state sync, nothing to sync
+12-13 10:32:31.035   226   257 I PackageWatchdog: Saving observer state to file
+12-13 10:32:31.036   226   226 I rescue_note: [0,1,9756]
+12-13 10:32:31.036   226   226 I SystemServerTiming: StartLightsService
+12-13 10:32:31.036   226   226 I SystemServiceManager: Starting com.android.server.lights.LightsService
+12-13 10:32:31.039    22    22 E servicemanager: Could not find android.hardware.light.ILights/default in the VINTF manifest.
+12-13 10:32:31.055   226   226 D SystemServerTiming: StartLightsService took to complete: 19ms
+12-13 10:32:31.055   226   226 I SystemServerTiming: StartSidekickService
+12-13 10:32:31.055   226   226 D SystemServerTiming: StartSidekickService took to complete: 0ms
+12-13 10:32:31.055   226   226 I SystemServerTiming: StartDisplayManager
+12-13 10:32:31.055   226   226 I SystemServiceManager: Starting com.android.server.display.DisplayManagerService
+12-13 10:32:31.067   226   226 D SystemServerTiming: StartDisplayManager took to complete: 12ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: WaitForDisplay
+12-13 10:32:31.067   226   226 I SystemServiceManager: Starting phase 100
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.security.FileIntegrityService
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.pm.Installer
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:31.067   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:31.067   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:31.068   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.power.PowerManagerService
+12-13 10:32:31.068   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:31.068   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.power.ThermalManagerService
+12-13 10:32:31.068   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:31.068   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:31.068   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:31.068   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.lights.LightsService
+12-13 10:32:31.068   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:31.068   226   226 I SystemServerTiming: OnBootPhase_100_com.android.server.display.DisplayManagerService
+12-13 10:32:31.073    89   164 E HWComposer: getSupportedContentTypes: getSupportedContentTypes failed for display 0: Unsupported (8)
+12-13 10:32:31.079   226   249 I DisplayManagerService: Display device added: DisplayDeviceInfo{"Built-in Screen": uniqueId="local:0", 3840 x 2160, modeId 1, defaultModeId 1, supportedModes [{id=1, width=3840, height=2160, fps=60.000004}], colorMode 0, supportedColorModes [0], HdrCapabilities HdrCapabilities{mSupportedHdrTypes=[], mMaxLuminance=500.0, mMaxAverageLuminance=500.0, mMinLuminance=0.0}, allmSupported false, gameContentTypeSupported false, density 240, 0.24 x 0.24 dpi, appVsyncOff 1000000, presDeadline 16666666, touch INTERNAL, rotation 0, type INTERNAL, address {port=0}, deviceProductInfo null, state UNKNOWN, FLAG_DEFAULT_DISPLAY, FLAG_ROTATES_WITH_CONTENT, FLAG_SECURE, FLAG_SUPPORTS_PROTECTED_BUFFERS}
+12-13 10:32:31.081   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:31.081    89    89 D SurfaceFlinger: Setting power mode 2 on display 0
+12-13 10:32:31.084    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.light@2.0::ILight/default in either framework or device manifest.
+12-13 10:32:31.085   226   226 D SystemServerTiming: OnBootPhase_100_com.android.server.display.DisplayManagerService took to complete: 17ms
+12-13 10:32:31.085   226   226 D SystemServerTiming: OnBootPhase_100 took to complete: 18ms
+12-13 10:32:31.085   226   226 D SystemServerTiming: WaitForDisplay took to complete: 18ms
+12-13 10:32:31.085   226   249 I DisplayManagerService: Display device changed state: "Built-in Screen", ON
+12-13 10:32:31.085   226   226 I SystemServerTiming: StartPackageManagerService
+12-13 10:32:31.085   226   226 I Watchdog: Pausing HandlerChecker: main thread for reason: packagemanagermain. Pause count: 1
+12-13 10:32:31.098   226   226 I PackageManagerTiming: create package manager
+12-13 10:32:31.104   226   226 I boot_progress_pms_start: 9825
+12-13 10:32:31.104   226   226 I PackageManagerTiming: createSubComponents
+12-13 10:32:31.146   226   226 D PackageManagerTiming: createSubComponents took to complete: 42ms
+12-13 10:32:31.146   226   226 I PackageManagerTiming: addSharedUsers
+12-13 10:32:31.147   226   226 D PackageManagerTiming: addSharedUsers took to complete: 1ms
+12-13 10:32:31.151   226   226 I PackageManagerTiming: get system config
+12-13 10:32:31.152   226   226 D PackageManagerTiming: get system config took to complete: 1ms
+12-13 10:32:31.156   226   226 D PackageManager: Directories scanned as system partitions: [/system:0, /vendor:524288, /odm:4194304, /oem:262144, /product:1048576, /system_ext:2097152, /apex/com.microsoft.windows.framework:8388608, /apex/com.android.sdkext:8388608, /apex/com.android.media.swcodec:8388608, /apex/com.android.tzdata:8388608, /apex/com.android.os.statsd:8388608, /apex/com.android.art:8388608, /apex/com.android.conscrypt:8388608, /apex/com.android.neuralnetworks:8388608, /apex/com.android.i18n:8388608, /apex/com.android.runtime:8388608, /apex/com.android.vndk.v30:8388608, /apex/com.android.mediaprovider:8388608, /apex/com.android.adbd:8388608, /apex/com.android.wifi:8388608, /apex/com.android.ipsec:8388608, /apex/com.android.resolv:8388608, /apex/com.android.extservices:8388608, /apex/com.android.permission:8388608, /apex/com.android.tethering:8388608, /apex/com.android.media:8388608]
+12-13 10:32:31.160   226   226 D SELinuxMMAC: Using policy file /system/etc/selinux/plat_mac_permissions.xml
+12-13 10:32:31.162   226   226 D SELinuxMMAC: Using policy file /system_ext/etc/selinux/system_ext_mac_permissions.xml
+12-13 10:32:31.162   226   226 D SELinuxMMAC: Using policy file /product/etc/selinux/product_mac_permissions.xml
+12-13 10:32:31.163   226   226 D SELinuxMMAC: Using policy file /vendor/etc/selinux/vendor_mac_permissions.xml
+12-13 10:32:31.164   226   226 I PackageManagerTiming: loadFallbacks
+12-13 10:32:31.166   226   226 D FallbackCategoryProvider: Found 1 fallback categories
+12-13 10:32:31.166   226   226 D PackageManagerTiming: loadFallbacks took to complete: 2ms
+12-13 10:32:31.166   226   226 I PackageManagerTiming: read user settings
+12-13 10:32:31.182   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:31.237   226   226 W PackageSettings: Missing permission state for shared user: android.uid.log
+12-13 10:32:31.237   226   226 W PackageSettings: Missing permission state for shared user: android.uid.nfc
+12-13 10:32:31.237   226   226 W PackageSettings: Missing permission state for shared user: android.uid.bluetooth
+12-13 10:32:31.237   226   226 W PackageSettings: Missing permission state for shared user: android.uid.phone
+12-13 10:32:31.237   226   226 D PackageManagerTiming: read user settings took to complete: 72ms
+12-13 10:32:31.256   226   226 I boot_progress_pms_system_scan_start: 9977
+12-13 10:32:31.259   226   226 D PackageManager: Keeping known cache b01924d3e425a2bd7eeab117ff69c79f7355f3b0
+12-13 10:32:31.259   226   226 W PackageManager: Wiping cache directory because the system partition changed.
+12-13 10:32:31.260   226   226 D PackageManager: No files in app dir /system_ext/overlay
+12-13 10:32:31.260   226   226 D PackageManager: No files in app dir /product/overlay
+12-13 10:32:31.260   226   226 D PackageManager: No files in app dir /oem/overlay
+12-13 10:32:31.260   226   226 D PackageManager: No files in app dir /odm/overlay
+12-13 10:32:31.277   226   226 I PackageBackwardCompatibility: Loaded android.content.pm.AndroidTestBaseUpdater
+12-13 10:32:31.280   226   226 D CompatibilityChangeReporter: Compat change id reported: 143539591; UID -1; state: ENABLED
+12-13 10:32:31.283   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:31.292   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10000; state: ENABLED
+12-13 10:32:31.293   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10002; state: ENABLED
+12-13 10:32:31.294   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10001; state: ENABLED
+12-13 10:32:31.294   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10003; state: ENABLED
+12-13 10:32:31.296   226   226 W PackageManager: Failed to parse /system/framework/oat: Missing base APK in /system/framework/oat
+12-13 10:32:31.296   226   226 W PackageManager: Failed to parse /system/framework/x86: Missing base APK in /system/framework/x86
+12-13 10:32:31.296   226   226 W PackageManager: Failed to parse /system/framework/x86_64: Missing base APK in /system/framework/x86_64
+12-13 10:32:31.310   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 1000; state: ENABLED
+12-13 10:32:31.318   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10006; state: ENABLED
+12-13 10:32:31.326   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10004; state: ENABLED
+12-13 10:32:31.327   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 1073; state: ENABLED
+12-13 10:32:31.328   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10005; state: ENABLED
+12-13 10:32:31.330   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10009; state: ENABLED
+12-13 10:32:31.334   226   226 D CompatibilityChangeReporter: Compat change id reported: 143539591; UID -1; state: DISABLED
+12-13 10:32:31.335   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10012; state: DISABLED
+12-13 10:32:31.336   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10010; state: ENABLED
+12-13 10:32:31.338   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10011; state: ENABLED
+12-13 10:32:31.342   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10008; state: ENABLED
+12-13 10:32:31.347   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10007; state: ENABLED
+12-13 10:32:31.349   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 2000; state: ENABLED
+12-13 10:32:31.353   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 1068; state: ENABLED
+12-13 10:32:31.355   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10016; state: ENABLED
+12-13 10:32:31.356   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10017; state: DISABLED
+12-13 10:32:31.358   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10018; state: ENABLED
+12-13 10:32:31.360   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10015; state: ENABLED
+12-13 10:32:31.361   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10019; state: DISABLED
+12-13 10:32:31.363   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10013; state: ENABLED
+12-13 10:32:31.365   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10014; state: ENABLED
+12-13 10:32:31.366   226   226 D PackageManager: No files in app dir /vendor/priv-app
+12-13 10:32:31.366   226   226 D PackageManager: No files in app dir /vendor/app
+12-13 10:32:31.366   226   226 D PackageManager: No files in app dir /odm/priv-app
+12-13 10:32:31.366   226   226 D PackageManager: No files in app dir /odm/app
+12-13 10:32:31.366   226   226 D PackageManager: No files in app dir /oem/app
+12-13 10:32:31.370   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10020; state: ENABLED
+12-13 10:32:31.372   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10021; state: DISABLED
+12-13 10:32:31.374   226   226 W PackageManager: Skipping provider name com.amazon.mas.client.lockersync.sync (in package com.amazon.venezia): name already used by com.amazon.venezia
+12-13 10:32:31.375   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10022; state: DISABLED
+12-13 10:32:31.378   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10026; state: DISABLED
+12-13 10:32:31.379   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10029; state: ENABLED
+12-13 10:32:31.381   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10028; state: DISABLED
+12-13 10:32:31.382   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10027; state: ENABLED
+12-13 10:32:31.383   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10025; state: DISABLED
+12-13 10:32:31.384   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:31.384   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10024; state: DISABLED
+12-13 10:32:31.389   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10030; state: ENABLED
+12-13 10:32:31.391   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10031; state: ENABLED
+12-13 10:32:31.394   226   226 D PackageManager: No files in app dir /system_ext/app
+12-13 10:32:31.394   226   226 D PackageManager: No files in app dir /apex/com.microsoft.windows.framework/priv-app
+12-13 10:32:31.394   226   226 D PackageManager: No files in app dir /apex/com.microsoft.windows.framework/app
+12-13 10:32:31.394   226   226 D PackageManager: No files in app dir /apex/com.android.sdkext/priv-app
+12-13 10:32:31.394   226   226 D PackageManager: No files in app dir /apex/com.android.sdkext/app
+12-13 10:32:31.394   226   226 D PackageManager: No files in app dir /apex/com.android.media.swcodec/priv-app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.media.swcodec/app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.tzdata/priv-app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.tzdata/app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.os.statsd/priv-app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.os.statsd/app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.art/priv-app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.art/app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.conscrypt/priv-app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.conscrypt/app
+12-13 10:32:31.395   226   226 D PackageManager: No files in app dir /apex/com.android.neuralnetworks/priv-app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.neuralnetworks/app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.i18n/priv-app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.i18n/app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.runtime/priv-app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.runtime/app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.vndk.v30/priv-app
+12-13 10:32:31.396   226   226 D PackageManager: No files in app dir /apex/com.android.vndk.v30/app
+12-13 10:32:31.399   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10035; state: ENABLED
+12-13 10:32:31.400   226   226 D PackageManager: No files in app dir /apex/com.android.mediaprovider/app
+12-13 10:32:31.400   226   226 D PackageManager: No files in app dir /apex/com.android.adbd/priv-app
+12-13 10:32:31.400   226   226 D PackageManager: No files in app dir /apex/com.android.adbd/app
+12-13 10:32:31.404   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10032; state: ENABLED
+12-13 10:32:31.406   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10033; state: ENABLED
+12-13 10:32:31.406   226   226 D PackageManager: No files in app dir /apex/com.android.ipsec/priv-app
+12-13 10:32:31.406   226   226 D PackageManager: No files in app dir /apex/com.android.ipsec/app
+12-13 10:32:31.406   226   226 D PackageManager: No files in app dir /apex/com.android.resolv/priv-app
+12-13 10:32:31.407   226   226 D PackageManager: No files in app dir /apex/com.android.resolv/app
+12-13 10:32:31.409   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10036; state: ENABLED
+12-13 10:32:31.409   226   226 D PackageManager: No files in app dir /apex/com.android.extservices/app
+12-13 10:32:31.411   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10034; state: DISABLED
+12-13 10:32:31.411   226   226 D PackageManager: No files in app dir /apex/com.android.permission/app
+12-13 10:32:31.413   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 1073; state: DISABLED
+12-13 10:32:31.413   226   226 D PackageManager: No files in app dir /apex/com.android.tethering/app
+12-13 10:32:31.413   226   226 D PackageManager: No files in app dir /apex/com.android.media/priv-app
+12-13 10:32:31.413   226   226 D PackageManager: No files in app dir /apex/com.android.media/app
+12-13 10:32:31.416   226   226 I PackageManager: Finished scanning system apps. Time: 160 ms, packageCount: 54 , timePerPackage: 2 , cached: 54
+12-13 10:32:31.416   226   226 I boot_progress_pms_data_scan_start: 10137
+12-13 10:32:31.420   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.420   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.421   226   226 D CompatibilityChangeReporter: Compat change id reported: 133396946; UID -1; state: ENABLED
+12-13 10:32:31.422   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10054; state: ENABLED
+12-13 10:32:31.423   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.424   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.424   226   226 D CompatibilityChangeReporter: Compat change id reported: 133396946; UID -1; state: DISABLED
+12-13 10:32:31.425   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10047; state: DISABLED
+12-13 10:32:31.426   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.427   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.429   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10041; state: DISABLED
+12-13 10:32:31.430   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.430   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.431   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10045; state: DISABLED
+12-13 10:32:31.433   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.433   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.434   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10043; state: ENABLED
+12-13 10:32:31.436   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.436   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.437   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10044; state: ENABLED
+12-13 10:32:31.438   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.438   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.440   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10023; state: DISABLED
+12-13 10:32:31.441   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.441   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.442   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10049; state: DISABLED
+12-13 10:32:31.443   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.443   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.444   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10040; state: DISABLED
+12-13 10:32:31.445   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.445   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.446   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10038; state: ENABLED
+12-13 10:32:31.447   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.447   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.448   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10042; state: DISABLED
+12-13 10:32:31.449   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.449   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.450   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10050; state: DISABLED
+12-13 10:32:31.451   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.451   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.453   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10048; state: ENABLED
+12-13 10:32:31.454   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.454   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.455   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10046; state: ENABLED
+12-13 10:32:31.456   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.456   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.457   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10051; state: DISABLED
+12-13 10:32:31.458   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.458   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.462   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10037; state: ENABLED
+12-13 10:32:31.463   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.READ_COMPAT_CHANGE_CONFIG
+12-13 10:32:31.463   226   226 W android.permission.PermissionManager: Missing ActivityManager; assuming 1000 holds android.permission.LOG_COMPAT_CHANGE
+12-13 10:32:31.467   226   226 D CompatibilityChangeReporter: Compat change id reported: 135549675; UID 10039; state: DISABLED
+12-13 10:32:31.468   226   226 I PackageManager: Finished scanning non-system apps. Time: 53 ms, packageCount: 17 , timePerPackage: 3 , cached: 17
+12-13 10:32:31.470   226   226 E PackageManager: There should probably be exactly one storage manager; found 0: matches=[]
+12-13 10:32:31.471   226   226 E PackageManager: There should probably be exactly one setup wizard; found 0: matches=[]
+12-13 10:32:31.476   226   226 I boot_progress_pms_scan_end: 10197
+12-13 10:32:31.476   226   226 I PackageManager: Time to scan packages: 0.22 seconds
+12-13 10:32:31.477   226   226 I PackageManager: Permission ownership changed. Updating all permissions.
+12-13 10:32:31.484   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:31.487   226   226 V PackageManager: reconcileAppsData for null u0 0x1 migrateAppData=true
+12-13 10:32:31.491   112   132 I SELinux : SELinux: Loaded file_contexts
+12-13 10:32:31.507   226   226 V PackageManager: reconcileAppsData finished 13 packages
+12-13 10:32:31.507   226   226 I PackageManagerTiming: write settings
+12-13 10:32:31.507   226   277 I SystemServerTimingAsync: InitThreadPoolExec:prepareAppData
+12-13 10:32:31.507   226   277 D SystemServerInitThreadPool: Started executing prepareAppData
+12-13 10:32:31.529   112   132 W installd: Ignoring /data/data/Oru9KUmhMe7fr2BR,RdAY6T5ToJmgc4NkEUJlqz23OjIOaiUonjCrA/sUEmp4HJOT1HfelBu5avohHae20dp4C, with unexpected GID 0 instead of 10022
+12-13 10:32:31.529   226   226 I SELinux : SELinux: Loaded file_contexts
+12-13 10:32:31.543   112   132 W installd: Ignoring /data/data/m3buxggbaRqCV85GtRCuvCYPjjkBsi7l9z2CDJS,oSQoAG2A4EdlzC/qNoZv3rmnbHg1SZQqXN4DcrI4ztBTNca with unexpected GID 0 instead of 10027
+12-13 10:32:31.545   112   132 W installd: Ignoring /data/data/wN8t0UCcFbibH5rTOOCpxssize+Z87WnTBpcrLLiAVIUxMz1t2zzMC/cooWBq,fAcU2tFfHNNLKAIxzhpAXQxFN with unexpected GID 0 instead of 10045
+12-13 10:32:31.557   226   226 I commit_sys_config_file: [package-user-0,11]
+12-13 10:32:31.557   226   226 I commit_sys_config_file: [package,51]
+12-13 10:32:31.558   226   226 D PackageManagerTiming: write settings took to complete: 51ms
+12-13 10:32:31.558   226   226 I boot_progress_pms_ready: 10279
+12-13 10:32:31.558   226   226 E PackageManager: There should probably be a verifier, but, none were found
+12-13 10:32:31.562   226   226 D PackageManager: Ephemeral resolver NOT found; no matching intent filters
+12-13 10:32:31.562   226   226 D PackageManager: Instant App installer not found with android.intent.action.INSTALL_INSTANT_APP_PACKAGE
+12-13 10:32:31.562   112   132 W installd: Ignoring /data/data/s+IXDqZ+p08ciivQcwug9+GDxkHHg6lrDkEp,NuSFsVpyBeLC34uwB/eJ4JSKvJWPT8BpofTsyboKzJZ8VcJg6H with unexpected GID 0 instead of 10042
+12-13 10:32:31.562   226   226 D PackageManager: Clear ephemeral installer activity
+12-13 10:32:31.567   112   132 W installd: Ignoring /data/data/2Vkta2l2wrQE,RtkG33EA8oKsIatMgaHknkX55V80uMkqfPtyOOf5B/G838P2zni5GJsuQwHPleWnADuBucWBtb with unexpected GID 0 instead of 10037
+12-13 10:32:31.571   226   226 I PackageManagerTiming: GC
+12-13 10:32:31.578   112   132 W installd: Ignoring /data/data/+FaB1n0473lUUka5gPNlmTUwGzH0TZ89E8VmWBh5,eR09rooG24NnA/W+XucBU6YUYb2Jd0w,FO4VAkCrfMsM3n with unexpected GID 0 instead of 10044
+12-13 10:32:31.580   112   132 W installd: Ignoring /data/data/YEZa4bNE,,JEchTlFzRY4rk5MHKTIEqQutpT9tHuectptSxmJHsy1A/u1AH5TcfaEhvTpN9r0ph5c61IV+d7R2, with unexpected GID 0 instead of 10041
+12-13 10:32:31.585   123   255 I ServiceManager: Waiting for service 'package_native' on '/dev/binder'...
+12-13 10:32:31.596   226   226 I system_server: Explicit concurrent copying GC freed 112947(6595KB) AllocSpace objects, 84(3112KB) LOS objects, 49% free, 5343KB/10MB, paused 86us total 24.656ms
+12-13 10:32:31.596   226   226 D PackageManagerTiming: GC took to complete: 25ms
+12-13 10:32:31.596   226   226 D PackageManagerTiming: create package manager took to complete: 497ms
+12-13 10:32:31.596   226   226 V UserManagerService: Checking that all system packages are whitelisted.
+12-13 10:32:31.597   226   226 V UserManagerService: checkWhitelistedSystemPackages(mode=ENFORCE|IMPLICIT_WHITELIST|IMPLICIT_WHITELIST_SYSTEM) has no warnings
+12-13 10:32:31.598   226   226 I Watchdog: Resuming HandlerChecker: main thread for reason: packagemanagermain. Pause count: 0
+12-13 10:32:31.598   226   226 I SystemServerDexLoadReporter: Configuring system server dex reporter
+12-13 10:32:31.601   226   226 D SystemServerTiming: StartPackageManagerService took to complete: 516ms
+12-13 10:32:31.601   226   226 I SystemServerTiming: StartOtaDexOptService
+12-13 10:32:31.601   226   226 I Watchdog: Pausing HandlerChecker: main thread for reason: moveab. Pause count: 1
+12-13 10:32:31.603   226   226 D OTADexopt: No upgrade, skipping A/B artifacts check.
+12-13 10:32:31.603   226   226 I Watchdog: Resuming HandlerChecker: main thread for reason: moveab. Pause count: 0
+12-13 10:32:31.603   226   226 D SystemServerTiming: StartOtaDexOptService took to complete: 2ms
+12-13 10:32:31.603   226   226 I SystemServerTiming: StartUserManagerService
+12-13 10:32:31.603   226   226 I SystemServiceManager: Starting com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:31.603   226   226 D SystemServerTiming: StartUserManagerService took to complete: 1ms
+12-13 10:32:31.603   226   226 I SystemServerTiming: InitAttributerCache
+12-13 10:32:31.604   226   226 D SystemServerTiming: InitAttributerCache took to complete: 0ms
+12-13 10:32:31.604   226   226 I SystemServerTiming: SetSystemProcess
+12-13 10:32:31.611   226   226 I am_uid_running: 1000
+12-13 10:32:31.613   226   241 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:31.613   226   260 I ActivityManager: Connection with lmkd established
+12-13 10:32:31.614    21    21 I lowmemorykiller: lmkd data connection established
+12-13 10:32:31.615   226   226 I am_uid_active: 1000
+12-13 10:32:31.617   226   226 D SystemServerTiming: SetSystemProcess took to complete: 13ms
+12-13 10:32:31.617   226   226 I SystemServerTiming: InitWatchdog
+12-13 10:32:31.617   107   107 I cameraserver: Waiting for sensor privacy service
+12-13 10:32:31.619   226   277 D SystemServerTimingAsync: AppDataFixup took to complete: 112ms
+12-13 10:32:31.619   226   226 D SystemServerTiming: InitWatchdog took to complete: 2ms
+12-13 10:32:31.619   226   226 I SystemServerTiming: StartOverlayManagerService
+12-13 10:32:31.628   226   241 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:31.629    86    86 I audioserver: Waiting for sensor privacy service
+12-13 10:32:31.630     0     0 I init    : Control message: Processed ctl.start for 'idmap2d' from pid: 226 (system_server)
+12-13 10:32:31.639   112   132 W cutils  : Expected path /data/user_de/0/com.amazon.device.messaging with mode 700 but found 751
+12-13 10:32:31.646   226   226 D SystemServerTiming: StartOverlayManagerService took to complete: 26ms
+12-13 10:32:31.646   226   226 I SystemServerTiming: StartSensorPrivacyService
+12-13 10:32:31.647   226   226 D SystemServerTiming: StartSensorPrivacyService took to complete: 1ms
+12-13 10:32:31.647   226   226 D SystemServerTiming: startBootstrapServices took to complete: 941ms
+12-13 10:32:31.647   226   279 I SystemServerTimingAsync: InitThreadPoolExec:StartSensorService
+12-13 10:32:31.647   226   279 D SystemServerInitThreadPool: Started executing StartSensorService
+12-13 10:32:31.647   226   226 I SystemServerTiming: startCoreServices
+12-13 10:32:31.647   226   279 I SystemServerTimingAsync: StartSensorService
+12-13 10:32:31.647   226   226 I SystemServerTiming: StartSystemConfigService
+12-13 10:32:31.647   226   226 I SystemServiceManager: Starting com.android.server.SystemConfigService
+12-13 10:32:31.648   226   279 D SensorService: nuSensorService starting...
+12-13 10:32:31.648   226   226 D SystemServerTiming: StartSystemConfigService took to complete: 0ms
+12-13 10:32:31.648   226   226 I SystemServerTiming: StartBatteryService
+12-13 10:32:31.648   226   226 I SystemServiceManager: Starting com.android.server.BatteryService
+12-13 10:32:31.652    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.sensors@2.1::ISensors/default in either framework or device manifest.
+12-13 10:32:31.655    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.sensors@2.0::ISensors/default in either framework or device manifest.
+12-13 10:32:31.655    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.sensors@1.0::ISensors/default in either framework or device manifest.
+12-13 10:32:31.655   226   248 I commit_sys_config_file: [overlays,9]
+12-13 10:32:31.655   226   277 D SystemServerTimingAsync: AppDataPrepare took to complete: 37ms
+12-13 10:32:31.656   226   277 I PackageManager: Deferred reconcileAppsData finished 58 packages
+12-13 10:32:31.656   226   277 D SystemServerInitThreadPool: Finished executing prepareAppData
+12-13 10:32:31.656   226   277 D SystemServerTimingAsync: InitThreadPoolExec:prepareAppData took to complete: 149ms
+12-13 10:32:31.657   226   279 D SystemServerTimingAsync: StartSensorService took to complete: 10ms
+12-13 10:32:31.657   226   279 D SystemServerInitThreadPool: Finished executing StartSensorService
+12-13 10:32:31.657   226   279 D SystemServerTimingAsync: InitThreadPoolExec:StartSensorService took to complete: 10ms
+12-13 10:32:31.658   226   226 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hardware.health@2.0::IHealth/default
+12-13 10:32:31.663   226   268 I battery_status: [3,1,1,1,Unknown]
+12-13 10:32:31.663   226   268 I battery_level: [100,5000,0]
+12-13 10:32:31.665   226   226 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hidl.manager@1.0::IServiceManager/default
+12-13 10:32:31.668   226   226 I HealthServiceWrapper: health: HealthServiceWrapper listening to instance default
+12-13 10:32:31.668    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power.stats@1.0::IPowerStats/default in either framework or device manifest.
+12-13 10:32:31.668   226   226 I BatteryService: health: Waited 0ms and received the update.
+12-13 10:32:31.668    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power@1.0::IPower/default in either framework or device manifest.
+12-13 10:32:31.668   226   264 E BatteryStatsService: Unable to load Power Hal or power.stats HAL
+12-13 10:32:31.669    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power.stats@1.0::IPowerStats/default in either framework or device manifest.
+12-13 10:32:31.669    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power@1.0::IPower/default in either framework or device manifest.
+12-13 10:32:31.669   226   264 E BatteryStatsService: Unable to load Power Hal or power.stats HAL
+12-13 10:32:31.669   226   226 D SystemServerTiming: StartBatteryService took to complete: 21ms
+12-13 10:32:31.669   226   280 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hardware.health@2.0::IHealth/default
+12-13 10:32:31.669   226   226 I SystemServerTiming: StartUsageService
+12-13 10:32:31.669   226   226 I SystemServiceManager: Starting com.android.server.usage.UsageStatsService
+12-13 10:32:31.670    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power.stats@1.0::IPowerStats/default in either framework or device manifest.
+12-13 10:32:31.670    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power@1.0::IPower/default in either framework or device manifest.
+12-13 10:32:31.670   226   264 E BatteryStatsService: Unable to load Power Hal or power.stats HAL
+12-13 10:32:31.670    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power.stats@1.0::IPowerStats/default in either framework or device manifest.
+12-13 10:32:31.671    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.power@1.0::IPower/default in either framework or device manifest.
+12-13 10:32:31.671   226   264 E BatteryStatsService: Unable to load Power Hal or power.stats HAL
+12-13 10:32:31.671   226   264 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state: open failed: ENOENT (No such file or directory)
+12-13 10:32:31.667     0     0 W healthd : battery l=100 v=5000 t=0.0 h=1 st=3 cc=-1 chg=a
+12-13 10:32:31.671    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup2: Permission denied
+12-13 10:32:31.672    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup0: Permission denied
+12-13 10:32:31.672    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup3: Permission denied
+12-13 10:32:31.672    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup1: Permission denied
+12-13 10:32:31.673    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup2: Permission denied
+12-13 10:32:31.673    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup0: Permission denied
+12-13 10:32:31.673    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup3: Permission denied
+12-13 10:32:31.673    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup1: Permission denied
+12-13 10:32:31.675   107   107 I HidlServiceManagement: Registered android.frameworks.cameraservice.service@2.1::ICameraService/default
+12-13 10:32:31.676   107   107 I CameraService: CameraService pinged cameraservice proxy
+12-13 10:32:31.677   107   107 I cameraserver: ServiceManager: 0xe95409b0 done instantiate
+12-13 10:32:31.673   226   264 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state: open failed: ENOENT (No such file or directory)
+12-13 10:32:31.685   226   226 D SystemServerTiming: StartUsageService took to complete: 16ms
+12-13 10:32:31.685   226   226 I SystemServerTiming: StartWebViewUpdateService
+12-13 10:32:31.685   226   226 I SystemServiceManager: Starting com.android.server.webkit.WebViewUpdateService
+12-13 10:32:31.690   226   226 D SystemServerTiming: StartWebViewUpdateService took to complete: 5ms
+12-13 10:32:31.690   226   226 I SystemServerTiming: StartCachedDeviceStateService
+12-13 10:32:31.690   226   226 I SystemServiceManager: Starting com.android.server.CachedDeviceStateService
+12-13 10:32:31.690   226   226 D SystemServerTiming: StartCachedDeviceStateService took to complete: 0ms
+12-13 10:32:31.690   226   226 I SystemServerTiming: StartBinderCallsStatsService
+12-13 10:32:31.690   226   226 I SystemServiceManager: Starting com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:31.691   226   226 D SystemServerTiming: StartBinderCallsStatsService took to complete: 1ms
+12-13 10:32:31.691   226   226 I SystemServerTiming: StartLooperStatsService
+12-13 10:32:31.691   226   226 I SystemServiceManager: Starting com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:31.696   226   226 D SystemServerTiming: StartLooperStatsService took to complete: 5ms
+12-13 10:32:31.696   226   226 I SystemServerTiming: StartRollbackManagerService
+12-13 10:32:31.696   226   226 I SystemServiceManager: Starting com.android.server.rollback.RollbackManagerService
+12-13 10:32:31.705   112   132 D installd: Found quota mount /dev/block/sda at /data
+12-13 10:32:31.705   112   132 D installd: Found quota mount /dev/block/sda at /data/user/0
+12-13 10:32:31.706   226   226 I PackageWatchdog: Syncing state, reason: added new observer
+12-13 10:32:31.706   226   226 I PackageWatchdog: Not pruning observers, elapsed time: 0ms
+12-13 10:32:31.706   226   226 I PackageWatchdog: Cancelling state sync, nothing to sync
+12-13 10:32:31.706   226   257 I PackageWatchdog: Saving observer state to file
+12-13 10:32:31.713   226   226 D SystemServerTiming: StartRollbackManagerService took to complete: 17ms
+12-13 10:32:31.713   226   226 I SystemServerTiming: StartBugreportManagerService
+12-13 10:32:31.713   226   226 I SystemServiceManager: Starting com.android.server.os.BugreportManagerService
+12-13 10:32:31.713   226   226 D SystemServerTiming: StartBugreportManagerService took to complete: 1ms
+12-13 10:32:31.713   226   226 I SystemServerTiming: GpuService
+12-13 10:32:31.714   226   226 I SystemServiceManager: Starting com.android.server.gpu.GpuService
+12-13 10:32:31.714   226   226 D SystemServerTiming: GpuService took to complete: 0ms
+12-13 10:32:31.714   226   226 D SystemServerTiming: startCoreServices took to complete: 67ms
+12-13 10:32:31.716   226   226 I SystemServerTiming: startOtherServices
+12-13 10:32:31.716   226   226 I SystemServerTiming: StartKeyAttestationApplicationIdProviderService
+12-13 10:32:31.717   226   285 I SystemServerTimingAsync: InitThreadPoolExec:SecondaryZygotePreload
+12-13 10:32:31.717   226   285 D SystemServerInitThreadPool: Started executing SecondaryZygotePreload
+12-13 10:32:31.717   226   285 I SystemServer: SecondaryZygotePreload
+12-13 10:32:31.717   226   285 I SystemServerTimingAsync: SecondaryZygotePreload
+12-13 10:32:31.717   226   226 D SystemServerTiming: StartKeyAttestationApplicationIdProviderService took to complete: 0ms
+12-13 10:32:31.717   226   226 I SystemServerTiming: StartKeyChainSystemService
+12-13 10:32:31.718   226   226 I SystemServiceManager: Starting com.android.server.security.KeyChainSystemService
+12-13 10:32:31.718   226   226 D SystemServerTiming: StartKeyChainSystemService took to complete: 0ms
+12-13 10:32:31.718   226   226 I SystemServerTiming: StartSchedulingPolicyService
+12-13 10:32:31.718   226   286 I SystemServerTimingAsync: InitThreadPoolExec:SchedulingPolicyService.<init>
+12-13 10:32:31.718   226   286 D SystemServerInitThreadPool: Started executing SchedulingPolicyService.<init>
+12-13 10:32:31.719   226   226 D SystemServerTiming: StartSchedulingPolicyService took to complete: 1ms
+12-13 10:32:31.719   226   226 I SystemServerTiming: StartTelecomLoaderService
+12-13 10:32:31.719   226   226 I SystemServiceManager: Starting com.android.server.telecom.TelecomLoaderService
+12-13 10:32:31.720   226   226 D SystemServerTiming: StartTelecomLoaderService took to complete: 1ms
+12-13 10:32:31.720   226   226 I SystemServerTiming: StartTelephonyRegistry
+12-13 10:32:31.721   226   286 I SchedulingPolicyService: Moving 140 back to group default
+12-13 10:32:31.721    68    68 I Zygote  : Lazily preloading resources.
+12-13 10:32:31.721   226   286 D SystemServerInitThreadPool: Finished executing SchedulingPolicyService.<init>
+12-13 10:32:31.721   226   286 D SystemServerTimingAsync: InitThreadPoolExec:SchedulingPolicyService.<init> took to complete: 2ms
+12-13 10:32:31.721    68    68 D Zygote  : begin preload
+12-13 10:32:31.721    68    68 I Zygote  : Calling ZygoteHooks.beginPreload()
+12-13 10:32:31.723   226   226 D SystemServerTiming: StartTelephonyRegistry took to complete: 3ms
+12-13 10:32:31.723   226   226 I SystemServerTiming: StartEntropyMixer
+12-13 10:32:31.725   226   226 I EntropyMixer: Writing entropy...
+12-13 10:32:31.747   226   226 D SystemServerTiming: StartEntropyMixer took to complete: 23ms
+12-13 10:32:31.747   226   226 I SystemServerTiming: StartAccountManagerService
+12-13 10:32:31.747   226   226 I SystemServiceManager: Starting com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:31.752   226   226 D CompatibilityChangeReporter: Compat change id reported: 148180766; UID 1000; state: ENABLED
+12-13 10:32:31.753   226   226 D SystemServerTiming: StartAccountManagerService took to complete: 6ms
+12-13 10:32:31.753   226   226 I SystemServerTiming: StartContentService
+12-13 10:32:31.753   226   226 I SystemServiceManager: Starting com.android.server.content.ContentService$Lifecycle
+12-13 10:32:31.756   226   226 D SystemServerTiming: StartContentService took to complete: 3ms
+12-13 10:32:31.756   226   226 I SystemServerTiming: InstallSystemProviders
+12-13 10:32:31.775   226   226 I system_server: The ClassLoaderContext is a special shared library.
+12-13 10:32:31.793   226   226 W SettingsState: No settings state /data/system/users/0/settings_config.xml
+12-13 10:32:31.795   226   226 I SettingsState: directory info for directory/file /data/system/users/0/settings_config.xml with stacktrace 
+12-13 10:32:31.795   226   226 I SettingsState: java.lang.Exception
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsState.logSettingsDirectoryInformation(SettingsState.java:892)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsState.readStateSyncLocked(SettingsState.java:1011)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsState.<init>(SettingsState.java:292)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsStateLocked(SettingsProvider.java:2783)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.ensureSettingsForUserLocked(SettingsProvider.java:2748)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.peekSettingsStateLocked(SettingsProvider.java:3091)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.getSettingsNamesLocked(SettingsProvider.java:2713)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.syncSsaidTableOnStart(SettingsProvider.java:2695)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider$SettingsRegistry.<init>(SettingsProvider.java:2588)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.providers.settings.SettingsProvider.onCreate(SettingsProvider.java:347)
+12-13 10:32:31.795   226   226 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2388)
+12-13 10:32:31.795   226   226 I SettingsState: 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2358)
+12-13 10:32:31.795   226   226 I SettingsState: 	at android.app.ActivityThread.installProvider(ActivityThread.java:7246)
+12-13 10:32:31.795   226   226 I SettingsState: 	at android.app.ActivityThread.installContentProviders(ActivityThread.java:6787)
+12-13 10:32:31.795   226   226 I SettingsState: 	at android.app.ActivityThread.installSystemProviders(ActivityThread.java:7439)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.server.am.ActivityManagerService.installSystemProviders(ActivityManagerService.java:7910)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:1122)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.server.SystemServer.run(SystemServer.java:598)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.server.SystemServer.main(SystemServer.java:414)
+12-13 10:32:31.795   226   226 I SettingsState: 	at java.lang.reflect.Method.invoke(Native Method)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+12-13 10:32:31.795   226   226 I SettingsState: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
+12-13 10:32:31.795   226   226 I SettingsState: ancestor directory /data/system/users/0 exists
+12-13 10:32:31.795   226   226 I SettingsState: ancestor directory /data/system/users/0 permissions: r: true w: true x: true
+12-13 10:32:31.795   226   226 I SettingsState: ancestor's parent directory /data/system/users permissions: r: true w: true x: true
+12-13 10:32:31.799    68    68 D ZygoteInitTiming_lazy: BeginPreload took to complete: 77ms
+12-13 10:32:31.800    68    68 I Zygote  : Preloading classes...
+12-13 10:32:31.801    68    68 W Zygote  : Class not found for preloading: android.app.-$$Lambda$ResourcesManager$QJ7UiVk_XS90KuXAsIjIEym1DnM
+12-13 10:32:31.818   226   226 D SystemServerTiming: InstallSystemProviders took to complete: 61ms
+12-13 10:32:31.818   226   226 I SystemServerTiming: StartDropBoxManager
+12-13 10:32:31.818   226   226 I SystemServiceManager: Starting com.android.server.DropBoxManagerService
+12-13 10:32:31.820   226   226 D SystemServerTiming: StartDropBoxManager took to complete: 2ms
+12-13 10:32:31.820   226   226 I SystemServerTiming: StartVibratorService
+12-13 10:32:31.822    22    22 E servicemanager: Could not find android.hardware.vibrator.IVibrator/default in the VINTF manifest.
+12-13 10:32:31.822    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.vibrator@1.0::IVibrator/default in either framework or device manifest.
+12-13 10:32:31.822   226   226 E VibratorService: vibratorOff command failed (1).
+12-13 10:32:31.823    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.vibrator@1.3::IVibrator/default in either framework or device manifest.
+12-13 10:32:31.824   226   226 D SystemServerTiming: StartVibratorService took to complete: 4ms
+12-13 10:32:31.824   226   226 I SystemServerTiming: StartDynamicSystemService
+12-13 10:32:31.825   226   226 D SystemServerTiming: StartDynamicSystemService took to complete: 1ms
+12-13 10:32:31.825   226   226 I SystemServerTiming: StartConsumerIrService
+12-13 10:32:31.826    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.ir@1.0::IConsumerIr/default in either framework or device manifest.
+12-13 10:32:31.826   226   226 D SystemServerTiming: StartConsumerIrService took to complete: 2ms
+12-13 10:32:31.827   226   226 I SystemServerTiming: StartAlarmManagerService
+12-13 10:32:31.828   226   226 E AlarmManagerService: failed to open /sys/class/rtc/rtc0/hctosys: Permission denied
+12-13 10:32:31.828   226   226 W AlarmManagerService: no wall clock RTC found
+12-13 10:32:31.830   226   226 D AlarmManagerService: Kernel timezone updated to 480 minutes west of GMT
+12-13 10:32:31.831   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:31.832   226   226 D SystemServerTiming: StartAlarmManagerService took to complete: 5ms
+12-13 10:32:31.832   226   226 I SystemServerTiming: StartInputManagerService
+12-13 10:32:31.833   226   226 I InputManager: Initializing input manager, mUseDevInputEventForAudioJack=false
+12-13 10:32:31.905   226   226 D SystemServerTiming: StartInputManagerService took to complete: 73ms
+12-13 10:32:31.905   226   226 I SystemServerTiming: StartWindowManagerService
+12-13 10:32:31.925   226   249 I WindowTracing: Setting window tracing log level to 1
+12-13 10:32:31.925   226   249 I WindowTracing: Setting window tracing buffer capacity to 2097152bytes
+12-13 10:32:31.934   226   226 D SystemServerTiming: StartWindowManagerService took to complete: 29ms
+12-13 10:32:31.934   226   226 I SystemServerTiming: SetWindowManagerService
+12-13 10:32:31.937   226   248 I DropBoxManagerService: add tag=system_server_strictmode isTagEnabled=true flags=0x2
+12-13 10:32:31.950   226   248 I DropBoxManagerService: Cleaning temp file: /data/system/dropbox/drop151.tmp
+12-13 10:32:31.967   226   248 I DropBoxManagerService: add tag=system_server_strictmode isTagEnabled=true flags=0x2
+12-13 10:32:32.003   226   248 I chatty  : uid=1000(system) android.io identical 3 lines
+12-13 10:32:32.014   226   248 I DropBoxManagerService: add tag=system_server_strictmode isTagEnabled=true flags=0x2
+12-13 10:32:32.042   226   226 I ActivityTaskManager: Loaded persisted task ids for user 0
+12-13 10:32:32.044   226   226 I wm_task_created: [1,-1]
+12-13 10:32:32.045   226   226 I wm_stack_created: 1
+12-13 10:32:32.049   226   226 D SystemServerTiming: SetWindowManagerService took to complete: 115ms
+12-13 10:32:32.049   226   226 I SystemServerTiming: WindowManagerServiceOnInitReady
+12-13 10:32:32.049   226   246 I dvm_lock_sample: [system_server,0,android.fg,81,ActivityManagerService.java,16732,int com.android.server.am.ActivityManagerService.broadcastIntentWithFeature(android.app.IApplicationThread, java.lang.String, android.content.Intent, java.lang.String, android.content.IIntentReceiver, int, java.lang.String, android.os.Bundle, java.lang.String[], int, android.os.Bundle, boolean, boolean, int),-,6821,java.lang.String com.android.server.am.ActivityManagerService.checkContentProviderAccess(java.lang.String, int),16]
+12-13 10:32:32.057   226   226 D SystemServerTiming: WindowManagerServiceOnInitReady took to complete: 8ms
+12-13 10:32:32.057   226   226 I SystemServerTiming: StartInputManager
+12-13 10:32:32.057   226   226 I InputManager: Starting input manager
+12-13 10:32:32.057   226   290 I SystemServerTimingAsync: InitThreadPoolExec:StartHidlServices
+12-13 10:32:32.057   226   290 D SystemServerInitThreadPool: Started executing StartHidlServices
+12-13 10:32:32.057   226   290 I SystemServerTimingAsync: StartHidlServices
+12-13 10:32:32.059   226   290 I HidlServiceManagement: Registered android.frameworks.sensorservice@1.0::ISensorManager/default
+12-13 10:32:32.060   226   226 I InputManager: Enabling motion classifier because just booted: feature enabled, long press timeout = 400
+12-13 10:32:32.060   226   290 I HidlServiceManagement: Registered android.frameworks.schedulerservice@1.0::ISchedulingPolicyService/default
+12-13 10:32:32.060   226   226 I InputClassifier: Enabling motion classifier
+12-13 10:32:32.060   226   226 D SystemServerTiming: StartInputManager took to complete: 3ms
+12-13 10:32:32.060   226   226 I SystemServerTiming: DisplayManagerWindowManagerAndInputReady
+12-13 10:32:32.060   226   226 D SystemServerTiming: DisplayManagerWindowManagerAndInputReady took to complete: 0ms
+12-13 10:32:32.060   226   226 I SystemServer: No Bluetooth Service (Bluetooth Hardware Not Present)
+12-13 10:32:32.060   226   226 I SystemServerTiming: IpConnectivityMetrics
+12-13 10:32:32.060   226   226 I SystemServiceManager: Starting com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:32.061    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.input.classifier@1.0::IInputClassifier/default in either framework or device manifest.
+12-13 10:32:32.061   226   292 I EventHub: usingClockIoctl=true
+12-13 10:32:32.061   226   292 I EventHub: New device: id=1, fd=143, path='/dev/input/event1', name='virtual_touchscreen', classes=0x14, configuration='/vendor/usr/idc/virtual_touchscreen.idc', keyLayout='', keyCharacterMap='', builtinKeyboard=false, 
+12-13 10:32:32.061   226   292 D EventHub: No input device configuration file found for device 'virtual_keyboard'.
+12-13 10:32:32.061   226   293 I InputClassifier: Could not obtain InputClassifier HAL
+12-13 10:32:32.061   226   290 I HidlServiceManagement: Registered android.frameworks.stats@1.0::IStats/default
+12-13 10:32:32.061   226   290 D SystemServerTimingAsync: StartHidlServices took to complete: 4ms
+12-13 10:32:32.061   226   290 D SystemServerInitThreadPool: Finished executing StartHidlServices
+12-13 10:32:32.061   226   290 D SystemServerTimingAsync: InitThreadPoolExec:StartHidlServices took to complete: 5ms
+12-13 10:32:32.063   226   226 D SystemServerTiming: IpConnectivityMetrics took to complete: 2ms
+12-13 10:32:32.063   226   226 I SystemServerTiming: NetworkWatchlistService
+12-13 10:32:32.063   226   226 I SystemServiceManager: Starting com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:32.065   226   292 W EventHub: Unable to disable kernel key repeat for /dev/input/event0: Function not implemented
+12-13 10:32:32.065   226   292 I EventHub: usingClockIoctl=true
+12-13 10:32:32.065   226   292 I EventHub: New device: id=2, fd=144, path='/dev/input/event0', name='virtual_keyboard', classes=0x43, configuration='', keyLayout='/vendor/usr/keylayout/virtual_keyboard.kl', keyCharacterMap='/system/usr/keychars/Generic.kcm', builtinKeyboard=false, 
+12-13 10:32:32.067   226   292 I InputReader: Device added: id=-1, eventHubId=-1, name='Virtual', descriptor='a718a782d34bc767f4689c232d64d527998ea7fd',sources=0x00000301
+12-13 10:32:32.068   226   292 I InputReader: Device added: id=2, eventHubId=2, name='virtual_keyboard', descriptor='c3d74629a091c258bc3fcd570c4bec3008ce6eba',sources=0x00000501
+12-13 10:32:32.069   226   226 I WatchlistSettings: Reload watchlist settings done
+12-13 10:32:32.069   226   294 I WatchlistLoggingHandler: No need to aggregate record yet.
+12-13 10:32:32.069   226   294 I WatchlistLoggingHandler: Milliseconds spent on tryAggregateRecords(): 0
+12-13 10:32:32.069   226   226 D SystemServerTiming: NetworkWatchlistService took to complete: 7ms
+12-13 10:32:32.069   226   226 I SystemServerTiming: PinnerService
+12-13 10:32:32.069   226   226 I SystemServiceManager: Starting com.android.server.PinnerService
+12-13 10:32:32.071   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.071   226   292 I InputReader: Touch device 'virtual_touchscreen' could not query the properties of its associated display.  The device will be inoperable until the display size becomes available.
+12-13 10:32:32.071   226   292 I InputReader: Device added: id=3, eventHubId=1, name='virtual_touchscreen', descriptor='7b73e3762a90908a4e0e57fa07e0395ad003b019',sources=0x00005002
+12-13 10:32:32.072   226   226 D SystemServerTiming: PinnerService took to complete: 2ms
+12-13 10:32:32.072   226   226 I SystemServerTiming: IorapForwardingService
+12-13 10:32:32.072   226   226 I SystemServiceManager: Starting com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:32.073   226   226 D SystemServerTiming: IorapForwardingService took to complete: 1ms
+12-13 10:32:32.073   226   226 I SystemServerTiming: SignedConfigService
+12-13 10:32:32.073   226   226 D SystemServerTiming: SignedConfigService took to complete: 0ms
+12-13 10:32:32.073   226   226 I SystemServerTiming: AppIntegrityService
+12-13 10:32:32.073   226   226 I SystemServiceManager: Starting com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:32.075   226   226 E IntegrityFileManager: Error creating staging and rules directory
+12-13 10:32:32.076   226   226 D SystemServerTiming: AppIntegrityService took to complete: 3ms
+12-13 10:32:32.077    68    68 E ActivityRecognitionHardware: activity_recognition HAL is deprecated. class_init is effectively a no-op
+12-13 10:32:32.077   226   226 I WindowManager: SAFE MODE not enabled
+12-13 10:32:32.077   226   226 I SystemServerTiming: StartInputMethodManagerLifecycle
+12-13 10:32:32.078   226   226 I SystemServiceManager: Starting com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:32.084   226   226 D SystemServerTiming: StartInputMethodManagerLifecycle took to complete: 7ms
+12-13 10:32:32.084   226   226 I SystemServerTiming: StartAccessibilityManagerService
+12-13 10:32:32.085   226   226 I SystemServiceManager: Starting com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:32.092   226   226 D SystemServerTiming: StartAccessibilityManagerService took to complete: 7ms
+12-13 10:32:32.092   226   226 I SystemServerTiming: MakeDisplayReady
+12-13 10:32:32.092   226   226 I WindowManager: FORCED DISPLAY SIZE: 800x1280
+12-13 10:32:32.094   226   226 W InputReader: Device virtual_touchscreen is associated with display ADISPLAY_ID_NONE.
+12-13 10:32:32.095   226   226 I configuration_changed: 536894968
+12-13 10:32:32.096   226   226 I sysui_multi_action: [757,1659,758,4,759,1,1660,0]
+12-13 10:32:32.096   226   226 I ActivityTaskManager: Config changes=20005df8 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port ?uimode ?night -touch qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.2}
+12-13 10:32:32.100   226   226 I WindowManager: Override config changes=60007dfc {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port ?uimode ?night -touch qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.2} for displayId=0
+12-13 10:32:32.111   226   226 I configuration_changed: 8
+12-13 10:32:32.111   226   226 I ActivityTaskManager: Config changes=8 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port ?uimode ?night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.4}
+12-13 10:32:32.112   226   226 I WindowManager: Override config changes=8 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port ?uimode ?night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.4} for displayId=0
+12-13 10:32:32.113   226   226 D SystemServerTiming: MakeDisplayReady took to complete: 21ms
+12-13 10:32:32.113   226   226 I SystemServerTiming: StartStorageManagerService
+12-13 10:32:32.113   226   226 I SystemServiceManager: Starting com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:32.094   226   226 I chatty  : uid=1000 system_server identical 1 line
+12-13 10:32:32.110   226   226 W InputReader: Device virtual_touchscreen is associated with display ADISPLAY_ID_NONE.
+12-13 10:32:32.114   226   249 I InputManager-JNI: Viewport [0] to add: local:0, isActive: true
+12-13 10:32:32.115   226   292 I InputReader: Reconfiguring input devices, changes=DISPLAY_INFO | 
+12-13 10:32:32.115   226   292 I InputReader: Device reconfigured: id=3, name='virtual_touchscreen', size 2275x1280, orientation 0, mode 1, display id 0
+12-13 10:32:32.118   112   132 D installd: Found quota mount /dev/block/sda at /data
+12-13 10:32:32.118   112   132 D installd: Found quota mount /dev/block/sda at /data/user/0
+12-13 10:32:32.117     0     0 I init    : processing action (sys.sysctl.extra_free_kbytes=*) from (/system/etc/init/hw/init.rc:990)
+12-13 10:32:32.123   226   297 D StorageManagerService: Thinking about init, mBootCompleted=false, mDaemonConnected=true
+12-13 10:32:32.123   226   297 D StorageManagerService: Thinking about reset, mBootCompleted=false, mDaemonConnected=true
+12-13 10:32:32.123   226   297 D StorageManagerService: Thinking about init, mBootCompleted=false, mDaemonConnected=true
+12-13 10:32:32.123   226   297 D StorageManagerService: Thinking about reset, mBootCompleted=false, mDaemonConnected=true
+12-13 10:32:32.124   226   226 D SystemServerTiming: StartStorageManagerService took to complete: 11ms
+12-13 10:32:32.124   226   226 I SystemServerTiming: StartStorageStatsService
+12-13 10:32:32.124   226   226 I SystemServiceManager: Starting com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:32.127   112   132 D installd: Found quota mount /dev/block/sda at /data
+12-13 10:32:32.127   112   132 D installd: Found quota mount /dev/block/sda at /data/user/0
+12-13 10:32:32.128   112   132 D installd: Found quota mount /dev/block/sda at /data
+12-13 10:32:32.128   112   132 D installd: Found quota mount /dev/block/sda at /data/user/0
+12-13 10:32:32.130   226   226 D SystemServerTiming: StartStorageStatsService took to complete: 6ms
+12-13 10:32:32.130   226   226 I SystemServerTiming: StartUiModeManager
+12-13 10:32:32.130   226   226 I SystemServiceManager: Starting com.android.server.UiModeManagerService
+12-13 10:32:32.136   226   298 I SystemServerTimingAsync: InitThreadPoolExec:UiModeManager.onStart
+12-13 10:32:32.136   226   298 D SystemServerInitThreadPool: Started executing UiModeManager.onStart
+12-13 10:32:32.136   226   226 D SystemServerTiming: StartUiModeManager took to complete: 7ms
+12-13 10:32:32.136   226   226 I SystemServerTiming: UpdatePackagesIfNeeded
+12-13 10:32:32.137   226   226 I Watchdog: Pausing HandlerChecker: main thread for reason: dexopt. Pause count: 1
+12-13 10:32:32.139   226   226 I Watchdog: Resuming HandlerChecker: main thread for reason: dexopt. Pause count: 0
+12-13 10:32:32.139   226   226 D SystemServerTiming: UpdatePackagesIfNeeded took to complete: 2ms
+12-13 10:32:32.139   226   226 I SystemServerTiming: PerformFstrimIfNeeded
+12-13 10:32:32.146   226   226 D SystemServerTiming: PerformFstrimIfNeeded took to complete: 7ms
+12-13 10:32:32.146   226   226 I SystemServerTiming: StartLockSettingsService
+12-13 10:32:32.146   226   226 I SystemServiceManager: Starting com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:32.158   226   298 D SystemServerInitThreadPool: Finished executing UiModeManager.onStart
+12-13 10:32:32.158   226   298 D SystemServerTimingAsync: InitThreadPoolExec:UiModeManager.onStart took to complete: 22ms
+12-13 10:32:32.201   226   226 W SystemServiceManager: Service com.android.server.locksettings.LockSettingsService$Lifecycle took 55 ms in onStart
+12-13 10:32:32.201   226   226 D SystemServerTiming: StartLockSettingsService took to complete: 55ms
+12-13 10:32:32.201   226   226 I SystemServerTiming: StartTestHarnessMode
+12-13 10:32:32.201   226   226 I SystemServiceManager: Starting com.android.server.testharness.TestHarnessModeService
+12-13 10:32:32.202   226   226 D SystemServerTiming: StartTestHarnessMode took to complete: 1ms
+12-13 10:32:32.204    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.oemlock@1.0::IOemLock/default in either framework or device manifest.
+12-13 10:32:32.205   226   226 I OemLock : OemLock HAL not present on device
+12-13 10:32:32.205   226   226 I SystemServerTiming: StartDeviceIdleController
+12-13 10:32:32.207   226   226 I SystemServiceManager: Starting com.android.server.DeviceIdleController
+12-13 10:32:32.212   226   226 D SystemServerTiming: StartDeviceIdleController took to complete: 7ms
+12-13 10:32:32.212   226   226 I SystemServerTiming: StartDevicePolicyManager
+12-13 10:32:32.212   226   226 I SystemServiceManager: Starting com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:32.229    68    68 W Zygote  : Class not found for preloading: android.inputmethodservice.-$$Lambda$InputMethodService$TvVfWDKZ3ljQdrU87qYykg6uD-I
+12-13 10:32:32.257   226   226 D SystemServerTiming: StartDevicePolicyManager took to complete: 45ms
+12-13 10:32:32.257   226   226 I SystemServerTiming: StartStatusBarManagerService
+12-13 10:32:32.259   226   226 D SystemServerTiming: StartStatusBarManagerService took to complete: 2ms
+12-13 10:32:32.259   226   226 D SystemServer: ContentCaptureService disabled because resource is not overlaid
+12-13 10:32:32.259   226   226 D SystemServer: AttentionService is not configured on this device
+12-13 10:32:32.260   226   226 D SystemServer: SystemCaptionsManagerService disabled because resource is not overlaid
+12-13 10:32:32.260   226   226 D SystemServer: AppPredictionService not defined by OEM
+12-13 10:32:32.260   226   226 D SystemServer: ContentSuggestionsService not defined by OEM
+12-13 10:32:32.260   226   226 I SystemServerTiming: InitConnectivityModuleConnector
+12-13 10:32:32.260   226   226 D ConnectivityModuleConnector: Network stack init
+12-13 10:32:32.273   226   226 D SystemServerTiming: InitConnectivityModuleConnector took to complete: 13ms
+12-13 10:32:32.273   226   226 I SystemServerTiming: InitNetworkStackClient
+12-13 10:32:32.284   226   226 D SystemServerTiming: InitNetworkStackClient took to complete: 11ms
+12-13 10:32:32.284   226   226 I SystemServerTiming: StartNetworkManagementService
+12-13 10:32:32.291    68    68 I zygote  : Thread[1,tid=68,Native,Thread*=0xe3b82a10,peer=0x12c801e8,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:32.292    68    68 I zygote  : Thread[1,tid=68,Native,Thread*=0xe3b82a10,peer=0x12c801e8,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:32.292    68    68 D MtpDeviceJNI: register_android_mtp_MtpDevice
+12-13 10:32:32.292    68    68 I zygote  : Thread[1,tid=68,Native,Thread*=0xe3b82a10,peer=0x12c801e8,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:32.301   226   226 D SystemServerTiming: StartNetworkManagementService took to complete: 17ms
+12-13 10:32:32.301   226   226 I SystemServerTiming: StartIpSecService
+12-13 10:32:32.302   226   226 D SystemServerTiming: StartIpSecService took to complete: 1ms
+12-13 10:32:32.302   226   226 I SystemServerTiming: StartTextServicesManager
+12-13 10:32:32.302   226   226 I SystemServiceManager: Starting com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:32.303   226   226 D SystemServerTiming: StartTextServicesManager took to complete: 1ms
+12-13 10:32:32.303   226   226 I SystemServerTiming: StartTextClassificationManagerService
+12-13 10:32:32.303   226   226 I SystemServiceManager: Starting com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:32.293    68    68 I zygote  : Thread[1,tid=68,Native,Thread*=0xe3b82a10,peer=0x12c801e8,"main"] recursive attempt to load library "libmedia_jni.so"
+12-13 10:32:32.304    68    68 W Zygote  : Class not found for preloading: android.media.MediaRouter$Static$Client$1
+12-13 10:32:32.304    68    68 W Zygote  : Class not found for preloading: android.media.MediaRouter$Static$Client$2
+12-13 10:32:32.305   226   226 D SystemServerTiming: StartTextClassificationManagerService took to complete: 1ms
+12-13 10:32:32.305   226   226 I SystemServerTiming: StartNetworkScoreService
+12-13 10:32:32.305   226   226 I SystemServiceManager: Starting com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:32.306   226   226 I NetworkScoreService: Registering network_score
+12-13 10:32:32.307   226   226 D SystemServerTiming: StartNetworkScoreService took to complete: 2ms
+12-13 10:32:32.307   226   226 I SystemServerTiming: StartNetworkStatsService
+12-13 10:32:32.309   226   226 D SystemServerTiming: StartNetworkStatsService took to complete: 2ms
+12-13 10:32:32.309   226   226 I SystemServerTiming: StartNetworkPolicyManagerService
+12-13 10:32:32.314   226   226 D SystemServerTiming: StartNetworkPolicyManagerService took to complete: 4ms
+12-13 10:32:32.314   226   226 I SystemServerTiming: StartWifi
+12-13 10:32:32.322    68    68 W Zygote  : Class not found for preloading: android.net.shared.Inet4AddressUtils
+12-13 10:32:32.322    68    68 W Zygote  : Class not found for preloading: android.net.shared.InetAddressUtils
+12-13 10:32:32.327    68    68 D TelephonyManager: No /proc/cmdline exception=java.io.FileNotFoundException: /proc/cmdline: open failed: EACCES (Permission denied)
+12-13 10:32:32.327    68    68 D TelephonyManager: /proc/cmdline=
+12-13 10:32:32.337   226   226 I SystemServiceManager: Starting com.android.server.wifi.WifiService
+12-13 10:32:32.343   226   226 V NetworkScoreManager: registerNetworkScoreCallback: callback=com.android.server.wifi.WifiNetworkScoreCache@876ef0e, executor=com.android.wifi.x.android.os.HandlerExecutor@a4e3d2f
+12-13 10:32:32.368    68    68 W Zygote  : Class not found for preloading: android.telephony.ims.stub.-$$Lambda$ImsRegistrationImplBase$wwtkoeOtGwMjG5I0-ZTfjNpGU-s
+12-13 10:32:32.382    68    68 W Zygote  : Class not found for preloading: android.view.-$$Lambda$cZhmLzK8aetUdx4VlP9w5jR7En0
+12-13 10:32:32.390    68    68 W Zygote  : Class not found for preloading: android.view.autofill.-$$Lambda$AutofillManager$AutofillManagerClient$vxNm6RuuD-r5pkiSxNSBBd1w_Qc
+12-13 10:32:32.391    68    68 W Zygote  : Class not found for preloading: android.view.contentcapture.-$$Lambda$MainContentCaptureSession$1$JPRO-nNGZpgXrKr4QC_iQiTbQx0
+12-13 10:32:32.391    68    68 W Zygote  : Class not found for preloading: android.view.contentcapture.-$$Lambda$MainContentCaptureSession$1$Xhq3WJibbalS1G_W3PRC2m7muhM
+12-13 10:32:32.391    68    68 W Zygote  : Class not found for preloading: android.view.contentcapture.MainContentCaptureSession$1
+12-13 10:32:32.413    68    68 W Zygote  : Class not found for preloading: com.android.internal.telephony.-$$Lambda$SubscriptionController$VCQsMNqRHpN3RyoXYzh2YUwA2yc
+12-13 10:32:32.414    68    68 W Zygote  : Class not found for preloading: com.android.internal.telephony.-$$Lambda$SubscriptionController$u5xE-urXR6ElZ50305_6guo20Fc
+12-13 10:32:32.425   226   226 D WifiCountryCode: mDefaultCountryCode null
+12-13 10:32:32.429   226   226 I WifiContext: Found Wifi Resources APK at: com.android.wifi.resources
+12-13 10:32:32.457    68    68 W Zygote  : Class not found for preloading: com.android.internal.telephony.IccSmsInterfaceManager$2
+12-13 10:32:32.465    68    68 W Zygote  : Class not found for preloading: com.android.internal.telephony.dataconnection.DcTracker$5
+12-13 10:32:32.470   226   226 D WifiOpenNetworkNotifier: Settings toggle enabled=false
+12-13 10:32:32.471    68    68 W Zygote  : Class not found for preloading: com.android.internal.widget.-$$Lambda$gPQuiuEDuOmrh2MixBcV6a5gu5s
+12-13 10:32:32.472    68    68 W Zygote  : Class not found for preloading: com.android.internal.widget.LockPatternUtils$2
+12-13 10:32:32.480   226   226 W HalDevMgr: isWifiStarted called but mWifi is null!?
+12-13 10:32:32.480   226   226 W HalDevMgr: isWifiStarted called but mWifi is null!?
+12-13 10:32:32.481   226   226 D WakeupController: WifiWake enabled
+12-13 10:32:32.482   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.483   226   226 E WifiClientModeImpl: getWifiLinkLayerStats called without an interface
+12-13 10:32:32.496   226   226 I WifiService: Registering wifi
+12-13 10:32:32.496   226   226 D SystemServerTiming: StartWifi took to complete: 182ms
+12-13 10:32:32.496   226   226 I SystemServerTiming: StartWifiScanning
+12-13 10:32:32.496   226   226 I SystemServiceManager: Starting com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:32.497   226   226 I WifiScanningService: Creating wifiscanner
+12-13 10:32:32.499   226   226 I WifiScanningService: Publishing wifiscanner
+12-13 10:32:32.500   226   226 D SystemServerTiming: StartWifiScanning took to complete: 4ms
+12-13 10:32:32.500   226   226 I SystemServerTiming: StartEthernet
+12-13 10:32:32.501   226   226 I SystemServiceManager: Starting com.android.server.ethernet.EthernetService
+12-13 10:32:32.501   226   226 I EthernetService: Registering service ethernet
+12-13 10:32:32.502   226   226 D SystemServerTiming: StartEthernet took to complete: 2ms
+12-13 10:32:32.502   226   226 I SystemServerTiming: StartConnectivityService
+12-13 10:32:32.502    68    68 I Zygote  : ...preloaded 12107 classes in 702ms.
+12-13 10:32:32.503    68    68 I zygote  : VMRuntime.preloadDexCaches starting
+12-13 10:32:32.513    68    68 I zygote  : VMRuntime.preloadDexCaches strings total=418392 before=11374 after=11374
+12-13 10:32:32.513    68    68 I zygote  : VMRuntime.preloadDexCaches types total=40936 before=11224 after=11400
+12-13 10:32:32.513    68    68 I zygote  : VMRuntime.preloadDexCaches fields total=173763 before=14203 after=15087
+12-13 10:32:32.513    68    68 I zygote  : VMRuntime.preloadDexCaches methods total=316014 before=18080 after=18080
+12-13 10:32:32.513    68    68 I zygote  : VMRuntime.preloadDexCaches finished
+12-13 10:32:32.513    68    68 D ZygoteInitTiming_lazy: PreloadClasses took to complete: 713ms
+12-13 10:32:32.518    68    68 I zygote  : The ClassLoaderContext is a special shared library.
+12-13 10:32:32.521    68    68 D ApplicationLoaders: Created zygote-cached class loader: /system/framework/android.hidl.base-V1.0-java.jar
+12-13 10:32:32.523    68    68 I zygote  : The ClassLoaderContext is a special shared library.
+12-13 10:32:32.523    68    68 D ApplicationLoaders: Created zygote-cached class loader: /system/framework/android.hidl.manager-V1.0-java.jar
+12-13 10:32:32.524    68    68 I zygote  : The ClassLoaderContext is a special shared library.
+12-13 10:32:32.524    68    68 D ApplicationLoaders: Created zygote-cached class loader: /system/framework/android.test.base.jar
+12-13 10:32:32.525    68    68 D ZygoteInitTiming_lazy: CacheNonBootClasspathClassLoaders took to complete: 12ms
+12-13 10:32:32.525    68    68 I Zygote  : Preloading resources...
+12-13 10:32:32.529   226   226 D ConnectivityService: ConnectivityService starting up
+12-13 10:32:32.534   226   226 D ConnectivityService: wifiOnly=false
+12-13 10:32:32.538   226   226 D CompatibilityChangeReporter: Compat change id reported: 147600208; UID 1000; state: ENABLED
+12-13 10:32:32.545    68    68 W Resources: Preloaded drawable resource #0x108028c (android:drawable/dialog_background_material) that varies with configuration!!
+12-13 10:32:32.547   226   226 D SystemServerTiming: StartConnectivityService took to complete: 45ms
+12-13 10:32:32.547   226   226 I SystemServerTiming: StartNsdService
+12-13 10:32:32.550   226   226 D NsdService: Network service discovery is enabled
+12-13 10:32:32.556    68    68 I Zygote  : ...preloaded 64 resources in 31ms.
+12-13 10:32:32.557   226   226 D SystemServerTiming: StartNsdService took to complete: 11ms
+12-13 10:32:32.558   226   226 I SystemServerTiming: StartSystemUpdateManagerService
+12-13 10:32:32.558   226   226 I SystemUpdateManagerService: No existing info file /data/system/system-update-info.xml
+12-13 10:32:32.558   226   226 D SystemServerTiming: StartSystemUpdateManagerService took to complete: 0ms
+12-13 10:32:32.558   226   226 I SystemServerTiming: StartUpdateLockService
+12-13 10:32:32.559   226   226 D SystemServerTiming: StartUpdateLockService took to complete: 1ms
+12-13 10:32:32.559   226   226 I SystemServerTiming: StartNotificationManager
+12-13 10:32:32.559   226   226 I SystemServiceManager: Starting com.android.server.notification.NotificationManagerService
+12-13 10:32:32.559    68    68 I Zygote  : ...preloaded 41 resources in 3ms.
+12-13 10:32:32.559    68    68 D ZygoteInitTiming_lazy: PreloadResources took to complete: 34ms
+12-13 10:32:32.568    68    68 I Zygote  : Preloading shared libraries...
+12-13 10:32:32.581    68    68 I Zygote  : Called ZygoteHooks.endPreload()
+12-13 10:32:32.581    68    68 I Zygote  : Installed AndroidKeyStoreProvider in 1ms.
+12-13 10:32:32.585    68    68 I Zygote  : Warmed up JCA providers in 3ms.
+12-13 10:32:32.585    68    68 D Zygote  : end preload
+12-13 10:32:32.585   226   285 D SystemServerTimingAsync: SecondaryZygotePreload took to complete: 868ms
+12-13 10:32:32.585   226   285 D SystemServerInitThreadPool: Finished executing SecondaryZygotePreload
+12-13 10:32:32.585   226   285 D SystemServerTimingAsync: InitThreadPoolExec:SecondaryZygotePreload took to complete: 869ms
+12-13 10:32:32.592   226   226 D ConditionProviders.SCP: new ScheduleConditionProvider()
+12-13 10:32:32.598   226   226 I NotificationAssistants: Read notification assistant permissions from xml
+12-13 10:32:32.598   226   226 I ConditionProviders: Read condition provider permissions from xml
+12-13 10:32:32.598   226   226 I ConditionProviders: Read condition provider permissions from xml
+12-13 10:32:32.598   226   226 D NotificationAssistants: Approving default notification assistant for user 0
+12-13 10:32:32.598   226   226 I ConditionProviders:  Allowing condition provider android.ext.services/android.ext.services.notification.Assistant
+12-13 10:32:32.611   226   248 I commit_sys_config_file: [notification-policy,12]
+12-13 10:32:32.615   226   226 D SystemServerTiming: StartNotificationManager took to complete: 56ms
+12-13 10:32:32.615   226   226 I SystemServerTiming: StartDeviceMonitor
+12-13 10:32:32.615   226   226 I SystemServiceManager: Starting com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:32.617   226   226 D SystemServerTiming: StartDeviceMonitor took to complete: 2ms
+12-13 10:32:32.617   226   226 I SystemServerTiming: StartLocationManagerService
+12-13 10:32:32.617   226   226 I SystemServiceManager: Starting com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:32.620   226   316 I storage_state: [41217664-9172-527a-b3d5-edabb50a7d69,0,0,127162109952,132061302784]
+12-13 10:32:32.625   226   248 I commit_sys_config_file: [notification-policy,12]
+12-13 10:32:32.628   226   226 D SystemServerTiming: StartLocationManagerService took to complete: 11ms
+12-13 10:32:32.628   226   226 I SystemServerTiming: StartCountryDetectorService
+12-13 10:32:32.629   226   226 D SystemServerTiming: StartCountryDetectorService took to complete: 1ms
+12-13 10:32:32.629   226   226 I SystemServerTiming: StartTimeDetectorService
+12-13 10:32:32.629   226   226 I SystemServiceManager: Starting com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:32.630   226   226 D SystemServerTiming: StartTimeDetectorService took to complete: 1ms
+12-13 10:32:32.630   226   226 I SystemServerTiming: StartTimeZoneDetectorService
+12-13 10:32:32.630   226   226 I SystemServiceManager: Starting com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:32.631   226   226 D SystemServerTiming: StartTimeZoneDetectorService took to complete: 1ms
+12-13 10:32:32.631   226   226 I SystemServerTiming: StartSearchManagerService
+12-13 10:32:32.631   226   226 I SystemServiceManager: Starting com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:32.632   226   226 D SystemServerTiming: StartSearchManagerService took to complete: 1ms
+12-13 10:32:32.632   226   226 I SystemServer: Wallpaper service disabled by config
+12-13 10:32:32.632   226   226 I SystemServerTiming: StartAudioService
+12-13 10:32:32.632   226   226 I SystemServiceManager: Starting com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:32.660   226   226 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hidl.manager@1.0::IServiceManager/default
+12-13 10:32:32.662    86   207 W AudioFlinger: no wake lock to update, system not ready yet
+12-13 10:32:32.665    86    86 D PermissionCache: checking android.permission.MODIFY_AUDIO_ROUTING for uid=1000 => granted (811 us)
+12-13 10:32:32.667    86   179 D PermissionCache: checking android.permission.MODIFY_AUDIO_SETTINGS for uid=1000 => granted (133 us)
+12-13 10:32:32.668    86   179 E AudioFlinger: getMicMute: error -38 getting state from HAL
+12-13 10:32:32.669    86   179 W AudioFlinger: setMicMute: error -38 setting state to HAL
+12-13 10:32:32.669   226   226 E AudioSystem-JNI: Command failed for android_media_AudioSystem_muteMicrophone: -38
+12-13 10:32:32.669    86   179 E AudioFlinger: getMicMute: error -38 getting state from HAL
+12-13 10:32:32.670   226   226 E AS.AudioService: Error changing mic mute state to false current:false
+12-13 10:32:32.680   226   226 I stream_devices_changed: [3,0,2]
+12-13 10:32:32.680   226   226 I stream_devices_changed: [6,0,2]
+12-13 10:32:32.694    86   179 W APM::AudioPolicyEngine: getDevicesForStrategy() unknown strategy: -1
+12-13 10:32:32.700    86   179 D AudioFlinger: isLowRamDevice:false totalMemory:6286368768 mClientSharedHeapSize:33554432
+12-13 10:32:32.703   226   226 D SystemServerTiming: StartAudioService took to complete: 71ms
+12-13 10:32:32.703   226   226 I SystemServerTiming: StartSoundTriggerMiddlewareService
+12-13 10:32:32.703   226   226 I SystemServiceManager: Starting com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:32.718   226   226 D SoundTriggerMiddlewareService: Connecting to default ISoundTriggerHw
+12-13 10:32:32.718    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.soundtrigger@2.0::ISoundTriggerHw/default in either framework or device manifest.
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: Failed to add a SoundTriggerModule instance
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: java.util.NoSuchElementException
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at android.os.HwBinder.getService(Native Method)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at android.hardware.soundtrigger.V2_0.ISoundTriggerHw.getService(ISoundTriggerHw.java:55)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at android.hardware.soundtrigger.V2_0.ISoundTriggerHw.getService(ISoundTriggerHw.java:62)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle.lambda$onStart$0(SoundTriggerMiddlewareService.java:176)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.soundtrigger_middleware.-$$Lambda$SoundTriggerMiddlewareService$Lifecycle$-t8UndY0AHGyM6n9ce2y6qok3Ho.create(Unknown Source:0)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.soundtrigger_middleware.SoundTriggerModule.attachToHal(SoundTriggerModule.java:219)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.soundtrigger_middleware.SoundTriggerModule.<init>(SoundTriggerModule.java:113)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareImpl.<init>(SoundTriggerMiddlewareImpl.java:89)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle.onStart(SoundTriggerMiddlewareService.java:182)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.SystemServiceManager.startService(SystemServiceManager.java:178)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.SystemServiceManager.startService(SystemServiceManager.java:165)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.SystemServer.startOtherServices(SystemServer.java:1654)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.SystemServer.run(SystemServer.java:598)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.server.SystemServer.main(SystemServer.java:414)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at java.lang.reflect.Method.invoke(Native Method)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+12-13 10:32:32.721   226   226 E SoundTriggerMiddlewareImpl: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
+12-13 10:32:32.722   226   226 D SystemServerTiming: StartSoundTriggerMiddlewareService took to complete: 19ms
+12-13 10:32:32.722   226   226 I SystemServerTiming: StartDockObserver
+12-13 10:32:32.722   226   226 I SystemServiceManager: Starting com.android.server.DockObserver
+12-13 10:32:32.722   226   226 W DockObserver: This kernel does not have dock station support
+12-13 10:32:32.723    86    86 I CaptureStateNotifier: Registering a listener
+12-13 10:32:32.723   226   226 D SystemServerTiming: StartDockObserver took to complete: 1ms
+12-13 10:32:32.723   226   226 I SystemServerTiming: StartWiredAccessoryManager
+12-13 10:32:32.723   226   321 I SoundTriggerMiddlewareLogging: setCaptureState[this=com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareImpl@4d85850, caller=1000/226](false)
+12-13 10:32:32.724   226   226 W WiredAccessoryManager: This kernel does not have wired headset support
+12-13 10:32:32.724   226   226 W WiredAccessoryManager: This kernel does not have usb audio support
+12-13 10:32:32.724   226   226 W WiredAccessoryManager: This kernel does not have HDMI audio support
+12-13 10:32:32.724   226   226 D SystemServerTiming: StartWiredAccessoryManager took to complete: 1ms
+12-13 10:32:32.724   226   226 I SystemServerTiming: StartAdbService
+12-13 10:32:32.724   226   226 I SystemServiceManager: Starting com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:32.727   226   226 D SystemServerTiming: StartAdbService took to complete: 3ms
+12-13 10:32:32.727   226   226 I SystemServerTiming: StartSerialService
+12-13 10:32:32.727   226   226 D SystemServerTiming: StartSerialService took to complete: 0ms
+12-13 10:32:32.727   226   226 I SystemServerTiming: StartHardwarePropertiesManagerService
+12-13 10:32:32.728    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.thermal@1.0::IThermal/default in either framework or device manifest.
+12-13 10:32:32.728   226   226 E HardwarePropertiesManagerService-JNI: Unable to get Thermal service.
+12-13 10:32:32.729   226   226 D SystemServerTiming: StartHardwarePropertiesManagerService took to complete: 2ms
+12-13 10:32:32.729   226   226 I SystemServerTiming: StartTwilightService
+12-13 10:32:32.729   226   226 I SystemServiceManager: Starting com.android.server.twilight.TwilightService
+12-13 10:32:32.729   226   226 D SystemServerTiming: StartTwilightService took to complete: 0ms
+12-13 10:32:32.729   226   226 I SystemServerTiming: StartColorDisplay
+12-13 10:32:32.729   226   226 I SystemServiceManager: Starting com.android.server.display.color.ColorDisplayService
+12-13 10:32:32.732   226   226 D SystemServerTiming: StartColorDisplay took to complete: 3ms
+12-13 10:32:32.732   226   226 I SystemServerTiming: StartJobScheduler
+12-13 10:32:32.736   226   226 I SystemServiceManager: Starting com.android.server.job.JobSchedulerService
+12-13 10:32:32.744   226   226 D JobStore: Start tag: job-info
+12-13 10:32:32.749   226   226 I JobStore: Read 21 jobs
+12-13 10:32:32.753   226   226 I TetheringManager: registerTetheringEventCallback:android
+12-13 10:32:32.754   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:32.761   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.761   226   226 D SystemServerTiming: StartJobScheduler took to complete: 29ms
+12-13 10:32:32.761   226   226 I SystemServerTiming: StartSoundTrigger
+12-13 10:32:32.761   226   226 I SystemServiceManager: Starting com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:32.762   226   226 D SystemServerTiming: StartSoundTrigger took to complete: 1ms
+12-13 10:32:32.762   226   226 I SystemServerTiming: StartTrustManager
+12-13 10:32:32.762   226   226 I SystemServiceManager: Starting com.android.server.trust.TrustManagerService
+12-13 10:32:32.764   226   226 D SystemServerTiming: StartTrustManager took to complete: 2ms
+12-13 10:32:32.764   226   226 I SystemServerTiming: StartAppWidgetService
+12-13 10:32:32.764   226   226 I SystemServiceManager: Starting com.android.server.appwidget.AppWidgetService
+12-13 10:32:32.769   226   226 D SystemServerTiming: StartAppWidgetService took to complete: 5ms
+12-13 10:32:32.769   226   226 I SystemServerTiming: StartRoleManagerService
+12-13 10:32:32.773   226   226 D SystemServerTiming: StartRoleManagerService took to complete: 4ms
+12-13 10:32:32.773   226   226 I SystemServerTiming: StartVoiceRecognitionManager
+12-13 10:32:32.773   226   226 I SystemServiceManager: Starting com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:32.777   226   226 W VoiceInteractionManager: Unable to resolve default voice recognition service.
+12-13 10:32:32.777   226   226 D SystemServerTiming: StartVoiceRecognitionManager took to complete: 4ms
+12-13 10:32:32.777   226   226 I SystemServerTiming: StartGestureLauncher
+12-13 10:32:32.777   226   226 I SystemServiceManager: Starting com.android.server.GestureLauncherService
+12-13 10:32:32.777   226   226 D SystemServerTiming: StartGestureLauncher took to complete: 1ms
+12-13 10:32:32.777   226   226 I SystemServerTiming: StartSensorNotification
+12-13 10:32:32.777   226   226 I SystemServiceManager: Starting com.android.server.SensorNotificationService
+12-13 10:32:32.777   226   226 D SystemServerTiming: StartSensorNotification took to complete: 0ms
+12-13 10:32:32.778   226   226 I SystemServerTiming: StartDiskStatsService
+12-13 10:32:32.781   226   226 D SystemServerTiming: StartDiskStatsService took to complete: 3ms
+12-13 10:32:32.781   226   226 I SystemServerTiming: RuntimeService
+12-13 10:32:32.781   226   226 D SystemServerTiming: RuntimeService took to complete: 0ms
+12-13 10:32:32.781   226   226 I SystemServerTiming: StartNetworkTimeUpdateService
+12-13 10:32:32.782   226   226 D SystemServerTiming: StartNetworkTimeUpdateService took to complete: 1ms
+12-13 10:32:32.782   226   226 I SystemServerTiming: CertBlacklister
+12-13 10:32:32.782   226   226 D SystemServerTiming: CertBlacklister took to complete: 0ms
+12-13 10:32:32.782   226   226 I SystemServerTiming: StartEmergencyAffordanceService
+12-13 10:32:32.782   226   226 I SystemServiceManager: Starting com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:32.783   226   226 D SystemServerTiming: StartEmergencyAffordanceService took to complete: 1ms
+12-13 10:32:32.783   226   226 I SystemServerTiming: StartDreamManager
+12-13 10:32:32.783   226   226 I SystemServiceManager: Starting com.android.server.dreams.DreamManagerService
+12-13 10:32:32.783   226   325 I SystemServerTimingAsync: InitThreadPoolExec:startBlobStoreManagerService
+12-13 10:32:32.783   226   325 D SystemServerInitThreadPool: Started executing startBlobStoreManagerService
+12-13 10:32:32.783   226   325 I SystemServerTimingAsync: startBlobStoreManagerService
+12-13 10:32:32.784   226   226 D SystemServerTiming: StartDreamManager took to complete: 1ms
+12-13 10:32:32.784   226   226 I SystemServerTiming: AddGraphicsStatsService
+12-13 10:32:32.789   226   226 D SystemServerTiming: AddGraphicsStatsService took to complete: 5ms
+12-13 10:32:32.791    65    71 I ServiceManager: Waiting for service 'statscompanion' on '/dev/binder'...
+12-13 10:32:32.793   226   226 I SystemServerTiming: StartPrintManager
+12-13 10:32:32.793   226   226 I SystemServiceManager: Starting com.android.server.print.PrintManagerService
+12-13 10:32:32.798   226   226 D SystemServerTiming: StartPrintManager took to complete: 5ms
+12-13 10:32:32.798   226   226 I SystemServerTiming: StartRestrictionManager
+12-13 10:32:32.798   226   226 I SystemServiceManager: Starting com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:32.799   226   226 D SystemServerTiming: StartRestrictionManager took to complete: 1ms
+12-13 10:32:32.799   226   226 I SystemServerTiming: StartMediaSessionService
+12-13 10:32:32.799   226   226 I SystemServiceManager: Starting com.android.server.media.MediaSessionService
+12-13 10:32:32.802   226   325 I SystemServiceManager: Starting com.android.server.blob.BlobStoreManagerService
+12-13 10:32:32.805   226   325 D SystemServerTimingAsync: startBlobStoreManagerService took to complete: 22ms
+12-13 10:32:32.805   226   325 D SystemServerInitThreadPool: Finished executing startBlobStoreManagerService
+12-13 10:32:32.805   226   325 D SystemServerTimingAsync: InitThreadPoolExec:startBlobStoreManagerService took to complete: 22ms
+12-13 10:32:32.810   226   226 D SystemServerTiming: StartMediaSessionService took to complete: 11ms
+12-13 10:32:32.810   226   226 I SystemServerTiming: StartMediaRouterService
+12-13 10:32:32.810   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.811   226   226 D SystemServerTiming: StartMediaRouterService took to complete: 1ms
+12-13 10:32:32.811   226   226 I SystemServerTiming: StartBiometricService
+12-13 10:32:32.811   226   226 I SystemServiceManager: Starting com.android.server.biometrics.BiometricService
+12-13 10:32:32.815   226   226 D SystemServerTiming: StartBiometricService took to complete: 4ms
+12-13 10:32:32.815   226   226 I SystemServerTiming: StartAuthService
+12-13 10:32:32.815   226   226 I SystemServiceManager: Starting com.android.server.biometrics.AuthService
+12-13 10:32:32.816   226   226 D SystemServerTiming: StartAuthService took to complete: 1ms
+12-13 10:32:32.816   226   226 I SystemServerTiming: StartBackgroundDexOptService
+12-13 10:32:32.816   226   226 W BackgroundDexOptService: SysProp pm.dexopt.downgrade_after_inactive_days not set
+12-13 10:32:32.817   226   226 D SystemServerTiming: StartBackgroundDexOptService took to complete: 1ms
+12-13 10:32:32.817   226   226 I SystemServerTiming: StartDynamicCodeLoggingService
+12-13 10:32:32.818   226   226 D SystemServerTiming: StartDynamicCodeLoggingService took to complete: 1ms
+12-13 10:32:32.818   226   226 I SystemServerTiming: StartPruneInstantAppsJobService
+12-13 10:32:32.818   226   226 D SystemServerTiming: StartPruneInstantAppsJobService took to complete: 0ms
+12-13 10:32:32.818   226   226 I SystemServerTiming: StartShortcutServiceLifecycle
+12-13 10:32:32.818   226   226 I SystemServiceManager: Starting com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:32.821   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.821   226   226 D SystemServerTiming: StartShortcutServiceLifecycle took to complete: 3ms
+12-13 10:32:32.821   226   226 I SystemServerTiming: StartLauncherAppsService
+12-13 10:32:32.821   226   226 I SystemServiceManager: Starting com.android.server.pm.LauncherAppsService
+12-13 10:32:32.823   226   226 D SystemServerTiming: StartLauncherAppsService took to complete: 1ms
+12-13 10:32:32.823   226   226 I SystemServerTiming: StartCrossProfileAppsService
+12-13 10:32:32.823   226   226 I SystemServiceManager: Starting com.android.server.pm.CrossProfileAppsService
+12-13 10:32:32.823   226   226 D SystemServerTiming: StartCrossProfileAppsService took to complete: 0ms
+12-13 10:32:32.823   226   226 I SystemServerTiming: StartPeopleService
+12-13 10:32:32.823   226   226 I SystemServiceManager: Starting com.android.server.people.PeopleService
+12-13 10:32:32.824   226   226 D SystemServerTiming: StartPeopleService took to complete: 0ms
+12-13 10:32:32.824   226   226 I SystemServerTiming: StartMediaProjectionManager
+12-13 10:32:32.824   226   226 I SystemServiceManager: Starting com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:32.827   226   226 V MediaRouter: Selecting route: RouteInfo{ name=Phone, description=null, status=null, category=RouteCategory{ name=System types=ROUTE_TYPE_LIVE_AUDIO ROUTE_TYPE_LIVE_VIDEO  groupable=false }, supportedTypes=ROUTE_TYPE_LIVE_AUDIO ROUTE_TYPE_LIVE_VIDEO , presentationDisplay=null }
+12-13 10:32:32.828   226   226 D SystemServerTiming: StartMediaProjectionManager took to complete: 4ms
+12-13 10:32:32.828   226   226 I SystemServerTiming: StartSliceManagerService
+12-13 10:32:32.828   226   226 I SystemServiceManager: Starting com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:32.829   226   226 D SystemServerTiming: StartSliceManagerService took to complete: 1ms
+12-13 10:32:32.829   226   226 I SystemServerTiming: StartCameraServiceProxy
+12-13 10:32:32.829   226   226 I SystemServiceManager: Starting com.android.server.camera.CameraServiceProxy
+12-13 10:32:32.832   226   226 D SystemServerTiming: StartCameraServiceProxy took to complete: 3ms
+12-13 10:32:32.832   226   226 I SystemServerTiming: StartStatsCompanion
+12-13 10:32:32.835   226   226 I SystemServiceManager: Starting com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:32.838   226   226 D SystemServerTiming: StartStatsCompanion took to complete: 7ms
+12-13 10:32:32.839   226   226 I SystemServerTiming: StartStatsPullAtomService
+12-13 10:32:32.847   226   226 I SystemServiceManager: Starting com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:32.848   226   226 D SystemServerTiming: StartStatsPullAtomService took to complete: 9ms
+12-13 10:32:32.848   226   226 I SystemServerTiming: StartIncidentCompanionService
+12-13 10:32:32.848   226   226 I SystemServiceManager: Starting com.android.server.incident.IncidentCompanionService
+12-13 10:32:32.849   226   226 D SystemServerTiming: StartIncidentCompanionService took to complete: 1ms
+12-13 10:32:32.849   226   226 I SystemServerTiming: StartMmsService
+12-13 10:32:32.849   226   226 I SystemServiceManager: Starting com.android.server.MmsServiceBroker
+12-13 10:32:32.849   226   226 D SystemServerTiming: StartMmsService took to complete: 0ms
+12-13 10:32:32.849   226   226 I SystemServerTiming: StartAutoFillService
+12-13 10:32:32.854   226   226 I SystemServiceManager: Starting com.android.server.autofill.AutofillManagerService
+12-13 10:32:32.856   226   226 D AutofillManagerService: setLogLevelFromSettings(): level=2, debug=true, verbose=false
+12-13 10:32:32.857   226   226 D AutofillManagerService: setMaxPartitionsFromSettings(): 10
+12-13 10:32:32.857   226   226 D AutofillManagerService: setMaxVisibleDatasetsFromSettings(): 0
+12-13 10:32:32.859   226   226 D AutofillManagerServiceImpl: Reset component for user 0:
+12-13 10:32:32.859   226   247 D AutofillUI: destroySaveUiUiThread(): already destroyed
+12-13 10:32:32.860   226   226 D SystemServerTiming: StartAutoFillService took to complete: 11ms
+12-13 10:32:32.860   226   226 I SystemServerTiming: StartClipboardService
+12-13 10:32:32.860   226   226 I SystemServiceManager: Starting com.android.server.clipboard.ClipboardService
+12-13 10:32:32.861   226   226 D SystemServerTiming: StartClipboardService took to complete: 1ms
+12-13 10:32:32.861   226   226 I SystemServerTiming: AppServiceManager
+12-13 10:32:32.861   226   226 I SystemServiceManager: Starting com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:32.862   226   226 D SystemServerTiming: AppServiceManager took to complete: 1ms
+12-13 10:32:32.862   226   226 I SystemServerTiming: MakeVibratorServiceReady
+12-13 10:32:32.863   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.863   226   226 D SystemServerTiming: MakeVibratorServiceReady took to complete: 2ms
+12-13 10:32:32.864   226   226 I SystemServerTiming: MakeLockSettingsServiceReady
+12-13 10:32:32.869    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.weaver@1.0::IWeaver/default in either framework or device manifest.
+12-13 10:32:32.870   226   226 I SyntheticPasswordManager: Device does not support weaver
+12-13 10:32:32.870    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.authsecret@1.0::IAuthSecret/default in either framework or device manifest.
+12-13 10:32:32.870   226   226 I LockSettingsService: Device doesn't implement AuthSecret HAL
+12-13 10:32:32.872   226   226 D SystemServerTiming: MakeLockSettingsServiceReady took to complete: 8ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: StartBootPhaseLockSettingsReady
+12-13 10:32:32.872   226   226 I SystemServiceManager: Starting phase 480
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.security.FileIntegrityService
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.pm.Installer
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.872   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:32.872   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.power.PowerManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.power.ThermalManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.lights.LightsService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.display.DisplayManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.om.OverlayManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.SensorPrivacyService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.SystemConfigService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.BatteryService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.usage.UsageStatsService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.usage.UsageStatsService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.CachedDeviceStateService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.LooperStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.rollback.RollbackManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.rollback.RollbackManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.os.BugreportManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.gpu.GpuService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.security.KeyChainSystemService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.telecom.TelecomLoaderService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.content.ContentService$Lifecycle took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.DropBoxManagerService
+12-13 10:32:32.873   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:32.873   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.AlarmManagerService
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.AlarmManagerService took to complete: 1ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.connectivity.IpConnectivityMetrics took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.PinnerService
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.StorageManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.UiModeManagerService
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.UiModeManagerService took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.testharness.TestHarnessModeService took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.DeviceIdleController
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.DeviceIdleController took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 1ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.874   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:32.874   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.wifi.WifiService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.wifi.WifiService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.wifi.scanner.WifiScanningService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.ethernet.EthernetService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.ethernet.EthernetService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.notification.NotificationManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.notification.NotificationManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.location.LocationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.DockObserver
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.adb.AdbService$Lifecycle took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.twilight.TwilightService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.display.color.ColorDisplayService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.job.JobSchedulerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.job.JobSchedulerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:32.875   226   226 D SoundTriggerService: onBootPhase: 480 : false
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.soundtrigger.SoundTriggerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.trust.TrustManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.trust.TrustManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.appwidget.AppWidgetService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.role.RoleManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.role.RoleManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.GestureLauncherService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.GestureLauncherService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.SensorNotificationService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.SensorNotificationService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.emergency.EmergencyAffordanceService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.dreams.DreamManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.dreams.DreamManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.print.PrintManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.blob.BlobStoreManagerService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.media.MediaSessionService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.biometrics.BiometricService
+12-13 10:32:32.875   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:32.875   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.biometrics.AuthService
+12-13 10:32:32.876   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:32.876   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.pm.ShortcutService$Lifecycle took to complete: 1ms
+12-13 10:32:32.877   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.pm.LauncherAppsService
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:32.877   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:32.877   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.people.PeopleService
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.people.PeopleService took to complete: 0ms
+12-13 10:32:32.877   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:32.877   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.877   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.camera.CameraServiceProxy
+12-13 10:32:32.877   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.camera.CameraServiceProxy took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.stats.pull.StatsPullAtomService took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.incident.IncidentCompanionService
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.MmsServiceBroker
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.autofill.AutofillManagerService
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.autofill.AutofillManagerService took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.clipboard.ClipboardService
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_480_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 0ms
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_480 took to complete: 6ms
+12-13 10:32:32.878   226   226 D SystemServerTiming: StartBootPhaseLockSettingsReady took to complete: 6ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: StartBootPhaseSystemServicesReady
+12-13 10:32:32.878   226   226 I SystemServiceManager: Starting phase 500
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.security.FileIntegrityService
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.pm.Installer
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:32.878   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.878   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 2ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.power.PowerManagerService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.power.ThermalManagerService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.lights.LightsService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.display.DisplayManagerService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.om.OverlayManagerService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.SensorPrivacyService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.SystemConfigService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.BatteryService
+12-13 10:32:32.880   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:32.880   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.usage.UsageStatsService
+12-13 10:32:32.882   226   226 D AppStandbyController: Setting app idle enabled state
+12-13 10:32:32.883   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.883   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.usage.UsageStatsService took to complete: 3ms
+12-13 10:32:32.883   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:32.883   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:32.883   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.CachedDeviceStateService
+12-13 10:32:32.883   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:32.883   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:32.886   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 3ms
+12-13 10:32:32.886   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.LooperStatsService$Lifecycle took to complete: 1ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.rollback.RollbackManagerService
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.rollback.RollbackManagerService took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.os.BugreportManagerService
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.gpu.GpuService
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.security.KeyChainSystemService
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.telecom.TelecomLoaderService took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.content.ContentService$Lifecycle took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.DropBoxManagerService
+12-13 10:32:32.887   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:32.887   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.AlarmManagerService
+12-13 10:32:32.890   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.AlarmManagerService took to complete: 4ms
+12-13 10:32:32.891   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:32.893   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.connectivity.IpConnectivityMetrics took to complete: 2ms
+12-13 10:32:32.893   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:32.893   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 0ms
+12-13 10:32:32.893   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.PinnerService
+12-13 10:32:32.894   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:32.894   226   226 I SystemServerTiming: OnBootPhase_500_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:32.894   226   226 D SystemServerTiming: OnBootPhase_500_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:32.894   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:32.895   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:32.895   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:32.895   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.895   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:32.895   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.895   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:32.895   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.StorageManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.895   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:32.895   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:32.895   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.UiModeManagerService
+12-13 10:32:32.898   226   226 I configuration_changed: 512
+12-13 10:32:32.898   226   226 I ActivityTaskManager: Config changes=200 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.6}
+12-13 10:32:32.899   226   226 I WindowManager: Override config changes=200 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.6} for displayId=0
+12-13 10:32:32.900   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.UiModeManagerService took to complete: 4ms
+12-13 10:32:32.900   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:32.900   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 0ms
+12-13 10:32:32.900   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:32.900   226   226 D TestHarnessModeService: Setting up test harness mode
+12-13 10:32:32.900   226   226 D TestHarnessModeService: Getting PersistentDataBlockManagerInternal from LocalServices
+12-13 10:32:32.901   226   226 E TestHarnessModeService: Failed to start Test Harness Mode; no implementation of PersistentDataBlockManagerInternal was bound!
+12-13 10:32:32.901   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.testharness.TestHarnessModeService took to complete: 1ms
+12-13 10:32:32.901   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.DeviceIdleController
+12-13 10:32:32.906   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.909   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.DeviceIdleController took to complete: 8ms
+12-13 10:32:32.909   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:32.909   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.909   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:32.909   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.909   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:32.909   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.909   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:32.909   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:32.909   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.wifi.WifiService
+12-13 10:32:32.911   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.wifi.WifiService took to complete: 2ms
+12-13 10:32:32.911   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:32.911   226   226 I WifiScanningService: Starting wifiscanner
+12-13 10:32:32.912   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.wifi.scanner.WifiScanningService took to complete: 1ms
+12-13 10:32:32.912   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.ethernet.EthernetService
+12-13 10:32:32.912   226   226 I EthernetServiceImpl: Starting Ethernet service
+12-13 10:32:32.915   226   226 D EthernetTracker: Interface match regexp set to 'eth\d'
+12-13 10:32:32.918   226   226 D Ethernet: Registering NetworkFactory
+12-13 10:32:32.918   226   310 D ConnectivityService: Got NetworkProvider Messenger for Ethernet
+12-13 10:32:32.919   226   333 D Ethernet: got request NetworkRequest [ REQUEST id=1, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:32.919   226   226 E IpConfigStore: Error opening configuration file: java.io.FileNotFoundException: /data/misc/ethernet/ipconfig.txt: open failed: ENOENT (No such file or directory)
+12-13 10:32:32.919   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.ethernet.EthernetService took to complete: 7ms
+12-13 10:32:32.919   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.notification.NotificationManagerService
+12-13 10:32:32.926   226   305 D WifiConfigStore: Reading from all stores completed in 11 ms.
+12-13 10:32:32.927   226   305 E SupplicantStaIfaceHal: Can't call setDebugParams, ISupplicant is null
+12-13 10:32:32.927   226   305 E HostapdHal: Can't call setDebugParams, IHostapd is null
+12-13 10:32:32.928   226   305 I WifiService: WifiService starting up with Wi-Fi enabled
+12-13 10:32:32.928   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.notification.NotificationManagerService took to complete: 8ms
+12-13 10:32:32.928   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:32.928   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:32.928   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:32.930   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.930   226   305 D WifiController: isAirplaneModeOn = false, isWifiEnabled = true, isScanningAvailable = false, isLocationModeActive = true
+12-13 10:32:32.930   226   305 D WifiActiveModeWarden: Starting ClientModeManager
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.location.LocationManagerService$Lifecycle took to complete: 2ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.DockObserver
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.adb.AdbService$Lifecycle took to complete: 0ms
+12-13 10:32:32.931   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.twilight.TwilightService
+12-13 10:32:32.931   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:32.932   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.display.color.ColorDisplayService
+12-13 10:32:32.932   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:32.932   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.job.JobSchedulerService
+12-13 10:32:32.932   226   226 E HistoricalRegistry: Interaction before persistence initialized
+12-13 10:32:32.933   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.job.JobSchedulerService took to complete: 1ms
+12-13 10:32:32.934   226   305 D WifiController: EnabledState.enter()
+12-13 10:32:32.934   226   305 D WifiClientModeManager: entering IdleState
+12-13 10:32:32.934   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:32.934   226   226 D SoundTriggerService: onBootPhase: 500 : false
+12-13 10:32:32.934   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.soundtrigger.SoundTriggerService took to complete: 0ms
+12-13 10:32:32.934   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.trust.TrustManagerService
+12-13 10:32:32.935   226   305 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hidl.manager@1.2::IServiceManager/default
+12-13 10:32:32.935   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.trust.TrustManagerService took to complete: 1ms
+12-13 10:32:32.935   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.appwidget.AppWidgetService
+12-13 10:32:32.935   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:32.935   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.role.RoleManagerService
+12-13 10:32:32.935   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.role.RoleManagerService took to complete: 0ms
+12-13 10:32:32.935   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:32.935   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 0ms
+12-13 10:32:32.935   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.GestureLauncherService
+12-13 10:32:32.935   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.GestureLauncherService took to complete: 0ms
+12-13 10:32:32.935   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.SensorNotificationService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.SensorNotificationService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.emergency.EmergencyAffordanceService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.dreams.DreamManagerService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.dreams.DreamManagerService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.print.PrintManagerService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.blob.BlobStoreManagerService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.media.MediaSessionService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.biometrics.BiometricService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.biometrics.AuthService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.pm.ShortcutService$Lifecycle took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.pm.LauncherAppsService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:32.936   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:32.936   226   305 D WifiNl80211Manager: tearing down interfaces in wificond
+12-13 10:32:32.936   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.people.PeopleService
+12-13 10:32:32.937   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.people.PeopleService took to complete: 1ms
+12-13 10:32:32.937   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:32.937   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:32.937   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:32.937   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:32.937   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.camera.CameraServiceProxy
+12-13 10:32:32.937   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.camera.CameraServiceProxy took to complete: 0ms
+12-13 10:32:32.937   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:32.937   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 0ms
+12-13 10:32:32.937   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:32.938   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.stats.pull.StatsPullAtomService took to complete: 1ms
+12-13 10:32:32.939   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.incident.IncidentCompanionService
+12-13 10:32:32.939   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:32.939   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.MmsServiceBroker
+12-13 10:32:32.939   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:32.939   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.autofill.AutofillManagerService
+12-13 10:32:32.939   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.autofill.AutofillManagerService took to complete: 0ms
+12-13 10:32:32.939   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.clipboard.ClipboardService
+12-13 10:32:32.939   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:32.939   226   226 I SystemServerTiming: OnBootPhase_500_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:32.939   226   226 D SystemServerTiming: OnBootPhase_500_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 0ms
+12-13 10:32:32.939   226   226 D SystemServerTiming: OnBootPhase_500 took to complete: 61ms
+12-13 10:32:32.939   226   226 D SystemServerTiming: StartBootPhaseSystemServicesReady took to complete: 61ms
+12-13 10:32:32.939   226   226 I SystemServerTiming: MakeWindowManagerServiceReady
+12-13 10:32:32.940    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.configstore@1.0::ISurfaceFlingerConfigs/default in either framework or device manifest.
+12-13 10:32:32.942   226   226 D SystemServerTiming: MakeWindowManagerServiceReady took to complete: 3ms
+12-13 10:32:32.942   226   226 I SystemServerTiming: MakePowerManagerServiceReady
+12-13 10:32:32.941    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.configstore@1.0::ISurfaceFlingerConfigs/default in either framework or device manifest.
+12-13 10:32:32.943   226   246 I EthernetTracker: interfaceLinkStateChanged, iface: wlan0, up: false
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: Failed to initialize KernelCpuThreadReader
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: java.nio.file.NoSuchFileException: /proc/self/time_in_state
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at java.nio.file.Files.newByteChannel(Files.java:361)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at java.nio.file.Files.newByteChannel(Files.java:407)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at java.nio.file.Files.readAllBytes(Files.java:3152)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.internal.os.ProcTimeInStateReader.initializeTimeInStateFormat(ProcTimeInStateReader.java:163)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.internal.os.ProcTimeInStateReader.<init>(ProcTimeInStateReader.java:110)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.internal.os.KernelCpuThreadReader.<init>(KernelCpuThreadReader.java:138)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.internal.os.KernelCpuThreadReader.create(KernelCpuThreadReader.java:151)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.internal.os.KernelCpuThreadReaderSettingsObserver.<init>(KernelCpuThreadReaderSettingsObserver.java:95)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.internal.os.KernelCpuThreadReaderSettingsObserver.getSettingsModifiedReader(KernelCpuThreadReaderSettingsObserver.java:80)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.server.stats.pull.StatsPullAtomService.initializePullersState(StatsPullAtomService.java:729)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.server.stats.pull.StatsPullAtomService.lambda$onBootPhase$0$StatsPullAtomService(StatsPullAtomService.java:676)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at com.android.server.stats.pull.-$$Lambda$StatsPullAtomService$DD__7RQZDPvJeL9pnb_7J1voUNE.run(Unknown Source:2)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at android.os.Handler.handleCallback(Handler.java:938)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at android.os.Handler.dispatchMessage(Handler.java:99)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at android.os.Looper.loop(Looper.java:223)
+12-13 10:32:32.944   226   257 E KernelCpuThreadReader: 	at android.os.HandlerThread.run(HandlerThread.java:67)
+12-13 10:32:32.945   226   257 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hardware.health@2.0::IHealth/default
+12-13 10:32:32.946   226   257 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hidl.manager@1.0::IServiceManager/default
+12-13 10:32:32.947   226   257 I HealthServiceWrapper: health: HealthServiceWrapper listening to instance default
+12-13 10:32:32.947   226   339 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hardware.health@2.0::IHealth/default
+12-13 10:32:32.948   226   257 D StatsPullAtomService: Registering pullers with statsd
+12-13 10:32:32.948   226   305 I WifiNative: Vendor Hal not supported, ignoring start.
+12-13 10:32:32.949   226   305 I WifiNative: Vendor Hal not supported, ignoring createStaIface.
+12-13 10:32:32.949   226   305 D WifiNl80211Manager: Setting up interface for client mode
+12-13 10:32:32.950   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:32.950   226   226 E DisplayPowerController: failed to set up display white-balance: java.lang.IllegalStateException: cannot find light sensor
+12-13 10:32:32.950   226   257 I StatsPullAtomService: register thermal listener successfully
+12-13 10:32:32.950   133   133 I wificond: create scanner for interface with index: 14
+12-13 10:32:32.950   133   133 I wificond: subscribe scan result for interface with index: 14
+12-13 10:32:32.951   226   246 I EthernetTracker: interfaceLinkStateChanged, iface: wlan0, up: false
+12-13 10:32:32.952    85    85 I power-service.windows: Power isBoostSupported: 0
+12-13 10:32:32.955   226   305 I WifiNative: Interface state changed on Iface:{Name=wlan0,Id=0,Type=STA_SCAN}, isUp=true
+12-13 10:32:32.956   226   305 I WifiNative: Successfully setup Iface:{Name=wlan0,Id=0,Type=STA_SCAN}
+12-13 10:32:32.956   226   305 E SupplicantStaIfaceHal: checkHalVersionByInterfaceName: called but mServiceManager is null
+12-13 10:32:32.956   226   305 E SupplicantStaIfaceHal: checkHalVersionByInterfaceName: called but mServiceManager is null
+12-13 10:32:32.956   226   305 E SupplicantStaIfaceHal: Method getKeyMgmtCapabilities is not supported in existing HAL
+12-13 10:32:32.956   226   305 W HalDevMgr: isWifiStarted called but mWifi is null!?
+12-13 10:32:32.956   226   305 E SupplicantStaIfaceHal: checkHalVersionByInterfaceName: called but mServiceManager is null
+12-13 10:32:32.956   226   305 I SupplicantStaIfaceHal: Method getWpaDriverFeatureSet is not supported in existing HAL
+12-13 10:32:32.956   226   305 D WifiClientModeManager: entering StartedState
+12-13 10:32:32.956   226   305 D WifiClientModeManager: entering ScanOnlyModeState
+12-13 10:32:32.957   226   305 D WifiScanRequestProxy: Sending scan available broadcast: true
+12-13 10:32:32.957   226   305 I WifiScanRequestProxy: Scanning is enabled
+12-13 10:32:32.957   226   305 I WifiScanRequestProxy: Scanning for hidden networks is disabled
+12-13 10:32:32.957   226   264 W KernelCpuProcStringReader: File not found. It's normal if not implemented: /proc/uid_concurrent_policy_time
+12-13 10:32:32.958   226   264 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state: open failed: ENOENT (No such file or directory)
+12-13 10:32:32.958   226   309 I WifiScanningService: Received a request to enable scanning, UID = 1000
+12-13 10:32:32.958    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup2: Permission denied
+12-13 10:32:32.958    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup0: Permission denied
+12-13 10:32:32.959   226   226 D SystemServerTiming: MakePowerManagerServiceReady took to complete: 17ms
+12-13 10:32:32.959   226   226 I SystemServerTiming: StartPermissionPolicyService
+12-13 10:32:32.959   226   226 I SystemServiceManager: Starting com.android.server.policy.PermissionPolicyService
+12-13 10:32:32.960    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup3: Permission denied
+12-13 10:32:32.960    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup1: Permission denied
+12-13 10:32:32.961   226   309 I WifiScanningService: Created a new impl for wlan0
+12-13 10:32:32.962   226   309 I WifiScanningService: wifi driver loaded with scan capabilities: max buckets=16
+12-13 10:32:32.963   226   305 D WakeupController: start()
+12-13 10:32:32.965   226   226 D SystemServerTiming: StartPermissionPolicyService took to complete: 6ms
+12-13 10:32:32.965   226   226 I SystemServerTiming: MakePackageManagerServiceReady
+12-13 10:32:32.965   226   305 D WakeupController: Setting active to true
+12-13 10:32:32.965   226   267 W KeyguardServiceDelegate: onScreenTurningOn(): no keyguard service!
+12-13 10:32:32.966   226   267 V DisplayPowerController: Brightness [0.39763778] reason changing to: 'override', previous reason: '0'.
+12-13 10:32:32.967    85    85 I power-service.windows: Power isModeSupported: 9
+12-13 10:32:32.971   226   305 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hidl.manager@1.0::IServiceManager/default
+12-13 10:32:32.974   226   305 I SupplicantStaIfaceHal: Starting supplicant using HIDL
+12-13 10:32:32.975    23    23 I hwservicemanager: Since android.hardware.wifi.supplicant@1.0::ISupplicant/default is not registered, trying to start it as a lazy HAL.
+12-13 10:32:32.975   226   305 D SupplicantStaIfaceHal: Successfully triggered start of supplicant using HIDL
+12-13 10:32:32.977   226   226 I PackageManager: Permission ownership changed. Updating all permissions.
+12-13 10:32:32.979     0     0 I init    : starting service 'wpa_supplicant'...
+12-13 10:32:32.979     0     0 I init    : Created socket '/dev/socket/wpa_wlan0', mode 660, user 1010, group 1010
+12-13 10:32:32.981     0     0 I init    : Control message: Processed ctl.interface_start for 'android.hardware.wifi.supplicant@1.0::ISupplicant/default' from pid: 23 (/system/bin/hwservicemanager)
+12-13 10:32:33.004   226   226 I commit_sys_config_file: [package-session,16]
+12-13 10:32:33.008   226   226 V UserDataPreparer: Found /data/user_de/0 with serial number 0
+12-13 10:32:33.008   226   226 V UserDataPreparer: Found /data/user/0 with serial number 0
+12-13 10:32:33.008   226   226 V UserDataPreparer: Found /data/system_de/0 with serial number 0
+12-13 10:32:33.008   226   226 V UserDataPreparer: Found /data/system_ce/0 with serial number 0
+12-13 10:32:33.008   226   226 V UserDataPreparer: Found /data/misc_ce/0 with serial number 0
+12-13 10:32:33.010   226   226 D SystemServerTiming: MakePackageManagerServiceReady took to complete: 45ms
+12-13 10:32:33.010   226   226 I SystemServerTiming: MakeDisplayManagerServiceReady
+12-13 10:32:33.011   226   249 E DisplayModeDirector: Asked about unknown display, returning empty display mode specs!(id=0)
+12-13 10:32:33.011   226   249 E DisplayModeDirector: Asked about unknown display, returning empty display mode specs!(id=0)
+12-13 10:32:33.012   226   226 D SystemServerTiming: MakeDisplayManagerServiceReady took to complete: 3ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: StartDeviceSpecificServices
+12-13 10:32:33.013   226   226 I SystemServerTiming: StartDeviceSpecificServices com.microsoft.windows.service.SystemServerService
+12-13 10:32:33.013   226   226 I SystemServiceManager: Starting com.microsoft.windows.service.SystemServerService
+12-13 10:32:33.013   226   226 D SystemServerTiming: StartDeviceSpecificServices com.microsoft.windows.service.SystemServerService took to complete: 0ms
+12-13 10:32:33.013   226   226 D SystemServerTiming: StartDeviceSpecificServices took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: StartBootPhaseDeviceSpecificServicesReady
+12-13 10:32:33.013   226   226 I SystemServiceManager: Starting phase 520
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.security.FileIntegrityService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.Installer
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.power.PowerManagerService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.power.ThermalManagerService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.lights.LightsService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.display.DisplayManagerService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.om.OverlayManagerService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.SensorPrivacyService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.SystemConfigService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.BatteryService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.usage.UsageStatsService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.usage.UsageStatsService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.CachedDeviceStateService
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:33.013   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.LooperStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.013   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.rollback.RollbackManagerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.rollback.RollbackManagerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.os.BugreportManagerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.gpu.GpuService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.security.KeyChainSystemService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.telecom.TelecomLoaderService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.content.ContentService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.DropBoxManagerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.AlarmManagerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.AlarmManagerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.connectivity.IpConnectivityMetrics took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.PinnerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.StorageManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.UiModeManagerService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.UiModeManagerService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.testharness.TestHarnessModeService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.DeviceIdleController
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.DeviceIdleController took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.wifi.WifiService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.wifi.WifiService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.wifi.scanner.WifiScanningService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.ethernet.EthernetService
+12-13 10:32:33.014   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.ethernet.EthernetService took to complete: 0ms
+12-13 10:32:33.014   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.notification.NotificationManagerService
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.notification.NotificationManagerService took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.location.LocationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.DockObserver
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.adb.AdbService$Lifecycle took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.twilight.TwilightService
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.display.color.ColorDisplayService
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.job.JobSchedulerService
+12-13 10:32:33.015   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.job.JobSchedulerService took to complete: 0ms
+12-13 10:32:33.015   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:33.015   226   226 D SoundTriggerService: onBootPhase: 520 : false
+12-13 10:32:33.015   226   226 I SoundTriggerMiddlewareLogging: listModules[this=com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareImpl@4d85850, caller=1000/226]() -> [  ]
+12-13 10:32:33.016   226   226 W SoundTriggerHelper: listModules status=0, # of modules=0
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.soundtrigger.SoundTriggerService took to complete: 1ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.trust.TrustManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.trust.TrustManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.appwidget.AppWidgetService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.role.RoleManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.role.RoleManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.GestureLauncherService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.GestureLauncherService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.SensorNotificationService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.SensorNotificationService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.emergency.EmergencyAffordanceService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.dreams.DreamManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.dreams.DreamManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.print.PrintManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.blob.BlobStoreManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.media.MediaSessionService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.biometrics.BiometricService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.biometrics.AuthService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.ShortcutService$Lifecycle took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.LauncherAppsService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.people.PeopleService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.people.PeopleService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.camera.CameraServiceProxy
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.camera.CameraServiceProxy took to complete: 0ms
+12-13 10:32:33.016   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:33.016   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.stats.pull.StatsPullAtomService took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.incident.IncidentCompanionService
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.MmsServiceBroker
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.autofill.AutofillManagerService
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.autofill.AutofillManagerService took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.clipboard.ClipboardService
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 0ms
+12-13 10:32:33.017   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.policy.PermissionPolicyService
+12-13 10:32:33.017   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.policy.PermissionPolicyService took to complete: 0ms
+12-13 10:32:33.018   226   226 I SystemServerTiming: OnBootPhase_520_com.android.server.pm.StagingManager$Lifecycle
+12-13 10:32:33.018   226   226 D SystemServerTiming: OnBootPhase_520_com.android.server.pm.StagingManager$Lifecycle took to complete: 0ms
+12-13 10:32:33.018   226   226 I SystemServerTiming: OnBootPhase_520_com.microsoft.windows.service.SystemServerService
+12-13 10:32:33.018   226   226 V SystemServerService: PHASE_DEVICE_SPECIFIC_SERVICES_READY
+12-13 10:32:33.018   226   226 D SystemServerTiming: OnBootPhase_520_com.microsoft.windows.service.SystemServerService took to complete: 0ms
+12-13 10:32:33.018   226   226 D SystemServerTiming: OnBootPhase_520 took to complete: 5ms
+12-13 10:32:33.018   226   226 D SystemServerTiming: StartBootPhaseDeviceSpecificServicesReady took to complete: 5ms
+12-13 10:32:33.018   226   226 I SystemServerTiming: PhaseActivityManagerReady
+12-13 10:32:33.019   226   226 I SystemServerTiming: controllersReady
+12-13 10:32:33.023   226   253 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.topjohnwu.magisk changed
+12-13 10:32:33.023   226   277 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.joeykrim.rootcheck changed
+12-13 10:32:33.024   226   298 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package net.wooga.junes_journey_hidden_object_mystery_game changed
+12-13 10:32:33.024   226   285 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.ringapp.fire changed
+12-13 10:32:33.024   226   253 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.topjohnwu.magisk changed
+12-13 10:32:33.024   226   286 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.kindle changed
+12-13 10:32:33.024   226   286 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.amazon.kindle changed
+12-13 10:32:33.024   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.kingouser.com changed
+12-13 10:32:33.024   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.kingouser.com changed
+12-13 10:32:33.024   226   298 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package net.wooga.junes_journey_hidden_object_mystery_game changed
+12-13 10:32:33.024   226   285 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.ringapp.fire changed
+12-13 10:32:33.024   226   290 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.avod.thirdpartyclient changed
+12-13 10:32:33.024   226   226 D SystemServerTiming: controllersReady took to complete: 5ms
+12-13 10:32:33.024   226   253 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.topjohnwu.magisk changed
+12-13 10:32:33.024   226   253 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.topjohnwu.magisk changed took to complete: 1ms
+12-13 10:32:33.025   226   325 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.zhiliaoapp.musically changed
+12-13 10:32:33.025   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.kingouser.com changed
+12-13 10:32:33.025   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.kingouser.com changed took to complete: 1ms
+12-13 10:32:33.025   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.systemui changed
+12-13 10:32:33.025   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.systemui changed
+12-13 10:32:33.025   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.systemui changed
+12-13 10:32:33.025   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.systemui changed took to complete: 0ms
+12-13 10:32:33.025   226   253 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.media.module changed
+12-13 10:32:33.025   226   325 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.zhiliaoapp.musically changed
+12-13 10:32:33.025   226   298 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package net.wooga.junes_journey_hidden_object_mystery_game changed
+12-13 10:32:33.026   226   298 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package net.wooga.junes_journey_hidden_object_mystery_game changed took to complete: 2ms
+12-13 10:32:33.026   226   298 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.google.android.accessibility.talkback changed
+12-13 10:32:33.026   226   298 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.google.android.accessibility.talkback changed
+12-13 10:32:33.026   226   298 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.google.android.accessibility.talkback changed
+12-13 10:32:33.026   226   298 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.google.android.accessibility.talkback changed took to complete: 0ms
+12-13 10:32:33.026   226   298 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.venezia changed
+12-13 10:32:33.026   226   298 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.amazon.venezia changed
+12-13 10:32:33.026   226   226 I SystemServerTiming: killProcesses
+12-13 10:32:33.026   226   285 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.ringapp.fire changed
+12-13 10:32:33.026   226   290 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.amazon.avod.thirdpartyclient changed
+12-13 10:32:33.026   226   277 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.joeykrim.rootcheck changed
+12-13 10:32:33.027   226   286 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.amazon.kindle changed
+12-13 10:32:33.027   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.microsoft.windows.userapp changed
+12-13 10:32:33.027   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.microsoft.windows.userapp changed
+12-13 10:32:33.027   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.microsoft.windows.userapp changed
+12-13 10:32:33.027   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.microsoft.windows.userapp changed took to complete: 0ms
+12-13 10:32:33.027   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.device.messaging changed
+12-13 10:32:33.027   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.amazon.device.messaging changed
+12-13 10:32:33.027   226   290 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.amazon.avod.thirdpartyclient changed
+12-13 10:32:33.027   226   290 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.avod.thirdpartyclient changed took to complete: 3ms
+12-13 10:32:33.027   226   286 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.kindle changed took to complete: 3ms
+12-13 10:32:33.027   226   253 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.media.module changed
+12-13 10:32:33.027   226   325 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.zhiliaoapp.musically changed
+12-13 10:32:33.028   226   298 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.amazon.venezia changed
+12-13 10:32:33.028   226   298 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.venezia changed took to complete: 2ms
+12-13 10:32:33.028   226   298 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.media changed
+12-13 10:32:33.028   226   298 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.media changed
+12-13 10:32:33.028   226   277 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.joeykrim.rootcheck changed
+12-13 10:32:33.028   226   277 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.joeykrim.rootcheck changed took to complete: 4ms
+12-13 10:32:33.028   226   277 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.downloads changed
+12-13 10:32:33.028   226   277 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.downloads changed
+12-13 10:32:33.028   226   325 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.zhiliaoapp.musically changed took to complete: 3ms
+12-13 10:32:33.028   226   325 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.downloads.ui changed
+12-13 10:32:33.028   226   325 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.downloads.ui changed
+12-13 10:32:33.028   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.amazon.device.messaging changed
+12-13 10:32:33.028   226   298 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.media changed
+12-13 10:32:33.028   226   298 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.media changed took to complete: 1ms
+12-13 10:32:33.028   226   298 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.contacts changed
+12-13 10:32:33.029   226   298 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.contacts changed
+12-13 10:32:33.029   226   277 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.downloads changed
+12-13 10:32:33.029   226   277 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.downloads changed took to complete: 1ms
+12-13 10:32:33.029   226   277 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.microsoft.windows.systemapp changed
+12-13 10:32:33.029   226   277 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.microsoft.windows.systemapp changed
+12-13 10:32:33.029   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.amazon.device.messaging changed took to complete: 1ms
+12-13 10:32:33.029   226   290 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.traceur changed
+12-13 10:32:33.029   226   286 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.calendar changed
+12-13 10:32:33.029   226   286 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.calendar changed
+12-13 10:32:33.029   226   286 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.calendar changed
+12-13 10:32:33.029   226   226 D SystemServerTiming: killProcesses took to complete: 0ms
+12-13 10:32:33.029   226   285 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.ringapp.fire changed took to complete: 2ms
+12-13 10:32:33.029   226   325 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.downloads.ui changed
+12-13 10:32:33.029   226   325 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.downloads.ui changed took to complete: 2ms
+12-13 10:32:33.029   226   325 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.settings changed
+12-13 10:32:33.029   226   325 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.providers.settings changed
+12-13 10:32:33.030   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.dynsystem changed
+12-13 10:32:33.030   226   325 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.settings changed
+12-13 10:32:33.030   226   325 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.settings changed took to complete: 0ms
+12-13 10:32:33.030   226   290 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.traceur changed
+12-13 10:32:33.030   226   253 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.media.module changed
+12-13 10:32:33.030   226   298 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.providers.contacts changed
+12-13 10:32:33.030   226   286 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.calendar changed took to complete: 0ms
+12-13 10:32:33.030   226   226 I ActivityManager: System now ready
+12-13 10:32:33.030   226   285 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package android changed
+12-13 10:32:33.030   226   285 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package android changed
+12-13 10:32:33.030   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.dynsystem changed
+12-13 10:32:33.030   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.dynsystem changed
+12-13 10:32:33.030   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.dynsystem changed took to complete: 0ms
+12-13 10:32:33.030   226   253 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.media.module changed took to complete: 5ms
+12-13 10:32:33.030   226   253 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.settings changed
+12-13 10:32:33.030   226   253 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.settings changed
+12-13 10:32:33.030   226   277 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.microsoft.windows.systemapp changed
+12-13 10:32:33.031   226   277 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.microsoft.windows.systemapp changed took to complete: 2ms
+12-13 10:32:33.031   226   277 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.wallpaperbackup changed
+12-13 10:32:33.031   226   277 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.wallpaperbackup changed
+12-13 10:32:33.031   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.localtransport changed
+12-13 10:32:33.031   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.localtransport changed
+12-13 10:32:33.031   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.localtransport changed
+12-13 10:32:33.031   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.localtransport changed took to complete: 0ms
+12-13 10:32:33.031   226   279 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.location.fused changed
+12-13 10:32:33.031   226   279 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.location.fused changed
+12-13 10:32:33.031   226   290 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.traceur changed
+12-13 10:32:33.031   226   277 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.wallpaperbackup changed
+12-13 10:32:33.031   226   277 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.wallpaperbackup changed took to complete: 0ms
+12-13 10:32:33.031   226   286 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.keychain changed
+12-13 10:32:33.031   226   253 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.settings changed
+12-13 10:32:33.032   226   253 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.settings changed took to complete: 1ms
+12-13 10:32:33.032   226   325 I SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.inputdevices changed
+12-13 10:32:33.032   226   279 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.location.fused changed
+12-13 10:32:33.032   226   290 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.traceur changed took to complete: 2ms
+12-13 10:32:33.032   226   298 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.providers.contacts changed took to complete: 1ms
+12-13 10:32:33.032   226   286 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.keychain changed
+12-13 10:32:33.032   226   285 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package android changed
+12-13 10:32:33.032   226   285 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package android changed took to complete: 2ms
+12-13 10:32:33.032   226   279 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.location.fused changed took to complete: 1ms
+12-13 10:32:33.032   226   286 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.keychain changed
+12-13 10:32:33.032   226   286 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.keychain changed took to complete: 0ms
+12-13 10:32:33.032   226   325 D SystemServerInitThreadPool: Started executing Update app-ops uidState in case package com.android.inputdevices changed
+12-13 10:32:33.032   226   325 D SystemServerInitThreadPool: Finished executing Update app-ops uidState in case package com.android.inputdevices changed
+12-13 10:32:33.032   226   325 D SystemServerTimingAsync: InitThreadPoolExec:Update app-ops uidState in case package com.android.inputdevices changed took to complete: 1ms
+12-13 10:32:33.033   226   226 I boot_progress_ams_ready: 11751
+12-13 10:32:33.033   226   226 I SystemServerTiming: updateTopComponentForFactoryTest
+12-13 10:32:33.037   226   226 D SystemServerTiming: updateTopComponentForFactoryTest took to complete: 3ms
+12-13 10:32:33.037   226   226 I SystemServerTiming: registerActivityLaunchObserver
+12-13 10:32:33.038   226   226 D SystemServerTiming: registerActivityLaunchObserver took to complete: 0ms
+12-13 10:32:33.038   226   226 I SystemServerTiming: watchDeviceProvisioning
+12-13 10:32:33.068   226   226 D SystemServerTiming: watchDeviceProvisioning took to complete: 30ms
+12-13 10:32:33.068   226   226 I SystemServerTiming: retrieveSettings
+12-13 10:32:33.069   226   226 I configuration_changed: 256
+12-13 10:32:33.070   226   226 I ActivityTaskManager: Config changes=100 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.8}
+12-13 10:32:33.070   226   226 I WindowManager: Override config changes=100 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.8} for displayId=0
+12-13 10:32:33.071   226   226 D SystemServerTiming: retrieveSettings took to complete: 4ms
+12-13 10:32:33.071   226   226 I SystemServerTiming: Ugm.onSystemReady
+12-13 10:32:33.073   226   226 D SystemServerTiming: Ugm.onSystemReady took to complete: 1ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: updateForceBackgroundCheck
+12-13 10:32:33.073   226   226 D SystemServerTiming: updateForceBackgroundCheck took to complete: 0ms
+12-13 10:32:33.073   226   226 I SystemServer: Making services ready
+12-13 10:32:33.073   226   226 I SystemServerTiming: StartActivityManagerReadyPhase
+12-13 10:32:33.073   226   226 I SystemServiceManager: Starting phase 550
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.security.FileIntegrityService
+12-13 10:32:33.073   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.Installer
+12-13 10:32:33.073   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:33.073   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:33.073   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:33.073   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:33.073   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 1ms
+12-13 10:32:33.073   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:33.074   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:33.074   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.power.PowerManagerService
+12-13 10:32:33.074   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:33.074   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.power.ThermalManagerService
+12-13 10:32:33.075    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.thermal@2.0::IThermal/default in either framework or device manifest.
+12-13 10:32:33.076   226   226 E ThermalHalWrapper: Thermal HAL 2.0 service not connected.
+12-13 10:32:33.079    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.thermal@1.1::IThermal/default in either framework or device manifest.
+12-13 10:32:33.079   226   226 E ThermalHalWrapper: Thermal HAL 1.1 service not connected.
+12-13 10:32:33.079    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.thermal@1.0::IThermal/default in either framework or device manifest.
+12-13 10:32:33.079   226   226 E ThermalHalWrapper: Thermal HAL 1.0 service not connected.
+12-13 10:32:33.079   226   226 W ThermalManagerService: No Thermal HAL service on this device
+12-13 10:32:33.079   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.power.ThermalManagerService took to complete: 5ms
+12-13 10:32:33.079   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:33.079   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:33.079   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.lights.LightsService
+12-13 10:32:33.079   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:33.079   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.display.DisplayManagerService
+12-13 10:32:33.079   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.om.OverlayManagerService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.SensorPrivacyService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.SystemConfigService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.BatteryService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.usage.UsageStatsService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.usage.UsageStatsService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:33.080   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.CachedDeviceStateService
+12-13 10:32:33.080   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:33.081   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:33.081   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.LooperStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.rollback.RollbackManagerService
+12-13 10:32:33.081   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.rollback.RollbackManagerService took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.os.BugreportManagerService
+12-13 10:32:33.081   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.gpu.GpuService
+12-13 10:32:33.081   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.security.KeyChainSystemService
+12-13 10:32:33.081   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:33.081   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:33.085   226   226 W ActivityManager: Unable to start service Intent { act=com.android.ITelecomService cmp=com.android.server.telecom/.components.TelecomService } U=0: not found
+12-13 10:32:33.085   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.telecom.TelecomLoaderService took to complete: 5ms
+12-13 10:32:33.085   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:33.085   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.085   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:33.113     0     0 I capability: warning: `wpa_supplicant' uses 32-bit capabilities (legacy support in use)
+12-13 10:32:33.117   345   345 I wpa_supplicant: Processing hidl events on FD 3
+12-13 10:32:33.120   345   345 I HidlServiceManagement: Registered android.hardware.wifi.supplicant@1.3::ISupplicant/default
+12-13 10:32:33.122   345   345 I wpa_supplicant: Successfully initialized wpa_supplicant
+12-13 10:32:33.122   226   340 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hardware.wifi.supplicant@1.0::ISupplicant/default
+12-13 10:32:33.123   226   340 I SupplicantStaIfaceHal: Completed initialization of ISupplicant.
+12-13 10:32:33.176   226   305 E SupplicantStaIfaceHal: Can't call setupIface, ISupplicantStaIface is null
+12-13 10:32:33.177   226   305 I android_os_HwBinder: HwBinder: Starting thread pool for getting: android.hardware.wifi.supplicant@1.0::ISupplicant/default
+12-13 10:32:33.201   345   345 I wpa_supplicant: rfkill: Cannot open RFKILL control device
+12-13 10:32:33.202   226   246 I EthernetTracker: interfaceLinkStateChanged, iface: wlan0, up: false
+12-13 10:32:33.208   226   288 I commit_sys_config_file: [settings-0-0,13]
+12-13 10:32:33.216   226   226 W SystemServiceManager: Service com.android.server.content.ContentService$Lifecycle took 130 ms in onBootPhase
+12-13 10:32:33.216   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.content.ContentService$Lifecycle took to complete: 130ms
+12-13 10:32:33.216   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.DropBoxManagerService
+12-13 10:32:33.216   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:33.216   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.AlarmManagerService
+12-13 10:32:33.216   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.AlarmManagerService took to complete: 0ms
+12-13 10:32:33.216   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:33.216   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.connectivity.IpConnectivityMetrics took to complete: 0ms
+12-13 10:32:33.216   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:33.220   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 3ms
+12-13 10:32:33.220   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.PinnerService
+12-13 10:32:33.220   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:33.220   226   226 I SystemServerTiming: OnBootPhase_550_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:33.220   226   226 D SystemServerTiming: OnBootPhase_550_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:33.220   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:33.220   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:33.220   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:33.224   226   226 W InputMethodUtils: Found no fallback locale. imis=[]
+12-13 10:32:33.224   226   226 W InputMethodUtils: No software keyboard is found. imis=[] systemLocale=en_US fallbackLocale=null
+12-13 10:32:33.224   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 4ms
+12-13 10:32:33.224   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:33.224   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.224   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:33.224   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.StorageManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.225   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:33.225   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.225   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.UiModeManagerService
+12-13 10:32:33.225   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.UiModeManagerService took to complete: 0ms
+12-13 10:32:33.225   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:33.225   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.225   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:33.225   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.testharness.TestHarnessModeService took to complete: 0ms
+12-13 10:32:33.225   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.DeviceIdleController
+12-13 10:32:33.225   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.DeviceIdleController took to complete: 0ms
+12-13 10:32:33.225   226   297 D StorageManagerService: Isolated storage local flag 0 and remote flag 0 resolved to true
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.wifi.WifiService
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.wifi.WifiService took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.wifi.scanner.WifiScanningService took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.ethernet.EthernetService
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.ethernet.EthernetService took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.notification.NotificationManagerService
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.notification.NotificationManagerService took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.location.LocationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.226   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:33.226   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.227   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:33.227   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.227   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:33.227   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:33.227   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:33.227   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:33.227   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.DockObserver
+12-13 10:32:33.227   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:33.227   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.adb.AdbService$Lifecycle took to complete: 1ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.twilight.TwilightService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.display.color.ColorDisplayService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.job.JobSchedulerService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.job.JobSchedulerService took to complete: 0ms
+12-13 10:32:33.228   226   319 E AudioSystem-JNI: Command failed for android_media_AudioSystem_setParameters: -38
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:33.228   226   226 D SoundTriggerService: onBootPhase: 550 : false
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.soundtrigger.SoundTriggerService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.trust.TrustManagerService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.trust.TrustManagerService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.appwidget.AppWidgetService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.role.RoleManagerService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.role.RoleManagerService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.GestureLauncherService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.GestureLauncherService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.SensorNotificationService
+12-13 10:32:33.228   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.SensorNotificationService took to complete: 0ms
+12-13 10:32:33.228   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:33.229   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.emergency.EmergencyAffordanceService took to complete: 0ms
+12-13 10:32:33.229   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.dreams.DreamManagerService
+12-13 10:32:33.229   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.dreams.DreamManagerService took to complete: 0ms
+12-13 10:32:33.229   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.print.PrintManagerService
+12-13 10:32:33.229   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:33.229   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:33.229   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:33.229   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.blob.BlobStoreManagerService took to complete: 1ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.media.MediaSessionService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.biometrics.BiometricService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.biometrics.AuthService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.ShortcutService$Lifecycle took to complete: 0ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.LauncherAppsService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:33.230   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.people.PeopleService
+12-13 10:32:33.230   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.people.PeopleService took to complete: 0ms
+12-13 10:32:33.229   226   319 E AudioSystem-JNI: Command failed for android_media_AudioSystem_setParameters: -38
+12-13 10:32:33.231   226   319 E BluetoothAdapter: Bluetooth binder is null
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.camera.CameraServiceProxy
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.camera.CameraServiceProxy took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.stats.pull.StatsPullAtomService took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.incident.IncidentCompanionService
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.MmsServiceBroker
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.autofill.AutofillManagerService
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.autofill.AutofillManagerService took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.clipboard.ClipboardService
+12-13 10:32:33.231   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:33.231   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:33.231   226   226 I AppBindingService: Updating constants with: null
+12-13 10:32:33.232   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 1ms
+12-13 10:32:33.232   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.policy.PermissionPolicyService
+12-13 10:32:33.231   226   319 E BluetoothAdapter: Bluetooth binder is null
+12-13 10:32:33.232   226   320 E AudioSystem-JNI: Command failed for android_media_AudioSystem_setParameters: -38
+12-13 10:32:33.233   226   320 E AudioSystem-JNI: Command failed for android_media_AudioSystem_setParameters: -38
+12-13 10:32:33.253    86    86 I AudioFlinger: systemReady
+12-13 10:32:33.253    86   179 E AudioFlinger: getMicMute: error -38 getting state from HAL
+12-13 10:32:33.256   226   226 I PackageManager: Permission ownership changed. Updating all permissions.
+12-13 10:32:33.263   226   317 E SoundPool: error loading /system/media/audio/ui/Effect_Tick.ogg
+12-13 10:32:33.264   226   317 W AS.SfxHelper: SoundPool could not load file: /system/media/audio/ui/Effect_Tick.ogg
+12-13 10:32:33.264   226   317 E SoundPool: error loading /system/media/audio/ui/KeypressStandard.ogg
+12-13 10:32:33.265   226   317 W AS.SfxHelper: SoundPool could not load file: /system/media/audio/ui/KeypressStandard.ogg
+12-13 10:32:33.265   226   317 E SoundPool: error loading /system/media/audio/ui/KeypressSpacebar.ogg
+12-13 10:32:33.265   226   317 W AS.SfxHelper: SoundPool could not load file: /system/media/audio/ui/KeypressSpacebar.ogg
+12-13 10:32:33.265   226   317 E SoundPool: error loading /system/media/audio/ui/KeypressDelete.ogg
+12-13 10:32:33.265   226   317 W AS.SfxHelper: SoundPool could not load file: /system/media/audio/ui/KeypressDelete.ogg
+12-13 10:32:33.265   226   317 E SoundPool: error loading /system/media/audio/ui/KeypressReturn.ogg
+12-13 10:32:33.265   226   317 W AS.SfxHelper: SoundPool could not load file: /system/media/audio/ui/KeypressReturn.ogg
+12-13 10:32:33.265   226   317 E SoundPool: error loading /system/media/audio/ui/KeypressInvalid.ogg
+12-13 10:32:33.265   226   317 W AS.SfxHelper: SoundPool could not load file: /system/media/audio/ui/KeypressInvalid.ogg
+12-13 10:32:33.267   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.policy.PermissionPolicyService took to complete: 35ms
+12-13 10:32:33.267   226   226 I SystemServerTiming: OnBootPhase_550_com.android.server.pm.StagingManager$Lifecycle
+12-13 10:32:33.268   226   226 D SystemServerTiming: OnBootPhase_550_com.android.server.pm.StagingManager$Lifecycle took to complete: 0ms
+12-13 10:32:33.268   226   226 I SystemServerTiming: OnBootPhase_550_com.microsoft.windows.service.SystemServerService
+12-13 10:32:33.268   226   226 V SystemServerService: PHASE_ACTIVITY_MANAGER_READY
+12-13 10:32:33.278   226   226 D SystemServerTiming: OnBootPhase_550_com.microsoft.windows.service.SystemServerService took to complete: 11ms
+12-13 10:32:33.279   226   226 D SystemServerTiming: OnBootPhase_550 took to complete: 206ms
+12-13 10:32:33.279   226   226 D SystemServerTiming: StartActivityManagerReadyPhase took to complete: 206ms
+12-13 10:32:33.279   226   226 I SystemServerTiming: StartObservingNativeCrashes
+12-13 10:32:33.279   226   226 D SystemServerTiming: StartObservingNativeCrashes took to complete: 0ms
+12-13 10:32:33.279   226   226 I SystemServerTiming: StartSystemUI
+12-13 10:32:33.279   226   277 I SystemServerTimingAsync: InitThreadPoolExec:WebViewFactoryPreparation
+12-13 10:32:33.279   226   277 D SystemServerInitThreadPool: Started executing WebViewFactoryPreparation
+12-13 10:32:33.279   226   277 I SystemServer: WebViewFactoryPreparation
+12-13 10:32:33.279   226   277 I SystemServerTimingAsync: WebViewFactoryPreparation
+12-13 10:32:33.282   226   226 I am_uid_running: 10031
+12-13 10:32:33.284   226   226 D CompatibilityChangeReporter: Compat change id reported: 135634846; UID 10031; state: DISABLED
+12-13 10:32:33.284   226   259 D CompatibilityChangeReporter: Compat change id reported: 143937733; UID 10031; state: ENABLED
+12-13 10:32:33.285   226   277 I am_uid_running: 1037
+12-13 10:32:33.285   226   277 D SystemServerTimingAsync: WebViewFactoryPreparation took to complete: 6ms
+12-13 10:32:33.285   226   277 D SystemServerInitThreadPool: Finished executing WebViewFactoryPreparation
+12-13 10:32:33.285   226   277 D SystemServerTimingAsync: InitThreadPoolExec:WebViewFactoryPreparation took to complete: 7ms
+12-13 10:32:33.286   226   226 D SystemServerTiming: StartSystemUI took to complete: 7ms
+12-13 10:32:33.286   226   226 I SystemServerTiming: MakeNetworkManagementServiceReady
+12-13 10:32:33.287   226   226 W NetworkManagement: setDataSaverMode(): already false
+12-13 10:32:33.288   226   226 D SystemServerTiming: MakeNetworkManagementServiceReady took to complete: 2ms
+12-13 10:32:33.288   226   226 I SystemServerTiming: MakeIpSecServiceReady
+12-13 10:32:33.289   226   226 D IpSecService: IpSecService is ready
+12-13 10:32:33.289   226   226 D SystemServerTiming: MakeIpSecServiceReady took to complete: 1ms
+12-13 10:32:33.289   226   226 I SystemServerTiming: MakeNetworkStatsServiceReady
+12-13 10:32:33.291    67    67 D Zygote  : Forked child process 350
+12-13 10:32:33.292   226   259 I am_proc_start: [0,350,10031,com.android.systemui,service,{com.android.systemui/com.android.systemui.SystemUIService}]
+12-13 10:32:33.293   226   259 I ActivityManager: Start proc 350:com.android.systemui/u0a31 for service {com.android.systemui/com.android.systemui.SystemUIService}
+12-13 10:32:33.302   350   350 W ndroid.systemu: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.307   226   302 I commit_sys_config_file: [net-policy,14]
+12-13 10:32:33.307   226   302 W NetworkPolicy: setRestrictBackgroundUL: already false
+12-13 10:32:33.308   103   129 I adbd    : jdwp connection from 350
+12-13 10:32:33.308   226   226 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.314   226   341 I am_proc_bound: [0,350,com.android.systemui]
+12-13 10:32:33.324   226   341 I am_uid_active: 10031
+12-13 10:32:33.344   226   305 D SupplicantStaIfaceHal: Newer HAL is found, skip V1_2 remaining init flow.
+12-13 10:32:33.344   226   305 D SupplicantStaIfaceHal: Newer HAL is found, skip V1_1 remaining init flow.
+12-13 10:32:33.344   226   305 D SupplicantStaIfaceHal: Newer HAL is found, skip V1_0 remaining init flow.
+12-13 10:32:33.345   226   305 W HalDevMgr: isWifiStarted called but mWifi is null!?
+12-13 10:32:33.346   226   305 I WifiNative: Successfully switched to connectivity mode on iface=Iface:{Name=wlan0,Id=0,Type=STA_CONNECTIVITY}
+12-13 10:32:33.346   226   305 D WakeupController: stop()
+12-13 10:32:33.346   226   305 D WifiClientModeManager: entering ConnectModeState
+12-13 10:32:33.347   226   305 D WifiScanRequestProxy: Sending scan available broadcast: true
+12-13 10:32:33.347   226   309 I WifiScanningService: Received a request to enable scanning, UID = 1000
+12-13 10:32:33.347   226   309 I WifiScanningService: scanner impls already exists
+12-13 10:32:33.347   226   309 E WifiScanningService: wifi driver loaded received while already loaded
+12-13 10:32:33.347   226   305 I WifiScanRequestProxy: Scanning is enabled
+12-13 10:32:33.347   226   305 I WifiScanRequestProxy: Scanning for hidden networks is enabled
+12-13 10:32:33.348   226   305 D WifiClientModeImpl: entering ConnectModeState: ifaceName = wlan0
+12-13 10:32:33.348   226   305 D WifiClientModeImpl: setupClientMode() ifacename = wlan0
+12-13 10:32:33.354    68    68 D Zygote  : Forked child process 374
+12-13 10:32:33.356   226   259 W ActivityManager: Slow operation: 71ms so far, now at startProcess: returned from zygote!
+12-13 10:32:33.356   226   259 W ActivityManager: Slow operation: 72ms so far, now at startProcess: done updating battery stats
+12-13 10:32:33.356   226   259 I am_proc_start: [0,374,1037,WebViewLoader-x86,NULL,]
+12-13 10:32:33.356   226   259 W ActivityManager: Slow operation: 72ms so far, now at startProcess: building log message
+12-13 10:32:33.357   226   259 I ActivityManager: Start proc 374:WebViewLoader-x86/1037 [android.webkit.WebViewLibraryLoader$RelroFileCreator] for null
+12-13 10:32:33.357   226   259 W ActivityManager: Slow operation: 72ms so far, now at startProcess: starting to update pids map
+12-13 10:32:33.357   226   259 W ActivityManager: Slow operation: 72ms so far, now at startProcess: done updating pids map
+12-13 10:32:33.357   226   259 W ActivityManager: Slow operation: 72ms so far, now at startProcess: asking zygote to start proc
+12-13 10:32:33.361    67    67 D Zygote  : Forked child process 381
+12-13 10:32:33.362   374   374 W WebViewLoader-: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.363   226   259 W ActivityManager: Slow operation: 78ms so far, now at startProcess: returned from zygote!
+12-13 10:32:33.363   226   226 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:33.363   226   259 W ActivityManager: Slow operation: 78ms so far, now at startProcess: done updating battery stats
+12-13 10:32:33.363   226   259 I am_proc_start: [0,381,1037,WebViewLoader-x86_64,NULL,]
+12-13 10:32:33.363   226   259 W ActivityManager: Slow operation: 78ms so far, now at startProcess: building log message
+12-13 10:32:33.363   226   259 I ActivityManager: Start proc 381:WebViewLoader-x86_64/1037 [android.webkit.WebViewLibraryLoader$RelroFileCreator] for null
+12-13 10:32:33.363   226   259 W ActivityManager: Slow operation: 78ms so far, now at startProcess: starting to update pids map
+12-13 10:32:33.363   226   259 W ActivityManager: Slow operation: 78ms so far, now at startProcess: done updating pids map
+12-13 10:32:33.363   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.364   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.365   226   226 D SystemServerTiming: MakeNetworkStatsServiceReady took to complete: 76ms
+12-13 10:32:33.365   226   226 I SystemServerTiming: MakeConnectivityServiceReady
+12-13 10:32:33.366   350   350 E ndroid.systemu: Dex checksum does not match for dex: /system_ext/priv-app/SystemUI/SystemUI.apk.Expected: 1752772458, actual: 3680165327
+12-13 10:32:33.366   226   226 D PermissionMonitor: Monitoring
+12-13 10:32:33.366   381   381 W WebViewLoader-: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.368   226   302 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:33.369   350   350 I ndroid.systemu: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.373   103   129 I adbd    : jdwp connection from 381
+12-13 10:32:33.373   103   129 I adbd    : jdwp connection from 374
+12-13 10:32:33.375   226   226 D PermissionMonitor: Users: 1, Apps: 10
+12-13 10:32:33.378   226   240 I am_proc_bound: [0,381,WebViewLoader-x86_64]
+12-13 10:32:33.379   226   240 I am_uid_active: 1037
+12-13 10:32:33.382   381   381 V WebViewLibraryLoader: RelroFileCreator (64bit = true), package: com.android.webview library: libwebviewchromium.so
+12-13 10:32:33.390   226   226 D SystemServerTiming: MakeConnectivityServiceReady took to complete: 25ms
+12-13 10:32:33.390   226   226 I SystemServerTiming: MakeNetworkPolicyServiceReady
+12-13 10:32:33.390   226   226 D SystemServerTiming: MakeNetworkPolicyServiceReady took to complete: 0ms
+12-13 10:32:33.390   226   226 I SystemServerTiming: PhaseThirdPartyAppsCanStart
+12-13 10:32:33.390   226   226 I SystemServiceManager: Starting phase 600
+12-13 10:32:33.390   226   226 I SystemServerTiming: OnBootPhase_600
+12-13 10:32:33.390   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.security.FileIntegrityService
+12-13 10:32:33.390   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:33.390   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.391   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.Installer
+12-13 10:32:33.391   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:33.391   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:33.391   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:33.391   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:33.391   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.391   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:33.391   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.391   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:33.391   226   333 D Ethernet: got request NetworkRequest [ BACKGROUND_REQUEST id=2, [ Transports: CELLULAR Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId 0
+12-13 10:32:33.391   226   226 I ExplicitHealthCheckController: Explicit health checks enabled.
+12-13 10:32:33.391   226   226 I PackageWatchdog: Syncing state, reason: health check state enabled
+12-13 10:32:33.392   226   226 I PackageWatchdog: Not pruning observers, elapsed time: 0ms
+12-13 10:32:33.392   226   226 I PackageWatchdog: Cancelling state sync, nothing to sync
+12-13 10:32:33.392   226   257 I PackageWatchdog: Saving observer state to file
+12-13 10:32:33.392   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.392   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 1ms
+12-13 10:32:33.392   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:33.392   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:33.392   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.power.PowerManagerService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.power.PowerManagerService took to complete: 1ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.power.ThermalManagerService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.lights.LightsService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.display.DisplayManagerService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.om.OverlayManagerService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.SensorPrivacyService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.SystemConfigService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.BatteryService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.usage.UsageStatsService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.usage.UsageStatsService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.CachedDeviceStateService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.LooperStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.rollback.RollbackManagerService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.rollback.RollbackManagerService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.os.BugreportManagerService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.gpu.GpuService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.security.KeyChainSystemService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.telecom.TelecomLoaderService took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.393   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:33.393   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.content.ContentService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.DropBoxManagerService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.AlarmManagerService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.AlarmManagerService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.connectivity.IpConnectivityMetrics took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.PinnerService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.StorageManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.UiModeManagerService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.UiModeManagerService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.testharness.TestHarnessModeService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.DeviceIdleController
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.DeviceIdleController took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.wifi.WifiService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.wifi.WifiService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.wifi.scanner.WifiScanningService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.ethernet.EthernetService
+12-13 10:32:33.394   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.ethernet.EthernetService took to complete: 0ms
+12-13 10:32:33.394   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.notification.NotificationManagerService
+12-13 10:32:33.400   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.notification.NotificationManagerService took to complete: 6ms
+12-13 10:32:33.400   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:33.400   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:33.400   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:33.400   226   226 W LocationManagerService: no network location provider found
+12-13 10:32:33.401   226   226 E LocationManagerService: no geocoder provider found
+12-13 10:32:33.401   226   226 E ActivityRecognitionHardware: activity_recognition HAL is deprecated. is_supported is effectively a no-op
+12-13 10:32:33.401   226   226 E LocationManagerService: unable to bind ActivityRecognitionProxy
+12-13 10:32:33.405   226   226 D GnssLocationProvider: Trying IGnss_V2_1::getService()
+12-13 10:32:33.406   226   240 I am_proc_bound: [0,374,WebViewLoader-x86]
+12-13 10:32:33.409   381   381 I WebViewLoader-: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.409   374   374 V WebViewLibraryLoader: RelroFileCreator (64bit = false), package: com.android.webview library: libwebviewchromium.so
+12-13 10:32:33.411   381   381 D nativeloader: classloader namespace configured for unbundled product apk. library_path=/product/app/webview/lib/x86_64:/product/app/webview/webview.apk!/lib/x86_64:/product/lib64:/system/product/lib64
+12-13 10:32:33.413   226   226 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:33.419   226   246 D GnssLocationProvider: Link to death notification successful
+12-13 10:32:33.421   226   226 E LocationManagerService: unable to bind to GeofenceProxy
+12-13 10:32:33.421   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.location.LocationManagerService$Lifecycle took to complete: 21ms
+12-13 10:32:33.421   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:33.421   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.421   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:33.421   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.421   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.DockObserver
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.adb.AdbService$Lifecycle took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.twilight.TwilightService
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.display.color.ColorDisplayService
+12-13 10:32:33.422   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:33.422   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.job.JobSchedulerService
+12-13 10:32:33.424   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.job.JobSchedulerService took to complete: 2ms
+12-13 10:32:33.424   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:33.424   226   226 D SoundTriggerService: onBootPhase: 600 : false
+12-13 10:32:33.424   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.soundtrigger.SoundTriggerService took to complete: 0ms
+12-13 10:32:33.424   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.trust.TrustManagerService
+12-13 10:32:33.427   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.trust.TrustManagerService took to complete: 3ms
+12-13 10:32:33.427   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.appwidget.AppWidgetService
+12-13 10:32:33.427   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:33.427   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.role.RoleManagerService
+12-13 10:32:33.427   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.role.RoleManagerService took to complete: 0ms
+12-13 10:32:33.427   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:33.428   374   374 I WebViewLoader-: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.429   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 2ms
+12-13 10:32:33.429   226   246 D GnssLocationProvider: gnssSetCapabilitesCb: 9u
+12-13 10:32:33.429   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.GestureLauncherService
+12-13 10:32:33.430   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.GestureLauncherService took to complete: 1ms
+12-13 10:32:33.430   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.SensorNotificationService
+12-13 10:32:33.430   226   246 D GnssLocationProvider: gnssSetSystemInfoCb: yearOfHw=2020
+12-13 10:32:33.430   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.SensorNotificationService took to complete: 0ms
+12-13 10:32:33.430   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:33.431   226   246 D GnssLocationProvider: gnssNameCb: name=Virtual GNSS
+12-13 10:32:33.431   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.emergency.EmergencyAffordanceService took to complete: 2ms
+12-13 10:32:33.431   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.dreams.DreamManagerService
+12-13 10:32:33.432   226   246 I GnssLocationProvider: Unable to initialize IGnssXtra interface.
+12-13 10:32:33.432   226   246 I GnssLocationProvider: Unable to initialize IAGnss interface.
+12-13 10:32:33.432   226   246 I GnssLocationProvider: Unable to initialize IGnssGeofencing interface.
+12-13 10:32:33.432   226   246 I GnssLocationProvider: Unable to initialize IGnssNi interface.
+12-13 10:32:33.432   226   246 I GnssLocationProvider: Unable to initialize IAGnssRil interface.
+12-13 10:32:33.432   226   246 I GnssLocationProvider: Unable to find IMeasurementCorrections.
+12-13 10:32:33.432   374   374 D nativeloader: classloader namespace configured for unbundled product apk. library_path=/product/app/webview/lib/x86:/product/app/webview/webview.apk!/lib/x86:/product/lib:/system/product/lib
+12-13 10:32:33.433   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.dreams.DreamManagerService took to complete: 1ms
+12-13 10:32:33.433   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.print.PrintManagerService
+12-13 10:32:33.433   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:33.433   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:33.433   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:33.433   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:33.435   226   246 E GnssLocationProvider: android_location_GnssLocationProvider_set_agps_server: IAGnss interface not available.
+12-13 10:32:33.435   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.439   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.blob.BlobStoreManagerService took to complete: 5ms
+12-13 10:32:33.439   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.media.MediaSessionService
+12-13 10:32:33.439   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:33.439   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.biometrics.BiometricService
+12-13 10:32:33.439   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:33.439   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.biometrics.AuthService
+12-13 10:32:33.439   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.ShortcutService$Lifecycle took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.LauncherAppsService
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.people.PeopleService
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.people.PeopleService took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.camera.CameraServiceProxy
+12-13 10:32:33.440   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.camera.CameraServiceProxy took to complete: 0ms
+12-13 10:32:33.440   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:33.441   226   226 W AlarmManager: Unrecognized alarm listener com.android.server.stats.StatsCompanionService$AnomalyAlarmListener@536f470
+12-13 10:32:33.441   226   226 W AlarmManager: Unrecognized alarm listener com.android.server.stats.StatsCompanionService$PullingAlarmListener@58063e9
+12-13 10:32:33.441   226   246 W LocationManagerService: passive provider saw user 0 unexpectedly
+12-13 10:32:33.441   226   226 W AlarmManager: Unrecognized alarm listener com.android.server.stats.StatsCompanionService$PeriodicAlarmListener@551b86e
+12-13 10:32:33.441   226   246 W LocationManagerService: passive provider saw user 0 unexpectedly
+12-13 10:32:33.442   226   246 D GnssLocationProvider: gnssSetCapabilitesCb: 9u
+12-13 10:32:33.442   226   246 D GnssLocationProvider: gnssSetSystemInfoCb: yearOfHw=2020
+12-13 10:32:33.443   226   246 D GnssLocationProvider: gnssNameCb: name=Virtual GNSS
+12-13 10:32:33.443   226   246 I GnssLocationProvider: Unable to initialize IGnssXtra interface.
+12-13 10:32:33.443   226   246 I GnssLocationProvider: Unable to initialize IAGnss interface.
+12-13 10:32:33.443   226   246 I GnssLocationProvider: Unable to initialize IGnssGeofencing interface.
+12-13 10:32:33.443   226   246 I GnssLocationProvider: Unable to initialize IGnssNi interface.
+12-13 10:32:33.443   226   246 I GnssLocationProvider: Unable to initialize IAGnssRil interface.
+12-13 10:32:33.443   226   246 I GnssLocationProvider: Unable to find IMeasurementCorrections.
+12-13 10:32:33.443   226   246 E GnssLocationProvider: android_location_GnssLocationProvider_set_agps_server: IAGnss interface not available.
+12-13 10:32:33.443   226   246 E GnssBatchingProvider: Failed to initialize GNSS batching
+12-13 10:32:33.444   226   246 I GnssBlacklistHelper: Update GNSS satellite blacklist: 
+12-13 10:32:33.445   226   246 I GnssLocationProvider: restartRequests
+12-13 10:32:33.446   226   246 I GnssLocationProvider: restartRequests
+12-13 10:32:33.446   226   246 I GnssLocationProvider: IGnssConfiguration interface does not support satellite blacklist.
+12-13 10:32:33.452   226   226 I StatsCompanionService: Told statsd that StatsCompanionService is alive.
+12-13 10:32:33.452   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 12ms
+12-13 10:32:33.453   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:33.453   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.stats.pull.StatsPullAtomService took to complete: 0ms
+12-13 10:32:33.453   226   257 D StatsPullAtomService: Registering NetworkStats pullers with statsd
+12-13 10:32:33.457   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.461   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.incident.IncidentCompanionService
+12-13 10:32:33.462   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:33.462   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.MmsServiceBroker
+12-13 10:32:33.462   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:33.462   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.autofill.AutofillManagerService
+12-13 10:32:33.463   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.autofill.AutofillManagerService took to complete: 2ms
+12-13 10:32:33.464   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.clipboard.ClipboardService
+12-13 10:32:33.464   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:33.464   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:33.464   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 0ms
+12-13 10:32:33.464   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.policy.PermissionPolicyService
+12-13 10:32:33.464   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.policy.PermissionPolicyService took to complete: 0ms
+12-13 10:32:33.464   226   226 I SystemServerTiming: OnBootPhase_600_com.android.server.pm.StagingManager$Lifecycle
+12-13 10:32:33.464   226   226 D SystemServerTiming: OnBootPhase_600_com.android.server.pm.StagingManager$Lifecycle took to complete: 0ms
+12-13 10:32:33.464   226   226 I SystemServerTiming: OnBootPhase_600_com.microsoft.windows.service.SystemServerService
+12-13 10:32:33.464   226   226 V SystemServerService: PHASE_THIRD_PARTY_APPS_CAN_START
+12-13 10:32:33.464   226   226 D SystemServerTiming: OnBootPhase_600_com.microsoft.windows.service.SystemServerService took to complete: 0ms
+12-13 10:32:33.464   226   226 D SystemServerTiming: OnBootPhase_600 took to complete: 74ms
+12-13 10:32:33.464   226   226 D SystemServerTiming: PhaseThirdPartyAppsCanStart took to complete: 74ms
+12-13 10:32:33.464   226   226 I SystemServerTiming: StartNetworkStack
+12-13 10:32:33.464   226   226 D ConnectivityModuleConnector: Starting networking module android.net.INetworkStackConnector
+12-13 10:32:33.465   226   226 D ConnectivityModuleConnector: Starting networking module in network_stack process
+12-13 10:32:33.465   226   226 I am_uid_running: 1073
+12-13 10:32:33.466   226   226 D CompatibilityChangeReporter: Compat change id reported: 135634846; UID 1073; state: DISABLED
+12-13 10:32:33.466   226   226 D ConnectivityModuleConnector: Networking module service start requested
+12-13 10:32:33.466   226   226 D SystemServerTiming: StartNetworkStack took to complete: 2ms
+12-13 10:32:33.466   226   226 I SystemServerTiming: StartTethering
+12-13 10:32:33.466   226   226 D ConnectivityModuleConnector: Starting networking module android.net.ITetheringConnector
+12-13 10:32:33.466   226   226 D ConnectivityModuleConnector: Starting networking module in network_stack process
+12-13 10:32:33.467   226   226 D ConnectivityModuleConnector: Networking module service start requested
+12-13 10:32:33.467   226   226 D SystemServerTiming: StartTethering took to complete: 1ms
+12-13 10:32:33.467   226   226 I SystemServerTiming: MakeCountryDetectionServiceReady
+12-13 10:32:33.467   226   226 D SystemServerTiming: MakeCountryDetectionServiceReady took to complete: 0ms
+12-13 10:32:33.467   226   226 I SystemServerTiming: MakeNetworkTimeUpdateReady
+12-13 10:32:33.467   226   226 D ConnectivityService: requestNetwork for uid/pid:1000/226 NetworkRequest [ TRACK_DEFAULT id=9, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1000 AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ]
+12-13 10:32:33.468   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.468   226   226 D SystemServerTiming: MakeNetworkTimeUpdateReady took to complete: 1ms
+12-13 10:32:33.468   226   226 I SystemServerTiming: MakeInputManagerServiceReady
+12-13 10:32:33.468   226   333 D Ethernet: got request NetworkRequest [ TRACK_DEFAULT id=9, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1000 AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId 0
+12-13 10:32:33.469   226   226 D SystemServerTiming: MakeInputManagerServiceReady took to complete: 1ms
+12-13 10:32:33.469   226   226 I SystemServerTiming: MakeTelephonyRegistryReady
+12-13 10:32:33.431   226   226 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:33.473   226   226 D TelephonyRegistry: systemRunning register for intents
+12-13 10:32:33.473   226   292 I InputReader: Reconfiguring input devices, changes=KEYBOARD_LAYOUTS | DEVICE_ALIAS | 
+12-13 10:32:33.473   226   226 D SystemServerTiming: MakeTelephonyRegistryReady took to complete: 4ms
+12-13 10:32:33.473   226   226 I SystemServerTiming: MakeMediaRouterServiceReady
+12-13 10:32:33.474   226   226 D SystemServerTiming: MakeMediaRouterServiceReady took to complete: 0ms
+12-13 10:32:33.474   226   226 I SystemServerTiming: MakeMmsServiceReady
+12-13 10:32:33.474   226   226 I MmsServiceBroker: Delay connecting to MmsService until an API is called
+12-13 10:32:33.474   226   226 D SystemServerTiming: MakeMmsServiceReady took to complete: 0ms
+12-13 10:32:33.474   226   226 I SystemServerTiming: IncidentDaemonReady
+12-13 10:32:33.478    67    67 D Zygote  : Forked child process 424
+12-13 10:32:33.478   226   226 D SystemServerTiming: IncidentDaemonReady took to complete: 3ms
+12-13 10:32:33.478   226   226 I SystemServerTiming: getCurrentUser
+12-13 10:32:33.478   226   226 I ActivityManager: Current user:0
+12-13 10:32:33.478   226   226 D SystemServerTiming: getCurrentUser took to complete: 0ms
+12-13 10:32:33.478   226   226 I SystemServerTiming: ActivityManagerStartApps
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.StartUser-0
+12-13 10:32:33.479   226   226 I SystemServiceManager: Calling onStartUser 0
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.security.FileIntegrityService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.Installer
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.power.PowerManagerService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.power.ThermalManagerService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.lights.LightsService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.display.DisplayManagerService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.om.OverlayManagerService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.SensorPrivacyService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.SystemConfigService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.BatteryService
+12-13 10:32:33.479   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:33.479   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.usage.UsageStatsService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.usage.UsageStatsService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.CachedDeviceStateService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.LooperStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.rollback.RollbackManagerService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.rollback.RollbackManagerService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.os.BugreportManagerService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.gpu.GpuService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.security.KeyChainSystemService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.telecom.TelecomLoaderService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.content.ContentService$Lifecycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.DropBoxManagerService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.AlarmManagerService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.AlarmManagerService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.connectivity.IpConnectivityMetrics took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.PinnerService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:33.480   226   288 I commit_sys_config_file: [settings-0-0,19]
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:33.480   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.480   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:33.481   226   259 I am_proc_start: [0,424,1073,com.android.networkstack.process,service,{com.android.networkstack/com.android.server.NetworkStackService}]
+12-13 10:32:33.481   226   259 I ActivityManager: Start proc 424:com.android.networkstack.process/1073 for service {com.android.networkstack/com.android.server.NetworkStackService}
+12-13 10:32:33.487   226   226 V StorageManagerService: Package com.microsoft.windows.systemapp does not have legacy storage
+12-13 10:32:33.487   226   226 V StorageManagerService: Package com.android.cts.priv.ctsshim does not have legacy storage
+12-13 10:32:33.487   226   226 V StorageManagerService: Package stericson.busybox has legacy storage
+12-13 10:32:33.487   226   226 V StorageManagerService: Package com.android.dynsystem does not have legacy storage
+12-13 10:32:33.488   226   226 V StorageManagerService: Package com.android.providers.calendar does not have legacy storage
+12-13 10:32:33.488   226   226 V StorageManagerService: Package com.android.providers.media has legacy storage
+12-13 10:32:33.488   226   226 V StorageManagerService: Package com.google.android.accessibility.talkback does not have legacy storage
+12-13 10:32:33.488   226   226 V StorageManagerService: Package com.amazon.venezia has legacy storage
+12-13 10:32:33.488   226   226 V StorageManagerService: Package com.pbs.video does not have legacy storage
+12-13 10:32:33.488   226   226 V StorageManagerService: Package com.ringapp.fire does not have legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.documentsui does not have legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.htmlviewer does not have legacy storage
+12-13 10:32:33.489   424   424 W rkstack.proces: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.companiondevicemanager does not have legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.providers.downloads has legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.microsoft.windows.userapp does not have legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.providers.downloads.ui has legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.networkstack does not have legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.joeykrim.rootcheck does not have legacy storage
+12-13 10:32:33.489   226   226 V StorageManagerService: Package com.android.modulemetadata does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.certinstaller does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package android does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.contacts does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.camera2 has legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.backupconfirm does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.ted.android does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.settings.auto_generated_rro_vendor__ does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.systemui.auto_generated_rro_vendor__ does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.statementservice does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.playtika.wsop does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.providers.settings does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.printspooler does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.webview does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.se does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.inputdevices does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.bips does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.amazon.device.messaging does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.providers.settings.auto_generated_rro_vendor__ does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package android.ext.shared does not have legacy storage
+12-13 10:32:33.490   226   226 V StorageManagerService: Package com.android.keychain does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.android.gallery3d has legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package android.ext.services does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.android.wifi.resources does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.android.localtransport does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.android.packageinstaller does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.outfit7.mytalkingtom2.amazon does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.zhiliaoapp.musically does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.topjohnwu.magisk does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.fingersoft.hillclimbracing has legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package amazon.rumbic.mundus does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.android.networkstack.tethering does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.android.soundpicker has legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.amazon.avod.thirdpartyclient does not have legacy storage
+12-13 10:32:33.491   226   226 V StorageManagerService: Package com.kingouser.com has legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package net.wooga.junes_journey_hidden_object_mystery_game does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.settings does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.networkstack.permissionconfig does not have legacy storage
+12-13 10:32:33.492   350   350 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.cts.ctsshim does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package tv.twitch.android.viewer does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.music does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.shell has legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.wallpaperbackup does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.providers.media.module has legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.hotspot2.osulogin does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.location.fused does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.systemui has legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.kiloo.subwaysurf does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.permissioncontroller does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.traceur does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.android.providers.contacts does not have legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package com.amazon.kindle has legacy storage
+12-13 10:32:33.492   226   226 V StorageManagerService: Package android.auto_generated_rro_vendor__ does not have legacy storage
+12-13 10:32:33.492   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.StorageManagerService$Lifecycle took to complete: 12ms
+12-13 10:32:33.492   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:33.492   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:33.492   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.UiModeManagerService
+12-13 10:32:33.492   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.UiModeManagerService took to complete: 0ms
+12-13 10:32:33.492   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:33.492   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 1ms
+12-13 10:32:33.492   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:33.492   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.testharness.TestHarnessModeService took to complete: 0ms
+12-13 10:32:33.492   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.DeviceIdleController
+12-13 10:32:33.492   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.DeviceIdleController took to complete: 0ms
+12-13 10:32:33.492   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:33.495   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 2ms
+12-13 10:32:33.495   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:33.495   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.495   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:33.495   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 1ms
+12-13 10:32:33.495   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:33.495   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:33.495   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.wifi.WifiService
+12-13 10:32:33.495   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.wifi.WifiService took to complete: 0ms
+12-13 10:32:33.495   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:33.495   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.wifi.scanner.WifiScanningService took to complete: 0ms
+12-13 10:32:33.496   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.ethernet.EthernetService
+12-13 10:32:33.496   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.ethernet.EthernetService took to complete: 0ms
+12-13 10:32:33.496   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.notification.NotificationManagerService
+12-13 10:32:33.496   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.notification.NotificationManagerService took to complete: 0ms
+12-13 10:32:33.496   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:33.496   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:33.496   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:33.492   350   350 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.497   103   129 I adbd    : jdwp connection from 424
+12-13 10:32:33.497   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.location.LocationManagerService$Lifecycle took to complete: 2ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.DockObserver
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.adb.AdbService$Lifecycle took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.twilight.TwilightService
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.display.color.ColorDisplayService
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.job.JobSchedulerService
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.job.JobSchedulerService took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.soundtrigger.SoundTriggerService took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.trust.TrustManagerService
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.trust.TrustManagerService took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.appwidget.AppWidgetService
+12-13 10:32:33.498   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:33.498   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.role.RoleManagerService
+12-13 10:32:33.502   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.role.RoleManagerService took to complete: 4ms
+12-13 10:32:33.502   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:33.502   350   350 V SystemUIService: SystemUIApplication constructed.
+12-13 10:32:33.502   226   240 I am_proc_bound: [0,424,com.android.networkstack.process]
+12-13 10:32:33.503   226   240 I am_uid_active: 1073
+12-13 10:32:33.505   226   226 W VoiceInteractionManager: no available voice recognition services found for user 0
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 3ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.GestureLauncherService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.GestureLauncherService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.SensorNotificationService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.SensorNotificationService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.emergency.EmergencyAffordanceService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.dreams.DreamManagerService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.dreams.DreamManagerService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.print.PrintManagerService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:33.505   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.blob.BlobStoreManagerService took to complete: 0ms
+12-13 10:32:33.505   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.media.MediaSessionService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.biometrics.BiometricService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.biometrics.AuthService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.ShortcutService$Lifecycle took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.LauncherAppsService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.people.PeopleService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.people.PeopleService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:33.506   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:33.506   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.camera.CameraServiceProxy
+12-13 10:32:33.508   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.camera.CameraServiceProxy took to complete: 2ms
+12-13 10:32:33.508   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:33.508   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 0ms
+12-13 10:32:33.508   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:33.508   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.stats.pull.StatsPullAtomService took to complete: 0ms
+12-13 10:32:33.508   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.incident.IncidentCompanionService
+12-13 10:32:33.508   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:33.508   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.MmsServiceBroker
+12-13 10:32:33.508   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:33.508   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.autofill.AutofillManagerService
+12-13 10:32:33.508   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.autofill.AutofillManagerService took to complete: 0ms
+12-13 10:32:33.508   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.clipboard.ClipboardService
+12-13 10:32:33.509   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:33.509   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:33.509   226   226 W AppBindingService: [Default SMS app] u0 Target package not found
+12-13 10:32:33.509   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 0ms
+12-13 10:32:33.509   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.policy.PermissionPolicyService
+12-13 10:32:33.509   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.policy.PermissionPolicyService took to complete: 0ms
+12-13 10:32:33.509   226   226 I SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.StagingManager$Lifecycle
+12-13 10:32:33.509   226   226 D SystemServerTiming: ssm.onStartUser-0_com.android.server.pm.StagingManager$Lifecycle took to complete: 0ms
+12-13 10:32:33.509   226   226 I SystemServerTiming: ssm.onStartUser-0_com.microsoft.windows.service.SystemServerService
+12-13 10:32:33.509   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.510   226   226 D SystemServerTiming: ssm.onStartUser-0_com.microsoft.windows.service.SystemServerService took to complete: 0ms
+12-13 10:32:33.510   226   226 D SystemServerTiming: ssm.StartUser-0 took to complete: 31ms
+12-13 10:32:33.510   226   226 I SystemServerTiming: startPersistentApps
+12-13 10:32:33.510   226   257 I netstats_mobile_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353509]
+12-13 10:32:33.510   226   257 I netstats_wifi_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353509]
+12-13 10:32:33.510   226   226 I am_uid_running: 1068
+12-13 10:32:33.511   226   226 D CompatibilityChangeReporter: Compat change id reported: 135634846; UID 1068; state: DISABLED
+12-13 10:32:33.511   226   226 D SystemServerTiming: startPersistentApps took to complete: 1ms
+12-13 10:32:33.511   226   226 I SystemServerTiming: startHomeOnAllDisplays
+12-13 10:32:33.517    67    67 D Zygote  : Forked child process 445
+12-13 10:32:33.519   226   226 I ActivityTaskManager: START u0 {act=android.intent.action.MAIN cat=[android.intent.category.HOME] flg=0x10000100 cmp=com.android.settings/.FallbackHome} from uid 0
+12-13 10:32:33.519   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.529   226   240 W StorageManagerService: No primary storage defined yet; hacking together a stub
+12-13 10:32:33.537   445   445 W com.android.se: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.542   103   129 I adbd    : jdwp connection from 445
+12-13 10:32:33.543   424   424 I rkstack.proces: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.553   424   424 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.553   424   424 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.577   374   374 I WebViewLoader-: System.exit called, status: 0
+12-13 10:32:33.577   374   374 I AndroidRuntime: VM exiting with result code 0, cleanup skipped.
+12-13 10:32:33.581    68    68 I Zygote  : Process 374 exited cleanly (0)
+12-13 10:32:33.584   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.584   226   257 I netstats_mobile_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353584]
+12-13 10:32:33.584   226   257 I netstats_wifi_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353584]
+12-13 10:32:33.636   226   226 I wm_task_created: [2,0]
+12-13 10:32:33.636   226   226 I wm_stack_created: 2
+12-13 10:32:33.637   226   226 I wm_task_moved: [2,1,2147483647]
+12-13 10:32:33.641   226   226 I wm_create_task: [0,2]
+12-13 10:32:33.641   226   226 I wm_create_activity: [0,20146787,2,com.android.settings/.FallbackHome,android.intent.action.MAIN,NULL,NULL,276824320]
+12-13 10:32:33.586   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.641    85    85 I power-service.windows: Power isModeSupported: 5
+12-13 10:32:33.642   226   226 I wm_task_moved: [2,1,2147483647]
+12-13 10:32:33.646   226   226 D SystemServerTiming: startHomeOnAllDisplays took to complete: 135ms
+12-13 10:32:33.646   226   226 I SystemServerTiming: showSystemReadyErrorDialogs
+12-13 10:32:33.646   226   226 I system_server: getFrameworkHalManifest: Reading VINTF information.
+12-13 10:32:33.648   226   226 I system_server: getFrameworkHalManifest: Successfully processed VINTF information
+12-13 10:32:33.648   226   226 I system_server: getDeviceHalManifest: Reading VINTF information.
+12-13 10:32:33.649   226   226 I system_server: getDeviceHalManifest: Successfully processed VINTF information
+12-13 10:32:33.649   226   226 I system_server: getFrameworkCompatibilityMatrix: Reading VINTF information.
+12-13 10:32:33.671   226   226 I system_server: getFrameworkCompatibilityMatrix: Successfully processed VINTF information
+12-13 10:32:33.671   226   226 I system_server: getDeviceCompatibilityMatrix: Reading VINTF information.
+12-13 10:32:33.672   226   226 I system_server: getDeviceCompatibilityMatrix: Successfully processed VINTF information
+12-13 10:32:33.673   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.673   226   257 I netstats_mobile_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353673]
+12-13 10:32:33.673   226   257 I netstats_wifi_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353673]
+12-13 10:32:33.674   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.677   226   226 W VintfObject: VintfObject.verifyWithoutAvb() returns 1: Runtime info and framework compatibility matrix are incompatible: No kernel entry found for kernel version 5.10 at kernel FCM version 5. The following kernel requirements are checked:
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.14.180, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 4.19.110, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 W VintfObject:   Minimum LTS: 5.4.42, kernel FCM version: 5, with conditionals
+12-13 10:32:33.677   226   226 E Build   : Vendor interface is incompatible, error=1
+12-13 10:32:33.677   226   226 E ActivityTaskManager: Build fingerprint is not consistent, warning user
+12-13 10:32:33.677   226   226 D SystemServerTiming: showSystemReadyErrorDialogs took to complete: 31ms
+12-13 10:32:33.677   226   226 I SystemServerTiming: sendUserStartBroadcast
+12-13 10:32:33.678   226   226 D SystemServerTiming: sendUserStartBroadcast took to complete: 0ms
+12-13 10:32:33.678   226   226 I SystemServerTiming: resumeTopActivities
+12-13 10:32:33.678   226   226 D SystemServerTiming: resumeTopActivities took to complete: 0ms
+12-13 10:32:33.678   226   226 I SystemServerTiming: sendUserSwitchBroadcasts
+12-13 10:32:33.678   226   226 I uc_send_user_broadcast: [0,android.intent.action.USER_FOREGROUND]
+12-13 10:32:33.678   226   226 I uc_send_user_broadcast: [0,android.intent.action.USER_SWITCHED]
+12-13 10:32:33.678   226   226 D SystemServerTiming: sendUserSwitchBroadcasts took to complete: 1ms
+12-13 10:32:33.678   226   226 I SystemServerTiming: setBinderProxies
+12-13 10:32:33.678   226   226 D SystemServerTiming: setBinderProxies took to complete: 0ms
+12-13 10:32:33.679   226   226 D SystemServerTiming: ActivityManagerStartApps took to complete: 200ms
+12-13 10:32:33.679   226   226 D SystemServerTiming: PhaseActivityManagerReady took to complete: 660ms
+12-13 10:32:33.679   226   226 D SystemServerTiming: startOtherServices took to complete: 1963ms
+12-13 10:32:33.679   226   226 D SystemServerTiming: StartServices took to complete: 2973ms
+12-13 10:32:33.679   226   259 W system_server: Long monitor contention with owner main (226) at int com.android.server.am.UserController$Injector.broadcastIntent(android.content.Intent, java.lang.String, android.content.IIntentReceiver, int, java.lang.String, android.os.Bundle, java.lang.String[], int, android.os.Bundle, boolean, boolean, int, int, int, int, int)(UserController.java:2748) waiters=1 in void com.android.server.am.ProcessList.handleProcessStart(com.android.server.am.ProcessRecord, java.lang.String, int[], int, int, int, java.lang.String, java.lang.String, java.lang.String, long) for 161ms
+12-13 10:32:33.680   226   259 I dvm_lock_sample: [system_server,1,ActivityManager:procStart,161,ProcessList.java,2060,void com.android.server.am.ProcessList.handleProcessStart(com.android.server.am.ProcessRecord, java.lang.String, int[], int, int, int, java.lang.String, java.lang.String, java.lang.String, long),UserController.java,2748,int com.android.server.am.UserController$Injector.broadcastIntent(android.content.Intent, java.lang.String, android.content.IIntentReceiver, int, java.lang.String, android.os.Bundle, java.lang.String[], int, android.os.Bundle, boolean, boolean, int, int, int, int, int),32]
+12-13 10:32:33.680   226   259 W ActivityManager: Slow operation: 169ms so far, now at startProcess: done updating battery stats
+12-13 10:32:33.680   226   259 I am_proc_start: [0,445,1068,com.android.se,added application,com.android.se]
+12-13 10:32:33.680   226   259 W ActivityManager: Slow operation: 169ms so far, now at startProcess: building log message
+12-13 10:32:33.680   226   259 I ActivityManager: Start proc 445:com.android.se/1068 for added application com.android.se
+12-13 10:32:33.680   226   259 W ActivityManager: Slow operation: 169ms so far, now at startProcess: starting to update pids map
+12-13 10:32:33.680   226   259 W ActivityManager: Slow operation: 169ms so far, now at startProcess: done updating pids map
+12-13 10:32:33.682   226   466 W system_server: Long monitor contention with owner main (226) at int com.android.server.am.UserController$Injector.broadcastIntent(android.content.Intent, java.lang.String, android.content.IIntentReceiver, int, java.lang.String, android.os.Bundle, java.lang.String[], int, android.os.Bundle, boolean, boolean, int, int, int, int, int)(UserController.java:2748) waiters=5 in void com.android.server.am.ActivityManagerService$AppDeathRecipient.binderDied() for 101ms
+12-13 10:32:33.682   226   466 I dvm_lock_sample: [system_server,0,Binder:226_4,101,ActivityManagerService.java,1608,void com.android.server.am.ActivityManagerService$AppDeathRecipient.binderDied(),UserController.java,2748,int com.android.server.am.UserController$Injector.broadcastIntent(android.content.Intent, java.lang.String, android.content.IIntentReceiver, int, java.lang.String, android.os.Bundle, java.lang.String[], int, android.os.Bundle, boolean, boolean, int, int, int, int, int),20]
+12-13 10:32:33.682   226   466 I ActivityManager: Process WebViewLoader-x86 (pid 374) has died: psvc PER 
+12-13 10:32:33.682   226   466 I am_proc_died: [0,374,WebViewLoader-x86,-700,0]
+12-13 10:32:33.682   226   260 I libprocessgroup: Successfully killed process cgroup uid 1037 pid 374 in 0ms
+12-13 10:32:33.684   226   466 I am_low_memory: 5
+12-13 10:32:33.686   226   240 I am_proc_bound: [0,445,com.android.se]
+12-13 10:32:33.687   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.691   226   240 I am_uid_active: 1068
+12-13 10:32:33.692   226   249 D CompatibilityChangeReporter: Compat change id reported: 135634846; UID 1000; state: DISABLED
+12-13 10:32:33.688   226   302 I chatty  : uid=1000(system) NetworkPolicy identical 1 line
+12-13 10:32:33.689   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.693   226   249 I InputManager: Enabling motion classifier because user switched: feature enabled, long press timeout = 400
+12-13 10:32:33.693   226   249 I InputClassifier: Enabling motion classifier
+12-13 10:32:33.694    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.input.classifier@1.0::IInputClassifier/default in either framework or device manifest.
+12-13 10:32:33.695   381   381 I WebViewLoader-: System.exit called, status: 0
+12-13 10:32:33.695   381   381 I AndroidRuntime: VM exiting with result code 0, cleanup skipped.
+12-13 10:32:33.695   226   471 I InputClassifier: Could not obtain InputClassifier HAL
+12-13 10:32:33.698   226   226 W Looper  : Slow delivery took 2033ms main h=android.app.ActivityThread$H c=null m=156
+12-13 10:32:33.699    67    67 D Zygote  : Forked child process 476
+12-13 10:32:33.700   226   259 I am_proc_start: [0,476,1000,com.android.settings,top-activity,{com.android.settings/com.android.settings.FallbackHome}]
+12-13 10:32:33.700   226   259 I ActivityManager: Start proc 476:com.android.settings/1000 for top-activity {com.android.settings/com.android.settings.FallbackHome}
+12-13 10:32:33.701   226   470 I ActivityManager: Process WebViewLoader-x86_64 (pid 381) has died: psvc PER 
+12-13 10:32:33.701   226   470 I am_proc_died: [0,381,WebViewLoader-x86_64,-700,0]
+12-13 10:32:33.702   226   470 I am_uid_stopped: 1037
+12-13 10:32:33.702   226   260 I libprocessgroup: Successfully killed process cgroup uid 1037 pid 381 in 0ms
+12-13 10:32:33.703   226   470 I am_low_memory: 4
+12-13 10:32:33.704   226   226 D ConditionProviders.SCP: onConnected
+12-13 10:32:33.706    68    68 D Zygote  : Forked child process 482
+12-13 10:32:33.709    67    67 I Zygote  : Process 381 exited cleanly (0)
+12-13 10:32:33.711   424   424 I TetheringManager: registerTetheringEventCallback:com.android.networkstack
+12-13 10:32:33.711   226   226 D ConditionProviders: Subscribing to condition://android/event?userId=-10000&calendar=&reply=1 with ComponentInfo{android/com.android.server.notification.EventConditionProvider}
+12-13 10:32:33.711   226   226 D ConditionProviders: Subscribing to condition://android/schedule?days=1.2.3.4.5.6.7&start=22.0&end=7.0&exitAtAlarm=true with ComponentInfo{android/com.android.server.notification.ScheduleConditionProvider}
+12-13 10:32:33.713   226   466 D ConnectivityService: requestNetwork for uid/pid:1073/424 NetworkRequest [ TRACK_DEFAULT id=10, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1073 AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ]
+12-13 10:32:33.713   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.713   226   226 I notification_cancel_all: [1000,226,android,0,0,0,17,NULL]
+12-13 10:32:33.713   226   333 D Ethernet: got request NetworkRequest [ TRACK_DEFAULT id=10, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1073 AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ] with score 0 and providerId 0
+12-13 10:32:33.714   476   476 W ndroid.setting: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.714   226   226 I am_uid_running: 10036
+12-13 10:32:33.715   226   226 D CompatibilityChangeReporter: Compat change id reported: 135634846; UID 10036; state: DISABLED
+12-13 10:32:33.715   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.717   226   259 D CompatibilityChangeReporter: Compat change id reported: 143937733; UID 10036; state: ENABLED
+12-13 10:32:33.727   103   129 I adbd    : jdwp connection from 476
+12-13 10:32:33.728    67    67 D Zygote  : Forked child process 506
+12-13 10:32:33.729   226   349 W ZygoteProcess: Got error connecting to zygote, retrying. msg= Connection refused
+12-13 10:32:33.729   424   424 D ApplicationLoaders: Returning zygote-cached class loader: /system/framework/android.test.base.jar
+12-13 10:32:33.730   482   482 I WebViewZygoteInit: Starting WebViewZygoteInit
+12-13 10:32:33.730   226   259 I am_proc_start: [0,506,10036,android.ext.services,service,{android.ext.services/android.ext.services.autofill.InlineSuggestionRenderServiceImpl}]
+12-13 10:32:33.731   226   259 I ActivityManager: Start proc 506:android.ext.services/u0a36 for service {android.ext.services/android.ext.services.autofill.InlineSuggestionRenderServiceImpl}
+12-13 10:32:33.731   226   246 D CompatibilityChangeReporter: Compat change id reported: 150939131; UID 1000; state: ENABLED
+12-13 10:32:33.732   226   466 I am_proc_bound: [0,476,com.android.settings]
+12-13 10:32:33.736   226   466 I configuration_changed: 256
+12-13 10:32:33.737   226   466 I ActivityTaskManager: Config changes=100 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.10}
+12-13 10:32:33.739   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.739   226   466 I WindowManager: Override config changes=100 {1.0 ?mcc?mnc [en_US] ldltr sw533dp w533dp h829dp 240dpi lrg port night finger qwerty/v/v -nav/h winConfig={ mBounds=Rect(0, 0 - 800, 1280) mAppBounds=Rect(0, 0 - 800, 1280) mWindowingMode=fullscreen mDisplayWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_0} s.10} for displayId=0
+12-13 10:32:33.739   226   257 I netstats_mobile_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353739]
+12-13 10:32:33.739   226   257 I netstats_wifi_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353739]
+12-13 10:32:33.740   226   466 I wm_restart_activity: [0,20146787,2,com.android.settings/.FallbackHome]
+12-13 10:32:33.741   445   445 I com.android.se: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.741   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.743   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.743   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.743   424   424 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.743   424   424 W nsconfig: com.android.networkstack.process: New config does not match the previously set config.
+12-13 10:32:33.743   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.744   226   466 I wm_set_resumed_activity: [0,com.android.settings/.FallbackHome,minimalResumeActivityLocked]
+12-13 10:32:33.747   506   506 W id.ext.service: Unexpected CPU variant for X86 using defaults: x86_64
+12-13 10:32:33.753   103   129 I adbd    : jdwp connection from 506
+12-13 10:32:33.761   445   445 W ContextImpl: Failed to ensure /data/user/0/com.android.se/cache: mkdir failed: ENOENT (No such file or directory)
+12-13 10:32:33.761   226   226 D PackageWatchdog: Getting all observed packages pending health checks
+12-13 10:32:33.761   226   226 I PackageWatchdog: Syncing health check requests for packages: {}
+12-13 10:32:33.762   226   226 I ExplicitHealthCheckController: Service not ready to get health check supported packages. Binding...
+12-13 10:32:33.762   445   445 W ContextImpl: Failed to update user.inode_cache: stat failed: ENOENT (No such file or directory)
+12-13 10:32:33.762   226   470 I am_proc_bound: [0,506,android.ext.services]
+12-13 10:32:33.766   226   470 I am_uid_active: 10036
+12-13 10:32:33.767   445   445 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.770   226   226 I ExplicitHealthCheckController: Explicit health check service is bound
+12-13 10:32:33.767   445   445 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.770   476   476 I ndroid.setting: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.777   226   226 I system_server: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.780   476   476 E ndroid.setting: Dex checksum does not match for dex: /system_ext/priv-app/Settings/Settings.apk.Expected: 1664015969, actual: 1248130043
+12-13 10:32:33.780   226   466 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:33.781   226   226 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.781   226   226 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.782   482   482 I WebViewZygoteInit: Beginning application preload for com.android.webview
+12-13 10:32:33.782   226   248 I DropBoxManagerService: add tag=system_app_strictmode isTagEnabled=true flags=0x2
+12-13 10:32:33.783   445   445 I SecureElementService: main onCreate
+12-13 10:32:33.786   476   476 I ndroid.setting: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.788   482   482 I webview_zygote: The ClassLoaderContext is a special shared library.
+12-13 10:32:33.789   482   482 D nativeloader: classloader namespace configured for unbundled product apk. library_path=/product/app/webview/lib/x86:/product/app/webview/webview.apk!/lib/x86:/product/lib:/system/product/lib
+12-13 10:32:33.793   445   445 I SecureElementService: Check if terminal eSE1 is available.
+12-13 10:32:33.794    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.2::ISecureElement/eSE1 in either framework or device manifest.
+12-13 10:32:33.794   445   445 D SecureElement-Terminal-eSE1: SE Hal V1.2 is not supported
+12-13 10:32:33.794    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.1::ISecureElement/eSE1 in either framework or device manifest.
+12-13 10:32:33.794   226   470 D NetworkStats: registerNetworkStatsProvider from OffloadController uid/pid=1073/424
+12-13 10:32:33.794   445   445 D SecureElement-Terminal-eSE1: SE Hal V1.1 is not supported
+12-13 10:32:33.795    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.0::ISecureElement/eSE1 in either framework or device manifest.
+12-13 10:32:33.795   445   445 I SecureElementService: No HAL implementation for eSE1
+12-13 10:32:33.795   445   445 I SecureElementService: Check if terminal SIM1 is available.
+12-13 10:32:33.795    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.2::ISecureElement/SIM1 in either framework or device manifest.
+12-13 10:32:33.795   445   445 D SecureElement-Terminal-SIM1: SE Hal V1.2 is not supported
+12-13 10:32:33.795    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.1::ISecureElement/SIM1 in either framework or device manifest.
+12-13 10:32:33.795   445   445 D SecureElement-Terminal-SIM1: SE Hal V1.1 is not supported
+12-13 10:32:33.795    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.0::ISecureElement/SIM1 in either framework or device manifest.
+12-13 10:32:33.795   445   445 I SecureElementService: No HAL implementation for SIM1
+12-13 10:32:33.803   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.803   226   257 I netstats_mobile_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353803]
+12-13 10:32:33.803   226   257 I netstats_wifi_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353803]
+12-13 10:32:33.804   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.805   226   302 I chatty  : uid=1000(system) NetworkPolicy identical 1 line
+12-13 10:32:33.805   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.806   226   467 D NetworkStats: registerNetworkStatsProvider from BpfCoordinator uid/pid=1073/424
+12-13 10:32:33.806   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.807   424   424 D CompatibilityChangeReporter: Compat change id reported: 147600208; UID 1073; state: ENABLED
+12-13 10:32:33.810   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.805   226   248 I chatty  : uid=1000(system) android.io identical 1 line
+12-13 10:32:33.815   226   248 I DropBoxManagerService: add tag=system_app_strictmode isTagEnabled=true flags=0x2
+12-13 10:32:33.816   226   226 E TrustManagerService: EXTRA_USER_HANDLE missing or invalid, value=0
+12-13 10:32:33.819   226   258 I am_wtf  : [0,226,system_server,-1,TrustManagerService,EXTRA_USER_HANDLE missing or invalid, value=0]
+12-13 10:32:33.819   424   424 V WifiManager: registerSoftApCallback: callback=com.android.networkstack.tethering.Tethering$TetheringSoftApCallback@d6e3ffb, executor=com.android.networkstack.tethering.Tethering$TetheringThreadExecutor@691e818
+12-13 10:32:33.820   226   258 I DropBoxManagerService: add tag=system_server_wtf isTagEnabled=true flags=0x2
+12-13 10:32:33.821   226   467 D ConnectivityService: requestNetwork for uid/pid:1073/424 NetworkRequest [ REQUEST id=12, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ]
+12-13 10:32:33.821   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:33.822   226   333 D Ethernet: got request NetworkRequest [ REQUEST id=12, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ] with score 0 and providerId 0
+12-13 10:32:33.829   226   248 I DropBoxManagerService: add tag=system_app_strictmode isTagEnabled=true flags=0x2
+12-13 10:32:33.833   506   506 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.833   506   506 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.843   476   476 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.844   476   476 D NetworkSecurityConfig: No Network Security Config specified, using platform default
+12-13 10:32:33.846   350   350 D CompatibilityChangeReporter: Compat change id reported: 147600208; UID 10031; state: ENABLED
+12-13 10:32:33.854   226   257 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.854   226   257 I netstats_mobile_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353854]
+12-13 10:32:33.854   226   257 I netstats_wifi_sample: [0,0,0,0,0,0,0,0,0,0,0,0,1639420353854]
+12-13 10:32:33.855   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.855   226   257 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:33.856   226   257 D CountryDetector: Using custom country detector class: com.android.server.location.ComprehensiveCountryDetector
+12-13 10:32:33.855   226   302 W BestClock: java.time.DateTimeException: Missing NTP fix
+12-13 10:32:33.864   482   482 I WebViewZygoteInit: Application preload done
+12-13 10:32:33.883   226   226 D AccessibilityManagerService: Ignoring non-encryption-aware service ComponentInfo{com.microsoft.windows.userapp/com.microsoft.windows.inputmethod.TsfAccessibilityService}
+12-13 10:32:33.886   226   226 V NotificationAssistants: enabling notification assistant for 0: ComponentInfo{android.ext.services/android.ext.services.notification.Assistant}
+12-13 10:32:33.886   226   226 V NotificationAssistants: binding: Intent { act=android.service.notification.NotificationAssistantService cmp=android.ext.services/.notification.Assistant (has extras) }
+12-13 10:32:33.891    86    86 E AudioFlinger: getMicMute: error -38 getting state from HAL
+12-13 10:32:33.892    86    86 W AudioFlinger: setMicMute: error -38 setting state to HAL
+12-13 10:32:33.892   226   226 E AudioSystem-JNI: Command failed for android_media_AudioSystem_muteMicrophone: -38
+12-13 10:32:33.893    86    86 E AudioFlinger: getMicMute: error -38 getting state from HAL
+12-13 10:32:33.893   226   226 E AS.AudioService: Error changing mic mute state to false current:false
+12-13 10:32:33.901   226   467 W ActivityManager: Receiver with filter android.content.IntentFilter@ac581a3 already registered for pid 350, callerPackage is com.android.systemui
+12-13 10:32:33.907   350   350 D MediaResumeListener: loaded resume components []
+12-13 10:32:33.908   350   350 E BluetoothAdapter: Bluetooth binder is null
+12-13 10:32:33.913    86   179 W APM::AudioPolicyEngine: getDevicesForStrategy() unknown strategy: -1
+12-13 10:32:33.925   226   226 D ConditionProviders.SCP: onSubscribe condition://android/schedule?days=1.2.3.4.5.6.7&start=22.0&end=7.0&exitAtAlarm=true
+12-13 10:32:33.926   226   226 D ConditionProviders.SCP: setRegistered true
+12-13 10:32:33.928   226   315 W ActivityThread: Failed to find provider info for com.android.calendar (user not unlocked)
+12-13 10:32:33.928   476   543 D libEGL  : loaded /vendor/lib64/egl/libEGL_emulation.so
+12-13 10:32:33.928   350   350 W AlarmManager: Unrecognized alarm listener com.android.systemui.keyguard.-$$Lambda$KeyguardSliceProvider$IhzByd8TsqFuOrSyuGurVskyPLo@5e3f870
+12-13 10:32:33.930   476   543 D libEGL  : loaded /vendor/lib64/egl/libGLESv1_CM_emulation.so
+12-13 10:32:33.928   226   315 W ActivityThread: Failed to find provider info for com.android.calendar (user not unlocked)
+12-13 10:32:33.931   226   226 D ConditionProviders.SCP: evaluateSubscriptionLocked cal=ScheduleCalendar[mDays={1, 2, 3, 4, 5, 6, 7}, mSchedule=ScheduleInfo{days=[1, 2, 3, 4, 5, 6, 7], startHour=22, startMinute=0, endHour=7, endMinute=0, exitAtAlarm=true, nextAlarm=Wed Dec 31 16:00:00 PST 1969 (0)}], now=Mon Dec 13 10:32:33 PST 2021 (1639420353926), nextUserAlarmTime=Wed Dec 31 16:00:00 PST 1969 (0)
+12-13 10:32:33.931   226   226 D ConditionProviders.SCP: notifyCondition condition://android/schedule?days=1.2.3.4.5.6.7&start=22.0&end=7.0&exitAtAlarm=true STATE_FALSE reason=!meetsSchedule
+12-13 10:32:33.931   226   226 D ConditionProviders.SCP: Scheduling evaluate for Mon Dec 13 22:00:00 PST 2021 (1639461600000), in +11h27m26s74ms, now=Mon Dec 13 10:32:33 PST 2021 (1639420353926)
+12-13 10:32:33.932   226   226 I ConnectivityModuleConnector: Networking module service connected
+12-13 10:32:33.932   226   226 I ConnectivityModuleConnector: Networking module service connected
+12-13 10:32:33.932   226   226 I NetworkStackClient: Network stack service connected
+12-13 10:32:33.934   476   543 D libEGL  : loaded /vendor/lib64/egl/libGLESv2_emulation.so
+12-13 10:32:33.941   226   226 D AutofillManagerService: Restriction did not change for user 0
+12-13 10:32:33.941   226   226 I ConnectivityModuleConnector: Networking module service connected
+12-13 10:32:33.941   226   226 I ConnectivityModuleConnector: Networking module service connected
+12-13 10:32:33.945   226   226 I ExplicitHealthCheckController: Explicit health check service is connected ComponentInfo{android.ext.services/android.ext.services.watchdog.ExplicitHealthCheckServiceImpl}
+12-13 10:32:33.945   350   350 V SystemUIService: SystemUIApplication created.
+12-13 10:32:33.948   226   226 I ExplicitHealthCheckController: Service initialized, syncing requests
+12-13 10:32:33.948   350   350 D SystemUIBootTiming: DependencyInjection took to complete: 0ms
+12-13 10:32:33.949   226   226 V NotificationAssistants: 0 notification assistant service connected: ComponentInfo{android.ext.services/android.ext.services.notification.Assistant}
+12-13 10:32:33.956   226   288 I commit_sys_config_file: [settings-0-0,16]
+12-13 10:32:33.957   226   226 D TelephonyRegistry: notifyCellLocationForSubscriber: subId=0 cellLocation=null
+12-13 10:32:33.959   226   226 D PackageWatchdog: Getting all observed packages pending health checks
+12-13 10:32:33.959   226   226 I PackageWatchdog: Syncing health check requests for packages: {}
+12-13 10:32:33.959   226   226 D ExplicitHealthCheckController: Getting health check supported packages
+12-13 10:32:33.959   226   226 W Looper  : Drained
+12-13 10:32:33.961   226   240 I ExplicitHealthCheckController: Explicit health check supported packages [PackageConfig{com.android.networkstack, 86400000}]
+12-13 10:32:33.961   226   240 D PackageWatchdog: Received supported packages [PackageConfig{com.android.networkstack, 86400000}]
+12-13 10:32:33.961   226   240 D ExplicitHealthCheckController: Getting health check requested packages
+12-13 10:32:33.962   226   470 I ExplicitHealthCheckController: Explicit health check requested packages []
+12-13 10:32:33.962   226   470 I ExplicitHealthCheckController: No more health check requests, unbinding...
+12-13 10:32:33.964   226   470 I ExplicitHealthCheckController: Explicit health check service is unbound
+12-13 10:32:33.964   350   350 V SystemUIService: Starting SystemUI services for user 0.
+12-13 10:32:33.975   350   350 D InterruptionStateProvider: heads up is enabled
+12-13 10:32:33.978   476   476 I wm_on_create_called: [20146787,com.android.settings.FallbackHome,performCreate]
+12-13 10:32:33.981   476   476 I wm_on_start_called: [20146787,com.android.settings.FallbackHome,handleStartActivity]
+12-13 10:32:33.981   350   350 I FalsingManager: xdpi, ydpi: 0.24, 0.24
+12-13 10:32:33.982   476   476 I wm_on_resume_called: [20146787,com.android.settings.FallbackHome,RESUME_ACTIVITY]
+12-13 10:32:33.982   350   350 I FalsingManager: width, height: 800, 1280
+12-13 10:32:33.987    66   147 E Netd    : Removing unknown address 172.18.229.139/20 from ifindex 14
+12-13 10:32:33.988   350   350 D NavigationModeController: getCurrentUserContext: contextUser=0 currentUser=0
+12-13 10:32:33.988   350   350 D NavigationModeController: getCurrentInteractionMode: mode=0 contextUser=0
+12-13 10:32:33.989   226   305 E SupplicantStaIfaceHal: ISupplicantStaIface.getMacAddress failed: {.code = FAILURE_UNKNOWN, .debugMessage = }
+12-13 10:32:33.989   350   350 E NavigationModeController: updateCurrentInteractionMode: mode=0
+12-13 10:32:33.989   350   350 D NavigationModeController:   contextUser=0
+12-13 10:32:33.989   350   350 D NavigationModeController:   assetPaths=
+12-13 10:32:33.990   350   350 D NavigationModeController:     /system/framework/framework-res.apk
+12-13 10:32:33.990   350   350 D NavigationModeController:     /vendor/overlay/framework-res__auto_generated_rro_vendor.apk
+12-13 10:32:33.990   350   350 D NavigationModeController:     /system_ext/priv-app/SystemUI/SystemUI.apk
+12-13 10:32:33.990   350   350 D NavigationModeController:     /vendor/overlay/SystemUI__auto_generated_rro_vendor.apk
+12-13 10:32:33.990   226   305 D WifiCountryCode: Reading country code from telephony
+12-13 10:32:33.990   226   305 D WifiCountryCode: Set telephony country code to: 
+12-13 10:32:33.990   226   305 D WifiCountryCode: updateCountryCode to null
+12-13 10:32:33.990   226   305 W WifiDiags: Failed to start packet fate monitoring
+12-13 10:32:33.991   226   305 W WifiDiags: no ring buffers found
+12-13 10:32:33.991   226   305 D WifiDiags: startLogging() iface list is {wlan0} after adding wlan0
+12-13 10:32:33.992   350   350 D NavigationModeController: getCurrentInteractionMode: mode=0 contextUser=0
+12-13 10:32:33.992   226   305 E SupplicantStaIfaceHal: ISupplicantStaIface.setBtCoexistenceScanModeEnabled failed: {.code = FAILURE_UNKNOWN, .debugMessage = }
+12-13 10:32:33.993   226   305 E SupplicantStaIfaceHal: ISupplicantStaIface.stopRxFilter failed: {.code = FAILURE_UNKNOWN, .debugMessage = }
+12-13 10:32:33.993   226   305 E SupplicantStaIfaceHal: ISupplicantStaIface.stopRxFilter failed: {.code = FAILURE_UNKNOWN, .debugMessage = }
+12-13 10:32:33.994   226   305 E SupplicantStaIfaceHal: ISupplicantStaIface.setSuspendModeEnabled failed: {.code = FAILURE_UNKNOWN, .debugMessage = }
+12-13 10:32:33.995   226   305 E SupplicantStaIfaceHal: ISupplicantStaIface.setPowerSave failed: {.code = FAILURE_UNKNOWN, .debugMessage = }
+12-13 10:32:33.997   226   305 D WakeupController: reset()
+12-13 10:32:33.997   226   305 D WakeupController: Setting active to false
+12-13 10:32:33.999   226   305 I WifiClientModeImpl: disconnectedstate enter
+12-13 10:32:34.000   226   305 D ApConfigUtil: Update Softap capability, add client control feature support
+12-13 10:32:34.001   226   305 D ApConfigUtil: Update Softap capability, max client = 16
+12-13 10:32:34.001   226   305 D WifiActiveModeWarden: Switching all client mode managers
+12-13 10:32:34.003   226   305 E HalDevMgr: getAllChipInfo: called but mWifi is null!?
+12-13 10:32:34.003    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup2: Permission denied
+12-13 10:32:34.003    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup0: Permission denied
+12-13 10:32:34.004    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup3: Permission denied
+12-13 10:32:34.004    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup1: Permission denied
+12-13 10:32:34.005   476   476 I wm_on_top_resumed_gained_called: [20146787,com.android.settings.FallbackHome,topStateChangedWhenResumed]
+12-13 10:32:34.006   226   305 E HalDevMgr: getAllChipInfo: called but mWifi is null!?
+12-13 10:32:34.007   226   264 W KernelCpuProcStringReader: File not found. It's normal if not implemented: /proc/uid_concurrent_policy_time
+12-13 10:32:34.007   226   264 E KernelCpuSpeedReader: Failed to read cpu-freq: /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state: open failed: ENOENT (No such file or directory)
+12-13 10:32:34.007    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup2: Permission denied
+12-13 10:32:34.007    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup0: Permission denied
+12-13 10:32:34.008    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup3: Permission denied
+12-13 10:32:34.008    41    46 E android.system.suspend@1.0-service: Error opening kernel wakelock stats for: wakeup1: Permission denied
+12-13 10:32:34.012   350   350 D NavigationModeController: getCurrentInteractionMode: mode=0 contextUser=0
+12-13 10:32:34.023   476   541 D HostConnection: createUnique: call
+12-13 10:32:34.024   476   541 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.029   350   558 W TelecomManager: Telecom Service not found.
+12-13 10:32:34.030   350   350 I TetheringManager: registerTetheringEventCallback:com.android.systemui
+12-13 10:32:34.034   350   350 W CarrierConfigManager: Error getting config for subId -1 ICarrierConfigLoader is null
+12-13 10:32:34.034   350   560 W TelecomManager: Telecom Service not found.
+12-13 10:32:34.059   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:34.059   226   470 D ConnectivityService: requestNetwork for uid/pid:10031/350 NetworkRequest [ TRACK_DEFAULT id=14, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ]
+12-13 10:32:34.060   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:34.060   226   333 D Ethernet: got request NetworkRequest [ TRACK_DEFAULT id=14, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ] with score 0 and providerId 0
+12-13 10:32:34.060   350   350 V WifiManager: registerTrafficStateCallback: callback=com.android.systemui.statusbar.policy.WifiSignalController$WifiTrafficStateCallback@f50f451, executor=android.os.HandlerExecutor@2c642dc
+12-13 10:32:34.064   226   470 D ConnectivityService: requestNetwork for uid/pid:10031/350 NetworkRequest [ TRACK_DEFAULT id=15, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ]
+12-13 10:32:34.064   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:34.064   226   333 D Ethernet: got request NetworkRequest [ TRACK_DEFAULT id=15, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ] with score 0 and providerId 0
+12-13 10:32:34.064   226   470 D TelephonyRegistry: listen oscl: mHasNotifySubscriptionInfoChangedOccurred==false no callback
+12-13 10:32:34.095   476   541 D HostConnection: HostConnection::get() New Host Connection established 0x73ae60016190, tid 541
+12-13 10:32:34.100   476   541 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:34.108    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.configstore@1.0::ISurfaceFlingerConfigs/default in either framework or device manifest.
+12-13 10:32:34.110   476   541 E EGL_emulation: eglCreateContext: 0x73ae600181d0: maj 3 min 0 rcv 3
+12-13 10:32:34.115   476   541 D EGL_emulation: eglMakeCurrent: 0x73ae600181d0: ver 3 0 (tinfo 0x73b062b3d080) (first time)
+12-13 10:32:34.117   350   350 W System.err: java.lang.UnsupportedOperationException: Picture in picture is not supported on this device
+12-13 10:32:34.130   350   350 W System.err: 	at android.os.Parcel.createExceptionOrNull(Parcel.java:2385)
+12-13 10:32:34.130   350   350 W System.err: 	at android.os.Parcel.createException(Parcel.java:2357)
+12-13 10:32:34.130   350   350 W System.err: 	at android.os.Parcel.readException(Parcel.java:2340)
+12-13 10:32:34.130   350   350 W System.err: 	at android.os.Parcel.readException(Parcel.java:2282)
+12-13 10:32:34.130   350   350 W System.err: 	at android.window.ITaskOrganizerController$Stub$Proxy.registerTaskOrganizer(ITaskOrganizerController.java:323)
+12-13 10:32:34.130   350   350 W System.err: 	at android.window.TaskOrganizer.registerOrganizer(TaskOrganizer.java:46)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.phone.PipManager.<init>(PipManager.java:284)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.phone.PipManager_Factory.provideInstance(PipManager_Factory.java:100)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.phone.PipManager_Factory.get(PipManager_Factory.java:66)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.phone.PipManager_Factory.get(PipManager_Factory.java:17)
+12-13 10:32:34.130   350   350 W System.err: 	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.PipUI_Factory.provideInstance(PipUI_Factory.java:37)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.PipUI_Factory.get(PipUI_Factory.java:30)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.pip.PipUI_Factory.get(PipUI_Factory.java:9)
+12-13 10:32:34.130   350   350 W System.err: 	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.recents.OverviewProxyService_Factory.provideInstance(OverviewProxyService_Factory.java:99)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.recents.OverviewProxyService_Factory.get(OverviewProxyService_Factory.java:68)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.recents.OverviewProxyService_Factory.get(OverviewProxyService_Factory.java:19)
+12-13 10:32:34.130   350   350 W System.err: 	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.-$$Lambda$Vs-MsjQwuYhfrxzUr7AqZvcfoH4.createDependency(Unknown Source:2)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.Dependency.createDependency(Dependency.java:565)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.Dependency.getDependencyInner(Dependency.java:544)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.Dependency.getDependency(Dependency.java:533)
+12-13 10:32:34.130   350   350 W System.err: 	at com.android.systemui.Dependency.get(Dependency.java:622)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.recents.ScreenPinningRequest.<init>(ScreenPinningRequest.java:90)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.recents.ScreenPinningRequest_Factory.provideInstance(ScreenPinningRequest_Factory.java:34)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.recents.ScreenPinningRequest_Factory.get(ScreenPinningRequest_Factory.java:28)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.recents.ScreenPinningRequest_Factory.get(ScreenPinningRequest_Factory.java:11)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.statusbar.phone.dagger.StatusBarPhoneModule_ProvideStatusBarFactory.provideInstance(StatusBarPhoneModule_ProvideStatusBarFactory.java:620)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.statusbar.phone.dagger.StatusBarPhoneModule_ProvideStatusBarFactory.get(StatusBarPhoneModule_ProvideStatusBarFactory.java:409)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.statusbar.phone.dagger.StatusBarPhoneModule_ProvideStatusBarFactory.get(StatusBarPhoneModule_ProvideStatusBarFactory.java:88)
+12-13 10:32:34.131   350   350 W System.err: 	at dagger.internal.DoubleCheck.get(DoubleCheck.java:47)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.dagger.ContextComponentResolver.resolve(ContextComponentResolver.java:100)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.dagger.ContextComponentResolver.resolveSystemUI(ContextComponentResolver.java:93)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.SystemUIApplication.startServicesIfNeeded(SystemUIApplication.java:189)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.SystemUIApplication.startServicesIfNeeded(SystemUIApplication.java:143)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.systemui.SystemUIService.onCreate(SystemUIService.java:70)
+12-13 10:32:34.131   350   350 W System.err: 	at android.app.ActivityThread.handleCreateService(ActivityThread.java:4186)
+12-13 10:32:34.131   350   350 W System.err: 	at android.app.ActivityThread.access$1500(ActivityThread.java:237)
+12-13 10:32:34.131   350   350 W System.err: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1932)
+12-13 10:32:34.131   350   350 W System.err: 	at android.os.Handler.dispatchMessage(Handler.java:106)
+12-13 10:32:34.131   350   350 W System.err: 	at android.os.Looper.loop(Looper.java:223)
+12-13 10:32:34.131   350   350 W System.err: 	at android.app.ActivityThread.main(ActivityThread.java:7664)
+12-13 10:32:34.131   350   350 W System.err: 	at java.lang.reflect.Method.invoke(Native Method)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+12-13 10:32:34.131   350   350 W System.err: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
+12-13 10:32:34.132   350   350 W System.err: Caused by: android.os.RemoteException: Remote stack trace:
+12-13 10:32:34.132   350   350 W System.err: 	at com.android.server.wm.TaskOrganizerController.registerTaskOrganizer(TaskOrganizerController.java:298)
+12-13 10:32:34.132   350   350 W System.err: 	at android.window.ITaskOrganizerController$Stub.onTransact(ITaskOrganizerController.java:166)
+12-13 10:32:34.132   350   350 W System.err: 	at android.os.Binder.execTransactInternal(Binder.java:1154)
+12-13 10:32:34.132   350   350 W System.err: 	at android.os.Binder.execTransact(Binder.java:1123)
+12-13 10:32:34.133   350   350 D NavigationModeController: getCurrentInteractionMode: mode=0 contextUser=0
+12-13 10:32:34.133   226   288 I commit_sys_config_file: [settings-2-0,12]
+12-13 10:32:34.135   350   350 V OverviewProxyService: Cannot attempt connection, is enabled false
+12-13 10:32:34.135   350   350 D NavigationModeController: getCurrentInteractionMode: mode=0 contextUser=0
+12-13 10:32:34.139   350   350 I vol.Events: writeEvent collection_started
+12-13 10:32:34.159    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.159    78   121 D goldfish-address-space: allocate: Ask for block of size 0x3e8000
+12-13 10:32:34.159    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1fa001000 offset 0x1000 size 0x3e8000
+12-13 10:32:34.195    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@4.0::IMapper/default in either framework or device manifest.
+12-13 10:32:34.195   476   541 I Gralloc4: mapper 4.x is not supported
+12-13 10:32:34.195    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+12-13 10:32:34.195   476   541 W Gralloc3: mapper 3.x is not supported
+12-13 10:32:34.196   476   541 D HostConnection: createUnique: call
+12-13 10:32:34.199   476   541 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.211   226   288 I commit_sys_config_file: [settings-0-0,11]
+12-13 10:32:34.225   476   541 D HostConnection: HostConnection::get() New Host Connection established 0x73ae60017990, tid 541
+12-13 10:32:34.226   476   541 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:34.233    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.233    78   121 D goldfish-address-space: allocate: Ask for block of size 0x3e8000
+12-13 10:32:34.234    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1fa3e9000 offset 0x3e9000 size 0x3e8000
+12-13 10:32:34.240    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.241    78   121 D goldfish-address-space: allocate: Ask for block of size 0x3e8000
+12-13 10:32:34.241    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1fa7d1000 offset 0x7d1000 size 0x3e8000
+12-13 10:32:34.262    89   184 D HostConnection: createUnique: call
+12-13 10:32:34.264    89   184 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.265   350   563 I vol.Events: writeEvent level_changed STREAM_VOICE_CALL 5
+12-13 10:32:34.266   350   563 I vol.Events: writeEvent level_changed STREAM_SYSTEM 7
+12-13 10:32:34.268   350   563 I vol.Events: writeEvent level_changed STREAM_RING 7
+12-13 10:32:34.269   350   563 I vol.Events: writeEvent level_changed STREAM_MUSIC 15
+12-13 10:32:34.271    89   184 D HostConnection: HostConnection::get() New Host Connection established 0x7ae2771c1b10, tid 184
+12-13 10:32:34.271    89   184 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:34.271   350   563 I vol.Events: writeEvent level_changed STREAM_ALARM 7
+12-13 10:32:34.272    89    89 I SurfaceFlinger: Enter boot animation
+12-13 10:32:34.274    89    89 E FMQ     : grantorIdx must be less than 3
+12-13 10:32:34.274    84   136 E FMQ     : grantorIdx must be less than 3
+12-13 10:32:34.275    84   136 E FMQ     : grantorIdx must be less than 3
+12-13 10:32:34.276    89    89 E FMQ     : grantorIdx must be less than 3
+12-13 10:32:34.277   226   249 I ActivityManagerTiming: FinishBooting
+12-13 10:32:34.278   350   563 I vol.Events: writeEvent level_changed STREAM_BLUETOOTH_SCO 15
+12-13 10:32:34.278   226   249 I boot_progress_enable_screen: 12999
+12-13 10:32:34.278   226   249 I screen_toggled: 1
+12-13 10:32:34.279   226   249 W KeyguardServiceDelegate: onScreenTurningOn(): no keyguard service!
+12-13 10:32:34.282    84   136 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:34.284   350   563 I sysui_multi_action: [757,213,758,4,759,-1]
+12-13 10:32:34.284   350   563 I vol.Events: writeEvent external_ringer_mode_changed unknown
+12-13 10:32:34.284    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.285    78   121 D goldfish-address-space: allocate: Ask for block of size 0x1fa4000
+12-13 10:32:34.285    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1fabb9000 offset 0xbb9000 size 0x1fa4000
+12-13 10:32:34.286   350   563 I vol.Events: writeEvent zen_mode_config_changed [disallowAlarms=false disallowMedia=false disallowSystem=true disallowRinger=false]
+12-13 10:32:34.294   350   350 V MediaRouter: Selecting route: RouteInfo{ name=Phone, description=null, status=null, category=RouteCategory{ name=System types=ROUTE_TYPE_LIVE_AUDIO ROUTE_TYPE_LIVE_VIDEO  groupable=false }, supportedTypes=ROUTE_TYPE_LIVE_AUDIO ROUTE_TYPE_LIVE_VIDEO , presentationDisplay=null }
+12-13 10:32:34.305   350   350 I TetheringManager: registerTetheringEventCallback caller:com.android.systemui
+12-13 10:32:34.309    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.309    78   121 D goldfish-address-space: allocate: Ask for block of size 0x1fa4000
+12-13 10:32:34.310    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1f6000000 offset 0x0 size 0x1fa4000
+12-13 10:32:34.315   350   350 D StatusBar: disable<e i a s b h r c s > disable2<q i n >
+12-13 10:32:34.316   226   470 I StatusBarManagerService: registerStatusBar bar=com.android.internal.statusbar.IStatusBar$Stub$Proxy@a58d90f
+12-13 10:32:34.414   350   350 I CameraManagerGlobal: Connecting to camera service
+12-13 10:32:34.464   350   350 D StatusBar: mUserSetupObserver - DeviceProvisionedListener called for user 0
+12-13 10:32:34.465   350   350 D StatusBar: updateQsExpansionEnabled - QS Expand enabled: true
+12-13 10:32:34.465   350   350 D StatusBar: mUserSetupObserver - DeviceProvisionedListener called for user 0
+12-13 10:32:34.470   350   567 D OpenGLRenderer: profile bars disabled
+12-13 10:32:34.470   350   567 D OpenGLRenderer: ambientRatio = 1.50
+12-13 10:32:34.481   110   110 D incidentd: WorkDirectory::getReports
+12-13 10:32:34.492   350   350 W AudioManager: attempt to call registerAudioRecordingCallback() on a previouslyregistered callback
+12-13 10:32:34.492   350   350 D NotifPipeline: Notif pipeline initialized
+12-13 10:32:34.493   350   350 W TelecomManager: Telecom Service not found.
+12-13 10:32:34.496   350   350 V WifiManager: registerSoftApCallback: callback=com.android.systemui.statusbar.policy.HotspotControllerImpl@92463b5, executor=android.os.HandlerExecutor@dddca4a
+12-13 10:32:34.499   226   310 D ConnectivityService: NetReassign [no changes]
+12-13 10:32:34.501   350   350 D KeyguardViewMediator: adjustStatusBarLocked: mShowing=false mOccluded=false isSecure=false force=false --> flags=0x0
+12-13 10:32:34.503   350   350 D NavigationModeController: getCurrentInteractionMode: mode=0 contextUser=0
+12-13 10:32:34.506   350   350 D SystemUIBootTiming: StartServicescom.android.systemui.statusbar.phone.StatusBar took to complete: 542ms
+12-13 10:32:34.507   350   350 D SystemUIBootTiming: StartServicescom.android.systemui.toast.ToastUI took to complete: 0ms
+12-13 10:32:34.508   350   560 W ActivityThread: Failed to find provider info for com.android.contacts (user not unlocked)
+12-13 10:32:34.509   350   558 W TelecomManager: Telecom Service not found.
+12-13 10:32:34.513   350   350 D StatusBar: disable<e i a s b h r c s > disable2<q i n >
+12-13 10:32:34.513   350   350 D SystemUIBootTiming: StartServices took to complete: 550ms
+12-13 10:32:34.518   350   350 W KeyguardUpdateMonitor: invalid subId in handleServiceStateChange()
+12-13 10:32:34.519   350   372 D KeyguardViewMediator: onStartedWakingUp, seq = 1
+12-13 10:32:34.519   350   372 D KeyguardViewMediator: notifyStartedWakingUp
+12-13 10:32:34.519   350   372 D KeyguardViewMediator: notifyScreenOn
+12-13 10:32:34.519   350   372 D KeyguardViewMediator: notifyScreenTurnedOn
+12-13 10:32:34.520   350   372 D KeyguardViewMediator: adjustStatusBarLocked: mShowing=false mOccluded=false isSecure=false force=false --> flags=0x0
+12-13 10:32:34.526   226   466 E BluetoothAdapter: Bluetooth binder is null
+12-13 10:32:34.529   350   350 D CompatibilityChangeReporter: Compat change id reported: 150939131; UID 10031; state: ENABLED
+12-13 10:32:34.560   350   350 D QSTileHost: Recreating tiles
+12-13 10:32:34.561   350   350 D QSTileHost: Creating tile: wifi
+12-13 10:32:34.563   350   350 D QSTileHost: Creating tile: bt
+12-13 10:32:34.564   350   350 D QSTileHost: Destroying not available tile: bt
+12-13 10:32:34.564   350   350 D QSTileHost: Creating tile: dnd
+12-13 10:32:34.564   350   350 D QSTileHost: Creating tile: flashlight
+12-13 10:32:34.565   350   350 D QSTileHost: Destroying not available tile: flashlight
+12-13 10:32:34.565   350   350 D QSTileHost: Creating tile: rotation
+12-13 10:32:34.565   350   350 D QSTileHost: Creating tile: battery
+12-13 10:32:34.565   350   350 D QSTileHost: Creating tile: cell
+12-13 10:32:34.566   350   350 D QSTileHost: Creating tile: airplane
+12-13 10:32:34.566   350   350 D QSTileHost: Creating tile: cast
+12-13 10:32:34.566   350   350 D QSTileHost: Creating tile: screenrecord
+12-13 10:32:34.649   226   470 E WindowManager: Window Session Crash
+12-13 10:32:34.649   226   470 E WindowManager: java.lang.IllegalArgumentException: Requested window null does not exist
+12-13 10:32:34.649   226   470 E WindowManager: 	at com.android.server.wm.WindowManagerService.windowForClientLocked(WindowManagerService.java:5443)
+12-13 10:32:34.649   226   470 E WindowManager: 	at com.android.server.wm.Session.actionOnWallpaper(Session.java:356)
+12-13 10:32:34.649   226   470 E WindowManager: 	at com.android.server.wm.Session.setWallpaperZoomOut(Session.java:382)
+12-13 10:32:34.649   226   470 E WindowManager: 	at android.view.IWindowSession$Stub.onTransact(IWindowSession.java:1154)
+12-13 10:32:34.649   226   470 E WindowManager: 	at com.android.server.wm.Session.onTransact(Session.java:139)
+12-13 10:32:34.649   226   470 E WindowManager: 	at android.os.Binder.execTransactInternal(Binder.java:1159)
+12-13 10:32:34.649   226   470 E WindowManager: 	at android.os.Binder.execTransact(Binder.java:1123)
+12-13 10:32:34.649   226   470 W Binder  : Caught a RuntimeException from the binder stub implementation.
+12-13 10:32:34.649   226   470 W Binder  : java.lang.IllegalArgumentException: Requested window null does not exist
+12-13 10:32:34.649   226   470 W Binder  : 	at com.android.server.wm.WindowManagerService.windowForClientLocked(WindowManagerService.java:5443)
+12-13 10:32:34.649   226   470 W Binder  : 	at com.android.server.wm.Session.actionOnWallpaper(Session.java:356)
+12-13 10:32:34.649   226   470 W Binder  : 	at com.android.server.wm.Session.setWallpaperZoomOut(Session.java:382)
+12-13 10:32:34.649   226   470 W Binder  : 	at android.view.IWindowSession$Stub.onTransact(IWindowSession.java:1154)
+12-13 10:32:34.649   226   470 W Binder  : 	at com.android.server.wm.Session.onTransact(Session.java:139)
+12-13 10:32:34.649   226   470 W Binder  : 	at android.os.Binder.execTransactInternal(Binder.java:1159)
+12-13 10:32:34.649   226   470 W Binder  : 	at android.os.Binder.execTransact(Binder.java:1123)
+12-13 10:32:34.649   226   258 I am_wtf  : [0,0,system_server,-1,WindowManager,Requested window null does not exist]
+12-13 10:32:34.650   226   258 I DropBoxManagerService: add tag=system_server_wtf isTagEnabled=true flags=0x2
+12-13 10:32:34.653   350   350 D KeyguardClockSwitch: Updating clock: 1032
+12-13 10:32:34.705   350   558 W ActivityThread: Failed to find provider info for com.android.contacts (user not unlocked)
+12-13 10:32:34.708   350   558 W ActivityThread: Failed to find provider info for com.android.contacts (user not unlocked)
+12-13 10:32:34.733   226   466 V WindowManager: Orientation start waiting for draw, mDrawState=DRAW_PENDING in Window{7017dfd u0 com.android.settings/com.android.settings.FallbackHome}, surfaceController Surface(name=com.android.settings/com.android.settings.FallbackHome)/@0x48c9fe
+12-13 10:32:34.749   350   350 D StatusBar: disable<e i a s b h r c s > disable2<q i n >
+12-13 10:32:34.755   350   350 W Resources: Drawable com.android.systemui:anim/lock_unlock has unresolved theme attributes! Consider using Resources.getDrawable(int, Theme) or Context.getDrawable(int).
+12-13 10:32:34.755   350   350 W Resources: java.lang.RuntimeException
+12-13 10:32:34.755   350   350 W Resources: 	at android.content.res.Resources.getDrawable(Resources.java:899)
+12-13 10:32:34.755   350   350 W Resources: 	at com.android.systemui.statusbar.phone.LockIcon.getIcon(LockIcon.java:174)
+12-13 10:32:34.755   350   350 W Resources: 	at com.android.systemui.statusbar.phone.LockIcon.access$200(LockIcon.java:45)
+12-13 10:32:34.755   350   350 W Resources: 	at com.android.systemui.statusbar.phone.LockIcon$1.onPreDraw(LockIcon.java:68)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:1093)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3094)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1948)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8177)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:972)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.Choreographer.doCallbacks(Choreographer.java:796)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.Choreographer.doFrame(Choreographer.java:731)
+12-13 10:32:34.755   350   350 W Resources: 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:957)
+12-13 10:32:34.755   350   350 W Resources: 	at android.os.Handler.handleCallback(Handler.java:938)
+12-13 10:32:34.755   350   350 W Resources: 	at android.os.Handler.dispatchMessage(Handler.java:99)
+12-13 10:32:34.755   350   350 W Resources: 	at android.os.Looper.loop(Looper.java:223)
+12-13 10:32:34.755   350   350 W Resources: 	at android.app.ActivityThread.main(ActivityThread.java:7664)
+12-13 10:32:34.755   350   350 W Resources: 	at java.lang.reflect.Method.invoke(Native Method)
+12-13 10:32:34.755   350   350 W Resources: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
+12-13 10:32:34.755   350   350 W Resources: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
+12-13 10:32:34.771    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.773    78   121 D goldfish-address-space: allocate: Ask for block of size 0x3e8000
+12-13 10:32:34.773    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1f7fa4000 offset 0x1fa4000 size 0x3e8000
+12-13 10:32:34.778   350   567 D libEGL  : loaded /vendor/lib64/egl/libEGL_emulation.so
+12-13 10:32:34.779   350   567 D libEGL  : loaded /vendor/lib64/egl/libGLESv1_CM_emulation.so
+12-13 10:32:34.781   350   567 D libEGL  : loaded /vendor/lib64/egl/libGLESv2_emulation.so
+12-13 10:32:34.806   350   567 D HostConnection: createUnique: call
+12-13 10:32:34.809   350   567 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.812    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.813    78   121 D goldfish-address-space: allocate: Ask for block of size 0x3e8000
+12-13 10:32:34.814    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1f838c000 offset 0x238c000 size 0x3e8000
+12-13 10:32:34.815   350   567 D HostConnection: HostConnection::get() New Host Connection established 0x73ae60022b50, tid 567
+12-13 10:32:34.816   350   567 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:34.820    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.configstore@1.0::ISurfaceFlingerConfigs/default in either framework or device manifest.
+12-13 10:32:34.823   350   567 E EGL_emulation: eglCreateContext: 0x73ae600226d0: maj 3 min 0 rcv 3
+12-13 10:32:34.829   350   567 D EGL_emulation: eglMakeCurrent: 0x73ae600226d0: ver 3 0 (tinfo 0x73b06241e080) (first time)
+12-13 10:32:34.835   226   250 V WindowManager: Orientation start waiting for draw, mDrawState=DRAW_PENDING in Window{7017dfd u0 com.android.settings/com.android.settings.FallbackHome}, surfaceController Surface(name=com.android.settings/com.android.settings.FallbackHome)/@0x48c9fe
+12-13 10:32:34.865    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.866    78   121 D goldfish-address-space: allocate: Ask for block of size 0x1c200
+12-13 10:32:34.866    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1f8774000 offset 0x2774000 size 0x1c200
+12-13 10:32:34.870    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@4.0::IMapper/default in either framework or device manifest.
+12-13 10:32:34.871   350   567 I Gralloc4: mapper 4.x is not supported
+12-13 10:32:34.871    23    23 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+12-13 10:32:34.871   350   567 W Gralloc3: mapper 3.x is not supported
+12-13 10:32:34.872   350   567 D HostConnection: createUnique: call
+12-13 10:32:34.873   350   567 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.878   350   567 D HostConnection: HostConnection::get() New Host Connection established 0x73ae60021ad0, tid 567
+12-13 10:32:34.879   350   567 D HostConnection: HostComposition ext ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_virtio_gpu_next ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_sync_buffer_data GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr GL_EXT_texture_compression_bptc GL_EXT_texture_compression_s3tc ANDROID_EMU_host_side_tracing ANDROID_EMU_gles_max_version_3_0 
+12-13 10:32:34.882    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.883    78   121 D goldfish-address-space: allocate: Ask for block of size 0x1c200
+12-13 10:32:34.884    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1f8791000 offset 0x2791000 size 0x1c200
+12-13 10:32:34.890    78   121 D librcm  : SocketClient connected to host port 22469
+12-13 10:32:34.891    78   121 D goldfish-address-space: allocate: Ask for block of size 0x1c200
+12-13 10:32:34.891    78   121 D goldfish-address-space: allocate: allocate returned phys_addr 0x1f87ae000 offset 0x27ae000 size 0x1c200
+12-13 10:32:34.930   350   567 D skia    : Shader compilation error
+12-13 10:32:34.930   350   567 D skia    : ------------------------
+12-13 10:32:34.930   350   567 D skia    : Errors:
+12-13 10:32:34.930   350   567 D skia    : 
+12-13 10:32:34.995   350   567 D skia    : Shader compilation error
+12-13 10:32:34.995   350   567 D skia    : ------------------------
+12-13 10:32:34.995   350   567 D skia    : Errors:
+12-13 10:32:34.995   350   567 D skia    : 
+12-13 10:32:35.030   350   567 D skia    : Shader compilation error
+12-13 10:32:35.030   350   567 D skia    : ------------------------
+12-13 10:32:35.030   350   567 D skia    : Errors:
+12-13 10:32:35.030   350   567 D skia    : 
+12-13 10:32:35.076   350   567 D skia    : Shader compilation error
+12-13 10:32:35.076   350   567 D skia    : ------------------------
+12-13 10:32:35.076   350   567 D skia    : Errors:
+12-13 10:32:35.076   350   567 D skia    : 
+12-13 10:32:35.110   350   350 V ShadeControllerImpl: NotificationShadeWindow: com.android.systemui.statusbar.phone.NotificationShadeWindowView{fef3c4 I.E...... ......ID 0,0-800,1280} canPanelBeCollapsed(): false
+12-13 10:32:35.110   350   350 D KeyguardViewMediator: onSystemReady
+12-13 10:32:35.111   350   350 D KeyguardViewMediator: doKeyguard: not showing because lockscreen is off
+12-13 10:32:35.112   350   350 D KeyguardViewMediator: adjustStatusBarLocked: mShowing=false mOccluded=false isSecure=false force=false --> flags=0x0
+12-13 10:32:35.112   350   350 D KeyguardViewMediator: handleNotifyWakingUp
+12-13 10:32:35.120   350   350 D KeyguardViewMediator: handleNotifyScreenTurningOn
+12-13 10:32:35.121   350   350 D KeyguardClockSwitch: Updating clock: 1032
+12-13 10:32:35.123   226   249 I WindowManager: ******* TELLING SURFACE FLINGER WE ARE BOOTED!
+12-13 10:32:35.123    89   571 I SurfaceFlinger: Boot is finished (9550 ms)
+12-13 10:32:35.125   350   350 D KeyguardViewMediator: handleNotifyScreenTurnedOn
+12-13 10:32:35.125    89   571 I sf_stop_bootanim: 13846
+12-13 10:32:35.126   226   249 I wm_boot_animation_done: 13847
+12-13 10:32:35.126   226   249 I ActivityManagerTiming: FinishBooting
+12-13 10:32:35.127   226   249 I ActivityManager: About to commit checkpoint
+12-13 10:32:35.128   226   249 I SystemServiceManager: Starting phase 1000
+12-13 10:32:35.128   226   249 I ActivityManagerTiming: OnBootPhase_1000
+12-13 10:32:35.128   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.security.FileIntegrityService
+12-13 10:32:35.128   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.security.FileIntegrityService took to complete: 0ms
+12-13 10:32:35.128   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.Installer
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.Installer took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.os.DeviceIdentifiersPolicyService
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.os.DeviceIdentifiersPolicyService took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.uri.UriGrantsManagerService$Lifecycle
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.uri.UriGrantsManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.wm.ActivityTaskManagerService$Lifecycle
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.wm.ActivityTaskManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.am.ActivityManagerService$Lifecycle
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.am.ActivityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.DataLoaderManagerService
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.DataLoaderManagerService took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.power.PowerManagerService
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.power.PowerManagerService took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.power.ThermalManagerService
+12-13 10:32:35.129   226   267 V DisplayPowerController: Brightness [0.39763778] reason changing to: 'manual', previous reason: 'override'.
+12-13 10:32:35.129   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.power.ThermalManagerService took to complete: 0ms
+12-13 10:32:35.129   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.recoverysystem.RecoverySystemService$Lifecycle
+12-13 10:32:35.130    22    22 I servicemanager: Found android.hardware.power.IPower/default in device VINTF manifest.
+12-13 10:32:35.130   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.recoverysystem.RecoverySystemService$Lifecycle took to complete: 1ms
+12-13 10:32:35.131    89   571 I PowerAdvisor: Loaded AIDL Power HAL service
+12-13 10:32:35.131    85    85 I power-service.windows: Power isModeSupported: 6
+12-13 10:32:35.131    85    85 I power-service.windows: Power isBoostSupported: 1
+12-13 10:32:35.136   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.lights.LightsService
+12-13 10:32:35.136   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.lights.LightsService took to complete: 0ms
+12-13 10:32:35.136   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.display.DisplayManagerService
+12-13 10:32:35.136   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.display.DisplayManagerService took to complete: 0ms
+12-13 10:32:35.136   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.UserManagerService$LifeCycle
+12-13 10:32:35.136   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.UserManagerService$LifeCycle took to complete: 0ms
+12-13 10:32:35.136   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.om.OverlayManagerService
+12-13 10:32:35.136   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.om.OverlayManagerService took to complete: 0ms
+12-13 10:32:35.136   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.SensorPrivacyService
+12-13 10:32:35.137   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.SensorPrivacyService took to complete: 0ms
+12-13 10:32:35.137   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.SystemConfigService
+12-13 10:32:35.137   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.SystemConfigService took to complete: 0ms
+12-13 10:32:35.137   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.BatteryService
+12-13 10:32:35.137   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.BatteryService took to complete: 0ms
+12-13 10:32:35.137   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.usage.UsageStatsService
+12-13 10:32:35.138   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.usage.UsageStatsService took to complete: 1ms
+12-13 10:32:35.138   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.webkit.WebViewUpdateService
+12-13 10:32:35.138   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.webkit.WebViewUpdateService took to complete: 0ms
+12-13 10:32:35.138   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.CachedDeviceStateService
+12-13 10:32:35.138   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.CachedDeviceStateService took to complete: 0ms
+12-13 10:32:35.138   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.BinderCallsStatsService$LifeCycle
+12-13 10:32:35.138   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.BinderCallsStatsService$LifeCycle took to complete: 0ms
+12-13 10:32:35.138   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.LooperStatsService$Lifecycle
+12-13 10:32:35.138   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.LooperStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:35.138   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.rollback.RollbackManagerService
+12-13 10:32:35.139   226   257 D AppStandbyController: Loading headless system app cache. appIdleEnabled=true
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.rollback.RollbackManagerService took to complete: 23ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.os.BugreportManagerService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.os.BugreportManagerService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.gpu.GpuService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.gpu.GpuService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.security.KeyChainSystemService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.security.KeyChainSystemService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.telecom.TelecomLoaderService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.telecom.TelecomLoaderService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.accounts.AccountManagerService$Lifecycle
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.accounts.AccountManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.content.ContentService$Lifecycle
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.content.ContentService$Lifecycle took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.DropBoxManagerService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.DropBoxManagerService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.AlarmManagerService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.AlarmManagerService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.connectivity.IpConnectivityMetrics
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.connectivity.IpConnectivityMetrics took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.net.watchlist.NetworkWatchlistService$Lifecycle took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.PinnerService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.PinnerService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.google.android.startop.iorap.IorapForwardingService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.google.android.startop.iorap.IorapForwardingService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.integrity.AppIntegrityManagerService
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.integrity.AppIntegrityManagerService took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.inputmethod.InputMethodManagerService$Lifecycle
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.inputmethod.InputMethodManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.accessibility.AccessibilityManagerService$Lifecycle
+12-13 10:32:35.161   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.accessibility.AccessibilityManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.161   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.StorageManagerService$Lifecycle
+12-13 10:32:35.161   226   297 D StorageManagerService: Thinking about init, mBootCompleted=true, mDaemonConnected=true
+12-13 10:32:35.161   226   297 D StorageManagerService: Thinking about reset, mBootCompleted=true, mDaemonConnected=true
+12-13 10:32:35.161   226   249 D StorageManagerService: FUSE flags. Settings: true. Default: true
+12-13 10:32:35.162   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.StorageManagerService$Lifecycle took to complete: 1ms
+12-13 10:32:35.162   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.usage.StorageStatsService$Lifecycle
+12-13 10:32:35.162   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.usage.StorageStatsService$Lifecycle took to complete: 0ms
+12-13 10:32:35.162   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.UiModeManagerService
+12-13 10:32:35.162   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.UiModeManagerService took to complete: 0ms
+12-13 10:32:35.162   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.locksettings.LockSettingsService$Lifecycle
+12-13 10:32:35.162   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.locksettings.LockSettingsService$Lifecycle took to complete: 0ms
+12-13 10:32:35.162   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.testharness.TestHarnessModeService
+12-13 10:32:35.165   226   249 D TestHarnessModeService: Completing Test Harness Mode setup.
+12-13 10:32:35.165   226   249 D TestHarnessModeService: Getting PersistentDataBlockManagerInternal from LocalServices
+12-13 10:32:35.165   226   249 E TestHarnessModeService: Failed to start Test Harness Mode; no implementation of PersistentDataBlockManagerInternal was bound!
+12-13 10:32:35.165   226   284 D RollbackManager: mRollbackLifetimeDurationInMillis=1209600000
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.testharness.TestHarnessModeService took to complete: 3ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.DeviceIdleController
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.DeviceIdleController took to complete: 0ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.devicepolicy.DevicePolicyManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.textservices.TextServicesManagerService$Lifecycle
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.textservices.TextServicesManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.textclassifier.TextClassificationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.NetworkScoreService$Lifecycle
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.NetworkScoreService$Lifecycle took to complete: 0ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.wifi.WifiService
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.wifi.WifiService took to complete: 0ms
+12-13 10:32:35.165   226   305 D WifiService: Handle boot completed
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.wifi.scanner.WifiScanningService
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.wifi.scanner.WifiScanningService took to complete: 0ms
+12-13 10:32:35.165   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.ethernet.EthernetService
+12-13 10:32:35.165   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.ethernet.EthernetService took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.notification.NotificationManagerService
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.notification.NotificationManagerService took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.storage.DeviceStorageMonitorService
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.storage.DeviceStorageMonitorService took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.location.LocationManagerService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.location.LocationManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.timedetector.TimeDetectorService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.timedetector.TimeDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:35.166   226   297 I StorageSessionController: Started resetting external storage service...
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.timezonedetector.TimeZoneDetectorService$Lifecycle took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.search.SearchManagerService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.search.SearchManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.audio.AudioService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.audio.AudioService$Lifecycle took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.soundtrigger_middleware.SoundTriggerMiddlewareService$Lifecycle took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.DockObserver
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.DockObserver took to complete: 0ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.adb.AdbService$Lifecycle
+12-13 10:32:35.166   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.adb.AdbService$Lifecycle took to complete: 1ms
+12-13 10:32:35.166   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.twilight.TwilightService
+12-13 10:32:35.167   226   297 I StorageSessionController: Finished resetting external storage service
+12-13 10:32:35.167   226   297 I StorageManagerService: Resetting vold...
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.twilight.TwilightService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.display.color.ColorDisplayService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.display.color.ColorDisplayService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.job.JobSchedulerService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.job.JobSchedulerService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.soundtrigger.SoundTriggerService
+12-13 10:32:35.167   226   249 D SoundTriggerService: onBootPhase: 1000 : false
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.soundtrigger.SoundTriggerService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.trust.TrustManagerService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.trust.TrustManagerService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.appwidget.AppWidgetService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.appwidget.AppWidgetService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.role.RoleManagerService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.role.RoleManagerService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.voiceinteraction.VoiceInteractionManagerService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.voiceinteraction.VoiceInteractionManagerService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.GestureLauncherService
+12-13 10:32:35.167   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.GestureLauncherService took to complete: 0ms
+12-13 10:32:35.167   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.SensorNotificationService
+12-13 10:32:35.167   226   305 I WifiScoreCard: Installing MemoryStore
+12-13 10:32:35.167   226   305 I WifiHealthMonitor: Installing MemoryStore
+12-13 10:32:35.170   226   305 D WifiNetworkFactory: Registering NetworkFactory
+12-13 10:32:35.171   226   305 D UntrustedWifiNetworkFactory: Registering NetworkFactory
+12-13 10:32:35.171   226   310 D ConnectivityService: Got NetworkProvider Messenger for WifiNetworkFactory
+12-13 10:32:35.171   226   310 D ConnectivityService: Got NetworkProvider Messenger for UntrustedWifiNetworkFactory
+12-13 10:32:35.171   226   305 D WifiNetworkFactory: got request NetworkRequest [ REQUEST id=12, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ] with score 0 and providerId -1
+12-13 10:32:35.171   226   305 D WifiConnectivityHelper: Firmware supported feature set: 8a0000000
+12-13 10:32:35.171   226   305 D WifiConnectivityHelper: Firmware roaming is not supported
+12-13 10:32:35.171   226   297 I StorageManagerService: Reset vold
+12-13 10:32:35.172   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.SensorNotificationService took to complete: 5ms
+12-13 10:32:35.172   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.emergency.EmergencyAffordanceService
+12-13 10:32:35.172   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.emergency.EmergencyAffordanceService took to complete: 0ms
+12-13 10:32:35.172   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.dreams.DreamManagerService
+12-13 10:32:35.172   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.dreams.DreamManagerService took to complete: 0ms
+12-13 10:32:35.172   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.print.PrintManagerService
+12-13 10:32:35.172   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.print.PrintManagerService took to complete: 0ms
+12-13 10:32:35.172   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.restrictions.RestrictionsManagerService
+12-13 10:32:35.172   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.restrictions.RestrictionsManagerService took to complete: 0ms
+12-13 10:32:35.172   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.blob.BlobStoreManagerService
+12-13 10:32:35.172    26    57 I vold    : onUserAdded: 0
+12-13 10:32:35.172   226   305 E WifiScoringParams: Invalid frequency(-1), using 5G as default rssi array
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.blob.BlobStoreManagerService took to complete: 1ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.media.MediaSessionService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.media.MediaSessionService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.biometrics.BiometricService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.biometrics.BiometricService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.biometrics.AuthService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.biometrics.AuthService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.ShortcutService$Lifecycle
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.ShortcutService$Lifecycle took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.LauncherAppsService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.LauncherAppsService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.CrossProfileAppsService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.CrossProfileAppsService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.people.PeopleService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.people.PeopleService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.media.projection.MediaProjectionManagerService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.media.projection.MediaProjectionManagerService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.slice.SliceManagerService$Lifecycle
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.slice.SliceManagerService$Lifecycle took to complete: 0ms
+12-13 10:32:35.173   226   305 D WifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=14, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ] with score 0 and providerId -1
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.camera.CameraServiceProxy
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.camera.CameraServiceProxy took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.stats.StatsCompanion$Lifecycle
+12-13 10:32:35.173   226   305 D WifiNetworkFactory: got request NetworkRequest [ BACKGROUND_REQUEST id=2, [ Transports: CELLULAR Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.stats.StatsCompanion$Lifecycle took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.stats.pull.StatsPullAtomService
+12-13 10:32:35.173   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.stats.pull.StatsPullAtomService took to complete: 0ms
+12-13 10:32:35.173   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.incident.IncidentCompanionService
+12-13 10:32:35.174   226   305 D WifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=9, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1000 AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   305 D WifiNetworkFactory: got request NetworkRequest [ REQUEST id=1, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   305 D WifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=10, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1073 AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   305 D WifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=15, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ REQUEST id=12, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.incident.IncidentCompanionService took to complete: 0ms
+12-13 10:32:35.174   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=14, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.MmsServiceBroker
+12-13 10:32:35.174   226   246 E AdbDebuggingManager: Expected keyStore, but got tag=null
+12-13 10:32:35.174   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ BACKGROUND_REQUEST id=2, [ Transports: CELLULAR Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:35.174   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=9, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1000 AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:35.175   226   246 E AdbDebuggingManager: Expected keyStore, but got tag=null
+12-13 10:32:35.176   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.MmsServiceBroker took to complete: 0ms
+12-13 10:32:35.176   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.autofill.AutofillManagerService
+12-13 10:32:35.176   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.autofill.AutofillManagerService took to complete: 0ms
+12-13 10:32:35.176   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.clipboard.ClipboardService
+12-13 10:32:35.176   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.clipboard.ClipboardService took to complete: 0ms
+12-13 10:32:35.176   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.appbinding.AppBindingService$Lifecycle
+12-13 10:32:35.176   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.appbinding.AppBindingService$Lifecycle took to complete: 0ms
+12-13 10:32:35.176   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.policy.PermissionPolicyService
+12-13 10:32:35.176   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.policy.PermissionPolicyService took to complete: 0ms
+12-13 10:32:35.176   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.StagingManager$Lifecycle
+12-13 10:32:35.176   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ REQUEST id=1, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN AdministratorUids: [] RequestorUid: 1000 RequestorPackageName: android] ] with score 0 and providerId -1
+12-13 10:32:35.177   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=10, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 1073 AdministratorUids: [] RequestorUid: 1073 RequestorPackageName: com.android.networkstack] ] with score 0 and providerId -1
+12-13 10:32:35.177   226   305 D UntrustedWifiNetworkFactory: got request NetworkRequest [ TRACK_DEFAULT id=15, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED Uid: 10031 AdministratorUids: [] RequestorUid: 10031 RequestorPackageName: com.android.systemui] ] with score 0 and providerId -1
+12-13 10:32:35.177   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.android.server.pm.StagingManager$Lifecycle took to complete: 1ms
+12-13 10:32:35.177   226   249 I ActivityManagerTiming: OnBootPhase_1000_com.microsoft.windows.service.SystemServerService
+12-13 10:32:35.177   226   249 V SystemServerService: PHASE_BOOT_COMPLETED
+12-13 10:32:35.177   226   249 D ActivityManagerTiming: OnBootPhase_1000_com.microsoft.windows.service.SystemServerService took to complete: 0ms
+12-13 10:32:35.178   226   249 D ActivityManagerTiming: OnBootPhase_1000 took to complete: 49ms
+12-13 10:32:35.178   226   249 D ActivityManagerTiming: TotalBootTime took to complete: 4885ms

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ jobs:
           LinuxLogParsers\LinuxPlugins-MicrosoftPerformanceToolkSDK\Cloud-init\Cloud-Init.csproj
           LinuxLogParsers\LinuxPlugins-MicrosoftPerformanceToolkSDK\DmesgIsoLog\Dmesg.csproj
           LinuxLogParsers\LinuxPlugins-MicrosoftPerformanceToolkSDK\WaLinuxAgent\WaLinuxAgent.csproj
+          LinuxLogParsers\LinuxPlugins-MicrosoftPerformanceToolkSDK\AndroidLogCat\AndroidLogcat.csproj
           LinuxLogParsers\LinuxLogParsersUnitTest\LinuxLogParsersUnitTest.csproj
           
         includesymbols: true
@@ -122,6 +123,13 @@ jobs:
         SourceFolder: 'LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/WaLinuxAgent/bin/$(BuildConfiguration)/netstandard2.1'
         Contents: '**'
         TargetFolder: '$(Build.ArtifactStagingDirectory)/Microsoft-Performance-Tools-Linux/MicrosoftPerfToolkitAddins/WaLinuxAgent'
+
+    - task: CopyFiles@2
+      displayName: Copy AndroidLogCat Build to Output Artifacts
+      inputs:
+        SourceFolder: 'LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/bin/$(BuildConfiguration)/netstandard2.1'
+        Contents: '**'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/Microsoft-Performance-Tools-Linux/MicrosoftPerfToolkitAddins/AndroidLogCat'
         
     - task: CopyFiles@2
       displayName: Copy Launcher


### PR DESCRIPTION
Perfetto doesn't support kernel boot tracing at all, nor post-kernel start boot tracing until Android 13. Like other txt based log support - this gives free support for relative timestamps, measuring time between events, etc. Also can group by component Tag, Priority, PID, or TID. Also measures durations if logged by init or Timing components