### PR TITLE
Fix issue parsing logcat log with multiple boots and duplicated durations.

### DIFF
--- a/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcat.csproj
+++ b/LinuxLogParsers/LinuxPlugins-MicrosoftPerformanceToolkSDK/AndroidLogCat/AndroidLogcat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-	  <Version>1.3.3</Version>
+	  <Version>1.3.4</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RootNamespace>Android Logcat</RootNamespace>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
When multiple logs are opened, because of 1 log failure - keep processing other logs