### PR TITLE
Take TraceEvent update to fix user reported crash opening Linux Perf txt based trace

### DIFF
--- a/PerfDataTxtExtension/PerfDataTxtExtension.csproj
+++ b/PerfDataTxtExtension/PerfDataTxtExtension.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-	<Version>1.2.5</Version>
+	<Version>1.2.6</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corp.</Company>
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.6" GeneratePathProperty="true">
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.13" GeneratePathProperty="true">
       <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.27" />

--- a/PerfDataTxtExtension/Properties/launchSettings.json
+++ b/PerfDataTxtExtension/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "PerfDataExtensions": {
       "commandName": "Executable",
       "executablePath": "C:\\Tools\\WPT\\latest\\wpa.exe",
-      "commandLineArgs": "-addsearchdir C:\\src\\Microsoft-Performance-Tools-Linux\\PerfDataExtensions\\bin\\Debug\\netstandard2.1"
+      "commandLineArgs": "-addsearchdir E:\\src\\Microsoft-Performance-Tools-Linux-Android\\PerfDataTxtExtension\\bin\\Debug\\netstandard2.1"
     }
   }
 }

--- a/PerfDataTxtExtension/pluginManifest.json
+++ b/PerfDataTxtExtension/pluginManifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/microsoft-performance-toolkit-sdk/main/src/PluginsSystem/Tools/Microsoft.Performance.Toolkit.Plugins.Cli/Manifest/PluginManifestSchema.json",
   "identity": {
     "id": "Microsoft.Performance.Toolkit.Plugins.PerfDataTxtExtension",
-    "version": "1.2.5"
+    "version": "1.2.6"
   },
   "displayName": "Linux - Perf",
   "description": "Enables viewing Linux CPU Sampling events recorded with the kernel perf profiling utility",

--- a/PerfUnitTest/PerfUnitTest.csproj
+++ b/PerfUnitTest/PerfUnitTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.6" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Performance.SDK" Version="1.0.27" />
     <PackageReference Include="Microsoft.Performance.Toolkit.Engine" Version="1.0.16" />


### PR DESCRIPTION
Reported at https://github.com/microsoft/perfview/issues/2063 by @qizhang15 