### PR TITLE
Add and show LTTNG provider column for generic event table

### DIFF
--- a/LTTngCds/CookerData/LTTngContext.cs
+++ b/LTTngCds/CookerData/LTTngContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using CtfPlayback.Inputs;
 using CtfPlayback.Metadata.Interfaces;
 using LTTngCds.CtfExtensions;
@@ -18,6 +19,7 @@ namespace LTTngCds.CookerData
         private readonly LTTngMetadataCustomization metadata;
         private readonly ICtfInputStream eventStream;
         private readonly TraceContext traceContext;
+        private ISet<string> stringDictionary = new HashSet<string>();
 
         internal LTTngContext(LTTngMetadataCustomization metadata, ICtfInputStream eventStream, TraceContext traceContext)
         {
@@ -31,6 +33,19 @@ namespace LTTngCds.CookerData
         /// </summary>
         public IReadOnlyDictionary<string, ICtfClockDescriptor> Clocks => this.metadata.Metadata.ClocksByName;
 
+        /// <summary>
+        /// Intern (de-duplicate) string to save memory.
+        /// </summary>
+        public string Intern(string input)
+        {
+            if (stringDictionary.Contains(input))
+            {
+                return stringDictionary.First(item => item.Equals(input));
+            }
+            stringDictionary.Add(input);
+            return input;
+        }
+        
         /// <inheritdoc />
         public long Timestamp { get; internal set; }
 

--- a/LTTngCds/LTTngCds.csproj
+++ b/LTTngCds/LTTngCds.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-	<Version>1.2.2</Version>
+	<Version>1.3.0</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corp.</Company>

--- a/LTTngDataExtensions/LTTngDataExtensions.csproj
+++ b/LTTngDataExtensions/LTTngDataExtensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-	<Version>1.2.5</Version>
+	<Version>1.3.0</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corp.</Company>

--- a/LTTngDataExtensions/Resources/GenericEventTablePrebuiltConfigurations.json
+++ b/LTTngDataExtensions/Resources/GenericEventTablePrebuiltConfigurations.json
@@ -24,7 +24,7 @@
                     {
                       "DisplayHints": {
                         "AggregationMode": 0,
-                        "IsVisible": true,
+                        "IsVisible": false,
                         "SortOrder": 0,
                         "SortPriority": 0,
                         "TextAlignment": 0,

--- a/LTTngDataExtensions/Resources/GenericEventTablePrebuiltConfigurations.json
+++ b/LTTngDataExtensions/Resources/GenericEventTablePrebuiltConfigurations.json
@@ -31,6 +31,21 @@
                         "Width": 200
                       },
                       "Metadata": {
+                        "Description": "Provider",
+                        "Guid": "0ABDBEDE-8B10-4660-ACCA-3F41FCE90D25",
+                        "Name": "Provider"
+                      }
+                    },
+                    {
+                      "DisplayHints": {
+                        "AggregationMode": 0,
+                        "IsVisible": true,
+                        "SortOrder": 0,
+                        "SortPriority": 0,
+                        "TextAlignment": 0,
+                        "Width": 200
+                      },
+                      "Metadata": {
                         "Description": "Name",
                         "Guid": "8132ded0-8fe7-4533-b139-4c81133a7bcd",
                         "Name": "Name"

--- a/LTTngDataExtensions/Tables/GenericEventTable.cs
+++ b/LTTngDataExtensions/Tables/GenericEventTable.cs
@@ -24,6 +24,14 @@ namespace LTTngDataExtensions.Tables
             "All events in the LTTng trace",
             "Linux LTTng");
 
+        private static readonly ColumnConfiguration providerNameColumnConfig = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{0ABDBEDE-8B10-4660-ACCA-3F41FCE90D25}"), "Provider"),
+            new UIHints
+            {
+                IsVisible = true,
+                Width = 200,
+            });
+
         private static readonly ColumnConfiguration eventNameColumnConfig = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{8132DED0-8FE7-4533-B139-4C81133A7BCD}"), "Name"),
             new UIHints
@@ -90,6 +98,11 @@ namespace LTTngDataExtensions.Tables
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
 
             var genericEventProjection = new EventProjection<LTTngGenericEvent>(events);
+
+            var providerNameColumn = new DataColumn<string>(
+                providerNameColumnConfig,
+                genericEventProjection.Compose((genericEvent) => genericEvent.ProviderName));
+            tableGenerator.AddColumn(providerNameColumn);
 
             var eventNameColumn = new DataColumn<string>(
                 eventNameColumnConfig,


### PR DESCRIPTION
Update the LTTNG generic event table & default configuration to organize events by Provider (if included), to make custom Linux TraceLogging generic events look the same as custom Windows TraceLogging generic events.
New UI looks like this, with events now under an expandable Provider instead of as a flat list:
![image](https://user-images.githubusercontent.com/15131789/202542712-fb602d3c-2ab8-4f99-9538-7911100209e3.png)
